### PR TITLE
run info duration

### DIFF
--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -1047,8 +1047,8 @@ class DataCollection:
         first_train = self.train_ids[0]
         last_train = self.train_ids[-1]
         train_count = len(self.train_ids)
-        span_sec = (last_train - first_train) / 10
-        span_txt = str(datetime.timedelta(seconds=span_sec))
+        seconds, deciseconds = divmod((last_train - first_train + 1), 10)
+        span_txt = f'{datetime.timedelta(seconds=seconds)}.{int(deciseconds)}'
 
         detector_modules = {}
         for source in self.detector_sources:

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -1048,7 +1048,8 @@ class DataCollection:
         last_train = self.train_ids[-1]
         train_count = len(self.train_ids)
         seconds, deciseconds = divmod((last_train - first_train + 1), 10)
-        span_txt = f'{datetime.timedelta(seconds=seconds)}.{int(deciseconds)}'
+        span_txt = '{}.{}'.format(datetime.timedelta(seconds=seconds),
+                                  int(deciseconds))
 
         detector_modules = {}
         for source in self.detector_sources:

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ setup(name="EXtra-data",
               'dask[array]',
               'pytest',
               'pytest-cov',
+              'coverage <5',  # Until nbval issue #129 is fixed
               'nbval',
               'testpath',
           ]


### PR DESCRIPTION
Show run duration to time precision (100ms). Fix time delta calculation.

```bash
In [3]: run.info()                                                              
# of trains:    5738
Duration:       0:09:33.8
First train ID: 296112239
Last train ID:  296117976
```

closes #4 