### PR TITLE
Start writing release notes for next version

### DIFF
--- a/docs/agipd_lpd_data.rst
+++ b/docs/agipd_lpd_data.rst
@@ -21,6 +21,8 @@ pulling together the separate modules into a single array.
 
    .. automethod:: get_array
 
+   .. automethod:: get_dask_array
+
    .. automethod:: trains
 
    .. automethod:: write_virtual_cxi

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,25 @@
 Release Notes
 =============
 
+0.9
+---
+
+- Fix ``extra-data-validate`` with a run directory without a :ref:`cached data
+  map <run-map-caching>` (:ghpull:`12`).
+- Add ``.squeeze()`` method for virtual stacks of detector data from
+  :func:`stack_detector_data` (:ghpull:`16`).
+- Close each file after reading its metadata, to avoid hitting the limit of
+  open files when opening a large run (:ghpull:`8`).
+  This is a mitigation: you will still hit the limit if you access data from
+  enough files. The default limit on Maxwell is 1024 files, but you can
+  raise this to 4096 using the Python
+  `resource module <https://docs.python.org/3/library/resource.html>`_.
+- Display progress information while validating a run directory (:ghpull:`19`).
+- Display run duration to only one decimal place (:ghpull:`5`).
+- Documentation reorganised to emphasise tutorials and examples (:ghpull:`10`).
+
+This version requires Python 3.6 or above.
+
 0.8
 ---
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,7 +1,7 @@
 Release Notes
 =============
 
-0.9
+1.0
 ---
 
 - Fix ``extra-data-validate`` with a run directory without a :ref:`cached data

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,10 +4,12 @@ Release Notes
 1.0
 ---
 
+- New :meth:`~.LPD1M.get_dask_array` method for accessing detector data with
+  Dask (:ghpull:`18`).
 - Fix ``extra-data-validate`` with a run directory without a :ref:`cached data
   map <run-map-caching>` (:ghpull:`12`).
 - Add ``.squeeze()`` method for virtual stacks of detector data from
-  :func:`stack_detector_data` (:ghpull:`16`).
+  :func:`.stack_detector_data` (:ghpull:`16`).
 - Close each file after reading its metadata, to avoid hitting the limit of
   open files when opening a large run (:ghpull:`8`).
   This is a mitigation: you will still hit the limit if you access data from


### PR DESCRIPTION
Tentatively calling it 0.9, but it could equally be 1.0.