### PR TITLE
Crude mitigation for hitting file limit

### DIFF
--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -74,6 +74,7 @@ class FileAccess:
     """
     _file = None
     _format_version = None
+    metadata_fstat = None
 
     def __init__(self, filename, _cache_info=None):
         self.filename = filename
@@ -87,6 +88,11 @@ class FileAccess:
             self.train_ids = tid_data[tid_data != 0]
 
             self.control_sources, self.instrument_sources = self._read_data_sources()
+
+            # Store the stat of the file as it was when we read the metadata.
+            # This is used by the run files map.
+            self.metadata_fstat = os.stat(self.file.id.get_vfd_handle())
+
             # Close the file again - crude way to avoid hitting the limit of
             # open files, which is only 1024 by default.
             self.close()

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -87,6 +87,9 @@ class FileAccess:
             self.train_ids = tid_data[tid_data != 0]
 
             self.control_sources, self.instrument_sources = self._read_data_sources()
+            # Close the file again - crude way to avoid hitting the limit of
+            # open files, which is only 1024 by default.
+            self.close()
 
         # {(file, source, group): (firsts, counts)}
         self._index_cache = {}
@@ -151,7 +154,7 @@ class FileAccess:
         return isinstance(other, FileAccess) and (other.filename == self.filename)
 
     def __repr__(self):
-        return "{}({})".format(type(self).__name__, repr(self.file))
+        return "{}({})".format(type(self).__name__, repr(self.filename))
 
     @property
     def all_sources(self):

--- a/extra_data/run_files_map.py
+++ b/extra_data/run_files_map.py
@@ -140,17 +140,15 @@ class RunFilesMap:
                 need_save = True
 
                 # It's possible that the file we opened has been replaced by a
-                # new one before this runs. If possible, get the stat from the
-                # file descriptor, which will always be accurate. Stat-ing the
-                # filename will almost always work as a fallback.
-                try:
-                    fd = file_access.file.id.get_vfd_handle()
-                except Exception:
-                    log.warning("Can't get fd for %r, will stat name instead",
+                # new one before this runs. If possible, use the stat FileAccess got
+                # from the file descriptor, which will always be accurate.
+                # Stat-ing the filename will almost always work as a fallback.
+                if isinstance(file_access.metadata_fstat, os.stat_result):
+                    st = file_access.metadata_fstat
+                else:
+                    log.warning("No fstat for %r, will stat name instead",
                                 fname, exc_info=True)
                     st = os.stat(file_access.filename)
-                else:
-                    st = os.stat(fd)
 
                 self.files_data[fname] = {
                     'filename': fname,

--- a/extra_data/validation.py
+++ b/extra_data/validation.py
@@ -184,6 +184,7 @@ class RunValidator:
         for f in self.run.files:
             fv = FileValidator(f)
             self.problems.extend(fv.run_checks())
+            f.close()
 
     def check_files_map(self):
         # Outdated cache entries we can detect with the file's stat() are not a
@@ -201,6 +202,8 @@ class RunValidator:
                     cache_file=cache.cache_file,
                     data_file=f_access.filename,
                 ))
+
+            f_access.close()
 
 def main(argv=None):
     if argv is None:


### PR DESCRIPTION
This is a simple way to address the most likely cause of #2. I was able to `lsxfel` and `extra-data-validate` the same run mentioned there with these changes.

The mitigation is to close the files after getting metadata from them, but leave them open if we want anything else from them. I don't consider it a fix, but as we've only hit this once so far, and you rarely want to access every file in a run, it will probably avoid the problem for quite a while.

I also found that 1024 is the 'soft' limit on open files - a process can raise it up to the 'hard' limit (configured at 4096 on Maxwell) without any special privileges. From Python, the [resource module](https://docs.python.org/3/library/resource.html) provides the necessary API for this. So this is another way to dodge the problem further.