### PR TITLE
get_dask_array across detector modules

### DIFF
--- a/docs/agipd_lpd_data.rst
+++ b/docs/agipd_lpd_data.rst
@@ -17,6 +17,8 @@ pulling together the separate modules into a single array.
 
 .. autoclass:: LPD1M
 
+   .. automethod:: get_dask_array
+
    .. automethod:: get_array
 
    .. automethod:: trains

--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -330,6 +330,45 @@ class MPxDetectorBase:
 
         return xarray.concat(arrays, pd.Index(modnos, name='module'))
 
+    def get_dask_array(self, key):
+        """Get a labelled Dask array of detector data
+
+        Dask does lazy, parallelised computing, and can work with large data
+        volumes. This method doesn't immediately load the data: that only
+        happens once you trigger a computation.
+
+        Parameters
+        ----------
+
+        key: str
+          The data to get, e.g. 'image.data' for pixel values.
+        """
+        arrays = []
+        modnos = []
+        for modno, source in sorted(self.modno_to_source.items()):
+            modnos.append(modno)
+            mod_arr = self.data.get_dask_array(source, key, labelled=True)
+
+            # At present, all the per-pulse data is stored in the 'image' key.
+            # If that changes, this check will need to change as well.
+            if key.startswith('image.'):
+                # Add pulse IDs to create multi-level index
+                pulse_id = self.data.get_array(source, 'image.pulseId')
+                # Raw files have a spurious extra dimension
+                if pulse_id.ndim >= 2 and pulse_id.shape[1] == 1:
+                    pulse_id = pulse_id[:, 0]
+
+                mod_arr = mod_arr.rename({'trainId': 'train_pulse'})
+
+                mod_arr.coords['train_pulse'] = pd.MultiIndex.from_arrays(
+                    [mod_arr.coords['train_pulse'], pulse_id],
+                    names=['trainId', 'pulseId']
+                )
+
+            arrays.append(mod_arr)
+
+        return xarray.concat(arrays, pd.Index(modnos, name='module'))
+
     def trains(self, pulses=by_index[:]):
         """Iterate over trains for detector data.
 

--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -330,7 +330,7 @@ class MPxDetectorBase:
 
         return xarray.concat(arrays, pd.Index(modnos, name='module'))
 
-    def get_dask_array(self, key):
+    def get_dask_array(self, key, subtrain_index='pulseId'):
         """Get a labelled Dask array of detector data
 
         Dask does lazy, parallelised computing, and can work with large data
@@ -342,7 +342,15 @@ class MPxDetectorBase:
 
         key: str
           The data to get, e.g. 'image.data' for pixel values.
