### PR TITLE
Progress indication while validating a run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: python
 python:
+  - 3.8
   - 3.7
   - 3.6
-  - 3.5
 
 env:
   global:

--- a/extra_data/validation.py
+++ b/extra_data/validation.py
@@ -167,8 +167,8 @@ class RunValidator:
 
         for i, filename in enumerate(self.filenames):
             if self.term_progress:
-                print(f"\r{i}/{len(self.filenames)} files "
-                      f"({len(self.problems)} problems): {filename}", end='')
+                print(f"{i}/{len(self.filenames)} files "
+                      f"({len(self.problems)} problems): {filename}", end='\r')
             path = osp.join(self.run_dir, filename)
             try:
                 fa = FileAccess(path)
@@ -181,6 +181,9 @@ class RunValidator:
                 fv = FileValidator(fa)
                 self.problems.extend(fv.run_checks())
                 fa.close()
+
+        if self.term_progress:
+            print("{0}/{0} files".format(len(self.filenames)))
 
         if not self.file_accesses:
             self.problems.append(

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(name="EXtra-data",
               'testpath',
           ]
       },
-      python_requires='>=3.5',
+      python_requires='>=3.6',
       classifiers=[
           'Development Status :: 5 - Production/Stable',
           'Environment :: Console',


### PR DESCRIPTION
- Visible information about how many files have been checked, problems found, and which file it's currently examining.
- Ctrl-C during validation will show any problems found up to that point.

```
$ extra-data-validate /gpfs/exfel/exp/SPB/201802/p002157/proc/r0119
Checking run directory: /gpfs/exfel/exp/SPB/201802/p002157/proc/r0119
3/207 files (2 problems): CORR-R0119-AGIPD07-S00006.h5^C
^C (validation cancelled)
Validation failed!

Gaps (2) in index, e.g. at 41 (7040 + 0 < 7216)
  dataset: INDEX/SPB_DET_AGIPD1M-1/DET/3CH0:xtdf/image
  file: /gpfs/exfel/exp/SPB/201802/p002157/proc/r0119/CORR-R0119-AGIPD03-S00011.h5

Overlaps (3) in index, e.g. at 40 (7040 + 176 > 7040)
  dataset: INDEX/SPB_DET_AGIPD1M-1/DET/3CH0:xtdf/image
  file: /gpfs/exfel/exp/SPB/201802/p002157/proc/r0119/CORR-R0119-AGIPD03-S00011.h5
```

I increased the minimum Python version to 3.6 - see #6.