### PR TITLE
Use explicit mode for h5py.File() calls in tests

### DIFF
--- a/extra_data/tests/test_components.py
+++ b/extra_data/tests/test_components.py
@@ -117,7 +117,7 @@ def test_write_virtual_cxi(mock_spb_proc_run, tmpdir):
     det.write_virtual_cxi(test_file)
     assert_isfile(test_file)
 
-    with h5py.File(test_file) as f:
+    with h5py.File(test_file, 'r') as f:
         det_grp = f['entry_1/instrument_1/detector_1']
         ds = det_grp['data']
         assert isinstance(ds, h5py.Dataset)
@@ -149,7 +149,7 @@ def test_write_virtual_cxi_some_modules(mock_spb_proc_run, tmpdir):
     det.write_virtual_cxi(test_file)
     assert_isfile(test_file)
 
-    with h5py.File(test_file) as f:
+    with h5py.File(test_file, 'r') as f:
         det_grp = f['entry_1/instrument_1/detector_1']
         ds = det_grp['data']
         assert ds.shape[1:] == (16, 512, 128)

--- a/extra_data/tests/test_writer.py
+++ b/extra_data/tests/test_writer.py
@@ -36,7 +36,7 @@ def test_write_virtual(mock_fxe_raw_run):
 
         assert_isfile(new_file)
 
-        with h5py.File(new_file) as f:
+        with h5py.File(new_file, 'r') as f:
             ds = f['CONTROL/SPB_XTD9_XGM/DOOCS/MAIN/beamPosition/ixPos/value']
             assert ds.is_virtual
 


### PR DESCRIPTION
Avoids warning about the default mode changing.