+        subtrain_index: str
+          Specify 'pulseId' (default) or 'cellId' to label the frames recorded
+          within each train. Pulse ID should allow this data to be matched with
+          other devices, but depends on how the detector was manually configured
+          when the data was taken. Cell ID refers to the memory cell used for
+          that frame in the detector hardware.
         """
+        if subtrain_index not in {'pulseId', 'cellId'}:
+            raise ValueError("subtrain_index must be 'pulseId' or 'cellId'")
         arrays = []
         modnos = []
         for modno, source in sorted(self.modno_to_source.items()):
@@ -353,16 +361,16 @@ class MPxDetectorBase:
             # If that changes, this check will need to change as well.
             if key.startswith('image.'):
                 # Add pulse IDs to create multi-level index
-                pulse_id = self.data.get_array(source, 'image.pulseId')
+                inner_ix = self.data.get_array(source, 'image.' + subtrain_index)
                 # Raw files have a spurious extra dimension
-                if pulse_id.ndim >= 2 and pulse_id.shape[1] == 1:
-                    pulse_id = pulse_id[:, 0]
+                if inner_ix.ndim >= 2 and inner_ix.shape[1] == 1:
+                    inner_ix = inner_ix[:, 0]
 
                 mod_arr = mod_arr.rename({'trainId': 'train_pulse'})
 
                 mod_arr.coords['train_pulse'] = pd.MultiIndex.from_arrays(
-                    [mod_arr.coords['train_pulse'], pulse_id],
-                    names=['trainId', 'pulseId']
+                    [mod_arr.coords['train_pulse'], inner_ix],
+                    names=['trainId', subtrain_index]
                 )
 
             arrays.append(mod_arr)

--- a/extra_data/tests/test_components.py
+++ b/extra_data/tests/test_components.py
@@ -1,3 +1,4 @@
+import dask.array as da
 import h5py
 import numpy as np
 import os.path as osp
@@ -59,6 +60,23 @@ def test_get_array_pulse_indexes(mock_fxe_raw_run):
 
     arr = det.get_array('image.data', pulses=by_index[[1, 7, 22, 23]])
     assert arr.shape == (16, 3, 4, 256, 256)
+
+
+def test_get_dask_array(mock_fxe_raw_run):
+    run = RunDirectory(mock_fxe_raw_run)
+    det = LPD1M(run)
+    arr = det.get_dask_array('image.data')
+
+    assert isinstance(arr.data, da.Array)
+    assert arr.shape == (16, 480 * 128, 1, 256, 256)
+    assert arr.dims == ('module', 'train_pulse', 'dim_0', 'dim_1', 'dim_2')
+    np.testing.assert_array_equal(arr.coords['module'], np.arange(16))
+    np.testing.assert_array_equal(
+        arr.coords['trainId'], np.repeat(np.arange(10000, 10480), 128)
+    )
+    np.testing.assert_array_equal(
+        arr.coords['pulseId'], np.tile(np.arange(0, 128), 480)
+    )
 
 
 def test_iterate(mock_fxe_raw_run):

--- a/extra_data/tests/test_components.py
+++ b/extra_data/tests/test_components.py
@@ -78,6 +78,9 @@ def test_get_dask_array(mock_fxe_raw_run):
         arr.coords['pulseId'], np.tile(np.arange(0, 128), 480)
     )
 
+    arr_cellid = det.get_dask_array('image.data', subtrain_index='cellId')
+    assert arr_cellid.coords['cellId'].shape == (480 * 128,)
+
 
 def test_iterate(mock_fxe_raw_run):
     run = RunDirectory(mock_fxe_raw_run)

--- a/extra_data/tests/test_reader_mockdata.py
+++ b/extra_data/tests/test_reader_mockdata.py
@@ -443,6 +443,20 @@ def test_run_get_dask_array(mock_fxe_raw_run):
     assert arr.dtype == np.float32
 
 
+def test_run_get_dask_array_labelled(mock_fxe_raw_run):
+    import dask.array as da
+    run = RunDirectory(mock_fxe_raw_run)
+    arr = run.get_dask_array(
+        'SA1_XTD2_XGM/DOOCS/MAIN:output', 'data.intensityTD', labelled=True
+    )
+
+    assert isinstance(arr, DataArray)
+    assert isinstance(arr.data, da.Array)
+    assert arr.dims == ('trainId', 'dim_0')
+    assert arr.shape == (480, 1000)
+    assert arr.coords['trainId'][0] == 10000
+
+
 def test_select(mock_fxe_raw_run):
     run = RunDirectory(mock_fxe_raw_run)
 


### PR DESCRIPTION
This enables working with Dask like this:

```python
from extra_data.components import AGIPD1M
agipd = AGIPD1M(run, min_modules=16)
arr = agipd.get_dask_array('image.data')
avg = arr.unstack('train_pulse').mean(dim='trainId', dtype=np.float32)
avg.compute()
```

See #13.

In theory it should be possible to leave out `min_modules=16` and rely on xarray's missing value handling. But when I tried this, I got a `KilledWorker` error from Dask. Including only trains where all modules have data seems to work around this.

Unfortunately, the warnings I saw when experimenting with Dask & xarray before are back when I try this, though they don't seem to stop it working:

```
distributed.utils_perf - WARNING - full garbage collections took 52% CPU time recently (threshold: 10%)
```

There are a few API differences between `agipd.get_dask_array()` and `agipd.get_array()` (apart from the obvious one of the return type):

- `get_array()` splits trains and pulses into two separate dimensions, whereas `get_dask_array()` leaves them in a single `train_pulse` dimension, with a multi-level index. The latter is more natural if we one day have different numbers of pulses stored per train.
- The index levels in `get_dask_array()` are called `trainId` and `pulseId`, whereas `get_array()` calls them `train` and `pulse`. 'trainId' is consistent with the labels `run.get_array()` uses for a single source.
- `get_array()` tries to guess labels for the other dimensions, and automatically drops the spurious extra dimension (the one that was meant to be for the train builder) if it's present and length 1. `get_dask_array()` currently doesn't try to do any of this.

On the first two, I guess that not many people use `detector.get_array()` - it implies loading a lot of data into memory, and we've never advertised it widely. So I aimed for consistency with the `run.get_array()` interface instead.

I'm still unsure about the last one - making educated guesses about the axes. It feels wrong to be guessing, but on the other hand, these formats are pretty consistent, and we can make common use patterns more convenient with a few small assumptions.