### PR TITLE
Use of file cache to keep the number of opened files under the limit

### DIFF
--- a/extra_data/__init__.py
+++ b/extra_data/__init__.py
@@ -39,8 +39,6 @@ __version__ = "1.0.0"
 from .reader import *
 from .stacking import *
 from .utils import *
-from .filecache import get_global_filecache
 
 
-__all__ = reader.__all__ + utils.__all__ + stacking.__all__ + \
-          ['get_global_filecache', ]
+__all__ = reader.__all__ + utils.__all__ + stacking.__all__

--- a/extra_data/__init__.py
+++ b/extra_data/__init__.py
@@ -39,6 +39,8 @@ __version__ = "1.0.0"
 from .reader import *
 from .stacking import *
 from .utils import *
+from .filecache import get_global_filecache
 
 
-__all__ = reader.__all__ + utils.__all__ + stacking.__all__
+__all__ = reader.__all__ + utils.__all__ + stacking.__all__ + \
+          ['get_global_filecache', ]

--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -426,11 +426,8 @@ class MPxDetectorTrainIterator:
         self._datasets_cache = {}
 
     def _find_data(self, source, key, tid):
-        try:
-            file, ds = self._datasets_cache[(source, key)]
-        except KeyError:
-            pass
-        else:
+        file, ds = self._datasets_cache.get((source, key), (None, None))
+        if ds:
             ixs = (file.train_ids == tid).nonzero()[0]
             if ixs.size > 0:
                 return file, ixs[0], ds

--- a/extra_data/filecache.py
+++ b/extra_data/filecache.py
@@ -1,0 +1,161 @@
+import h5py
+
+class CachedFile(object):
+    def __init__(self, filename, prio, cache_instance=None):
+        self._filename = filename
+        self._fc_prio = prio
+        self._fc_pos = -1
+        self._file = h5py.File(filename, 'r')
+        self._cache = cache_instance if cache_instance is not None else get_global_filecache()
+        
+
+    def close(self):
+        if self._file is not None:
+            self._file.close()
+            self._file = None
+            self._fc_pos = -1
+        
+    def __lt__(self, other):
+        return self._fc_prio < other._fc_prio
+
+    @property
+    def file(self):
+        if self._file is not None:
+            self._cache._touch(self._fc_pos)
+        return self._file
+    
+class DummyCachedFile(object):
+    file = None
+        
+        
+class FileCache(object):
+    dummy = DummyCachedFile
+    
+    def __init__(self, maxfiles=128):
+        self._maxfiles = maxfiles
+        self.pq = []
+        self.cat = {}
+        self.counter = 0
+        
+    @property
+    def maxfiles(self):
+        return self._maxfiles
+    
+    @maxfiles.setter
+    def maxfiles(self, maxfiles):
+        n = len(self.pq)
+        while n > maxfiles:
+            f = self._pop()
+            del self.cat[f._filename]
+            f.close()
+            n -= 1
+        self._maxfiles = maxfiles
+        
+    def clean(self):
+        self.cat = {}
+        self.counter = 0
+        while self.pq:
+            f = self._pop()
+            f.close()
+
+    def get_or_open(self, filename):
+        try:
+            f = self.cat[filename]
+            pos = f._fc_pos
+            f._fc_prio = self.counter
+            self._siftup(pos)
+        except:
+            f = CachedFile(filename, self.counter)
+            n = len(self.pq)
+            if n < self._maxfiles:
+                f._fc_pos = n
+                self.pq.append(f)
+                self._siftdown(0, n)
+            else:
+                redundant = self.pq[0]
+                del self.cat[redundant._filename]
+                redundant.close()
+
+                f._fc_pos = 0
+                self.pq[0] = f
+                self._siftup(0)
+
+            self.cat[filename] = f
+
+        self.counter += 1
+        
+        return f
+    
+    def _touch(self, pos):
+        self.pq[pos]._fc_prio = self.counter
+        self._siftup(pos)
+        self.counter += 1
+    
+    def _pop(self):
+        last = self.pq.pop()    # raises appropriate IndexError if heap is empty
+        if self.pq:
+            ret = self.pq[0]
+            last._fc_pos = 0
+            self.pq[0] = last
+            self._siftup(0)
+            return ret
+        
+        return last
+        
+
+    def _siftdown(self, startpos, pos):
+        newitem = self.pq[pos]
+        # Follow the path to the root, moving parents down until finding a place
+        # newitem fits.
+        while pos > startpos:
+            parentpos = (pos - 1) >> 1
+            parent = self.pq[parentpos]
+            if newitem < parent:
+                parent._fc_pos = pos
+                self.pq[pos] = parent
+                pos = parentpos
+                continue
+            break
+        newitem._fc_pos = pos
+        self.pq[pos] = newitem
+
+    def _siftup(self, pos):
+        endpos = len(self.pq)
+        startpos = pos
+        newitem = self.pq[pos]
+        # Bubble up the smaller child until hitting a leaf.
+        childpos = 2*pos + 1    # leftmost child position
+        while childpos < endpos:
+            # Set childpos to index of smaller child.
+            rightpos = childpos + 1
+            if rightpos < endpos and not self.pq[childpos] < self.pq[rightpos]:
+                childpos = rightpos
+            # Move the smaller child up.
+            item = self.pq[childpos]
+            item._fc_pos = pos
+            self.pq[pos] = item
+            pos = childpos
+            childpos = 2*pos + 1
+        # The leaf at pos is empty now.  Put newitem there, and bubble it up
+        # to its final resting place (by sifting its parents down).
+        newitem._fc_pos = pos
+        self.pq[pos] = newitem
+        self._siftdown(startpos, pos)
+        
+import resource
+import atexit
+
+def set_global_filecache():
+    nofile_rlimits = resource.getrlimit(resource.RLIMIT_NOFILE)
+    maxfiles = nofile_rlimits[0] >> 1
+    global _extra_data_file_cache
+    _extra_data_file_cache = FileCache(maxfiles)
+
+def get_global_filecache():
+    return _extra_data_file_cache
+
+set_global_filecache()
+
+@atexit.register
+def clean_global_filecache():
+    _extra_data_file_cache.clean()

--- a/extra_data/filecache.py
+++ b/extra_data/filecache.py
@@ -114,6 +114,7 @@ class FileCache(object):
 import resource
 
 def init_extra_data_filecache():
+    # Raise the limit for open files (1024 -> 4096 on Maxwell)
     nofile = resource.getrlimit(resource.RLIMIT_NOFILE)
     resource.setrlimit(resource.RLIMIT_NOFILE, (nofile[1], nofile[1]))
     maxfiles = nofile[1] // 2

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -161,11 +161,6 @@ class FileAccess:
     def __repr__(self):
         return "{}({})".format(type(self).__name__, repr(self.filename))
 
-    def __getstate__(self):
-        state = self.__dict__.copy()
-        state['__file'] = None
-        return state
-
     @property
     def all_sources(self):
         return self.control_sources | self.instrument_sources

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -73,8 +73,8 @@ class FileAccess:
     file: h5py.File
         Open h5py file object
     """
-    _fc = get_global_filecache()
-    _file = None
+    __fc = get_global_filecache()
+    __file = None
     _format_version = None
     metadata_fstat = None
 
@@ -100,23 +100,17 @@ class FileAccess:
         # {source: set(keys)}
         self._keys_cache = {}
 
-    def __del__(self):
-        if self._file:
-            self._fc.close(self.filename)
-
     @property
     def file(self):
-        if self._file:
-            self._fc.touch(self.filename)
+        if self.__file:
+            self.__fc.touch(self.filename)
         else:
-            self._file = self._fc.open(self.filename)
+            self.__file = self.__fc.open(self.filename)
             
-        return self._file
+        return self.__file
 
     def close(self):
-        if self._file:
-            self._fc.close(self.filename)
-            self._file = None
+        self.__file = None
 
     @property
     def format_version(self):
@@ -166,11 +160,6 @@ class FileAccess:
 
     def __repr__(self):
         return "{}({})".format(type(self).__name__, repr(self.filename))
-
-    def __getstate__(self):
-        state = self.__dict__.copy()
-        state['_file'] = None
-        return state
 
     @property
     def all_sources(self):

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -161,6 +161,11 @@ class FileAccess:
     def __repr__(self):
         return "{}({})".format(type(self).__name__, repr(self.filename))
 
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        state['__file'] = None
+        return state
+
     @property
     def all_sources(self):
         return self.control_sources | self.instrument_sources

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -36,6 +36,7 @@ from .read_machinery import (
     find_proposal,
 )
 from .run_files_map import RunFilesMap
+from .filecache import get_global_filecache
 
 __all__ = [
     'H5File',
@@ -72,7 +73,7 @@ class FileAccess:
     file: h5py.File
         Open h5py file object
     """
-    _file = None
+    _file = get_global_filecache().dummy
     _format_version = None
     metadata_fstat = None
 
@@ -95,7 +96,7 @@ class FileAccess:
 
             # Close the file again - crude way to avoid hitting the limit of
             # open files, which is only 1024 by default.
-            self.close()
+            #self.close()
 
         # {(file, source, group): (firsts, counts)}
         self._index_cache = {}
@@ -104,14 +105,16 @@ class FileAccess:
 
     @property
     def file(self):
-        if self._file is None:
-            self._file = h5py.File(self.filename, 'r')
-        return self._file
+        f = self._file.file
+        if f is None:
+            self._file = get_global_filecache().get_or_open(self.filename)
+            f = self._file._file
+
+        return f
+
 
     def close(self):
-        if self._file:
-            self._file.close()
-            self._file = None
+            pass
 
     @property
     def format_version(self):

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -105,16 +105,15 @@ class FileAccess:
 
     @property
     def file(self):
-        f = self._file.file
-        if f is None:
+        if self._file.id.valid:
+            get_global_filecache().touch(self.filename)
+        else:
             self._file = get_global_filecache().get_or_open(self.filename)
-            f = self._file._file
-
-        return f
-
+            
+        return self._file
 
     def close(self):
-            pass
+        pass
 
     @property
     def format_version(self):

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -36,7 +36,7 @@ from .read_machinery import (
     find_proposal,
 )
 from .run_files_map import RunFilesMap
-from .filecache import get_global_filecache
+from .filecache import extra_data_filecache
 
 __all__ = [
     'H5File',
@@ -73,7 +73,6 @@ class FileAccess:
     file: h5py.File
         Open h5py file object
     """
-    _fc = get_global_filecache()
     _file = None
     _format_version = None
     metadata_fstat = None
@@ -101,21 +100,20 @@ class FileAccess:
         self._keys_cache = {}
 
     def __del__(self):
-        if self._file:
-            self._fc.close(self.filename)
+        self.close()
 
     @property
     def file(self):
         if self._file:
-            self._fc.touch(self.filename)
+            extra_data_filecache.touch(self.filename)
         else:
-            self._file = self._fc.open(self.filename)
+            self._file = extra_data_filecache.open(self.filename)
             
         return self._file
 
     def close(self):
         if self._file:
-            self._fc.close(self.filename)
+            extra_data_filecache.close(self.filename)
             self._file = None
 
     @property
@@ -168,6 +166,7 @@ class FileAccess:
         return "{}({})".format(type(self).__name__, repr(self.filename))
 
     def __getstate__(self):
+        """ Allows pickling `FileAccess` instance. """
         state = self.__dict__.copy()
         state['_file'] = None
         return state

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -1279,11 +1279,8 @@ class TrainIterator:
         self._datasets_cache = {}
 
     def _find_data(self, source, key, tid):
-        try:
-            file, ds = self._datasets_cache[(source, key)]
-        except KeyError:
-            pass
-        else:
+        file, ds = self._datasets_cache.get((source, key), (None, None))
+        if ds:
             ixs = (file.train_ids == tid).nonzero()[0]
             if ixs.size > 0:
                 return file, ixs[0], ds

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -102,7 +102,7 @@ class FileAccess:
 
     def __del__(self):
         if self._file:
-            self._fc.close()
+            self._fc.close(self.filename)
 
     @property
     def file(self):

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -100,6 +100,10 @@ class FileAccess:
         # {source: set(keys)}
         self._keys_cache = {}
 
+    def __del__(self):
+        if self._file:
+            self._fc.close()
+
     @property
     def file(self):
         if self._file:
@@ -306,11 +310,6 @@ class DataCollection:
         if self.ctx_closes:
             for file in self.files:
                 file.close()
-
-    def __del__(self):
-        if self.ctx_closes:
-            for file in self.files:
-                file.close()        
 
     @property
     def all_sources(self):

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -73,8 +73,8 @@ class FileAccess:
     file: h5py.File
         Open h5py file object
     """
-    __fc = get_global_filecache()
-    __file = None
+    _fc = get_global_filecache()
+    _file = None
     _format_version = None
     metadata_fstat = None
 
@@ -100,17 +100,23 @@ class FileAccess:
         # {source: set(keys)}
         self._keys_cache = {}
 
+    def __del__(self):
+        if self._file:
+            self._fc.close(self.filename)
+
     @property
     def file(self):
-        if self.__file:
-            self.__fc.touch(self.filename)
+        if self._file:
+            self._fc.touch(self.filename)
         else:
-            self.__file = self.__fc.open(self.filename)
+            self._file = self._fc.open(self.filename)
             
-        return self.__file
+        return self._file
 
     def close(self):
-        self.__file = None
+        if self._file:
+            self._fc.close(self.filename)
+            self._file = None
 
     @property
     def format_version(self):
@@ -160,6 +166,11 @@ class FileAccess:
 
     def __repr__(self):
         return "{}({})".format(type(self).__name__, repr(self.filename))
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        state['_file'] = None
+        return state
 
     @property
     def all_sources(self):

--- a/extra_data/tests/test_filecache.py
+++ b/extra_data/tests/test_filecache.py
@@ -1,0 +1,66 @@
+import os
+import pytest
+from collections import OrderedDict
+from extra_data.reader import DataCollection
+
+@pytest.fixture
+def filecache_512():
+    from extra_data.filecache import extra_data_filecache
+    orig_cache = extra_data_filecache._cache
+    orig_maxfiles = extra_data_filecache.maxfiles
+    extra_data_filecache._cache = OrderedDict()
+    extra_data_filecache._maxfiles = 512
+    yield extra_data_filecache
+    extra_data_filecache._cache = orig_cache
+    extra_data_filecache._maxfiles = orig_maxfiles
+
+@pytest.fixture
+def filecache_3():
+    from extra_data.filecache import extra_data_filecache
+    orig_cache = extra_data_filecache._cache
+    orig_maxfiles = extra_data_filecache.maxfiles
+    extra_data_filecache._cache = OrderedDict()
+    extra_data_filecache._maxfiles = 3
+    yield extra_data_filecache
+    extra_data_filecache._cache = orig_cache
+    extra_data_filecache._maxfiles = orig_maxfiles
+
+
+def test_filecache_large(mock_spb_raw_run, filecache_512):
+    fc = filecache_512
+
+    files = [os.path.join(mock_spb_raw_run, f) \
+             for f in os.listdir(mock_spb_raw_run) if f.endswith('.h5')]
+    run = DataCollection.from_paths(files)
+
+    trains_iter = run.trains()
+    tid, data = next(trains_iter)
+    assert tid == 10000
+    device = 'SPB_IRU_CAM/CAM/SIDEMIC:daqOutput'
+    assert device in data
+    assert data[device]['data.image.pixels'].shape == (1024, 768)
+    assert len(fc._cache) == len(run.files)
+
+    del run, trains_iter
+    assert len(fc._cache) == 0    
+
+def test_filecache_small(mock_spb_raw_run, filecache_3):
+    fc = filecache_3
+
+    files = [os.path.join(mock_spb_raw_run, f) \
+             for f in os.listdir(mock_spb_raw_run) if f.endswith('.h5')]
+    run = DataCollection.from_paths(files)
+    trains_iter = run.trains()
+
+    for i in range(3):
+        tid, data = next(trains_iter)
+        assert tid == 10000 + i
+        for j in range(16):
+            device = f'SPB_DET_AGIPD1M-1/DET/{j}CH0:xtdf'
+            assert device in data
+            assert data[device]['image.data'].shape == (64, 2, 512, 128)
+            assert len(fc._cache) == 3
+
+    del run, trains_iter
+    assert len(fc._cache) == 0
+

--- a/extra_data/tests/test_reader_mockdata.py
+++ b/extra_data/tests/test_reader_mockdata.py
@@ -15,7 +15,6 @@ from extra_data import (
     H5File, RunDirectory, by_index, by_id,
     SourceNameError, PropertyNameError, DataCollection, open_run,
 )
-from extra_data.filecache import extra_data_filecache
 
 def test_iterate_trains(mock_agipd_data):
     with H5File(mock_agipd_data) as f:

--- a/extra_data/tests/test_reader_mockdata.py
+++ b/extra_data/tests/test_reader_mockdata.py
@@ -14,8 +14,8 @@ from xarray import DataArray
 from extra_data import (
     H5File, RunDirectory, by_index, by_id,
     SourceNameError, PropertyNameError, DataCollection, open_run,
-    get_global_filecache,
 )
+from extra_data.filecache import extra_data_filecache
 
 def test_iterate_trains(mock_agipd_data):
     with H5File(mock_agipd_data) as f:
@@ -621,28 +621,3 @@ def test_permission():
         run = RunDirectory(d)
     assert "Permission denied" in str(excinfo.value)
     assert d in str(excinfo.value)
-
-
-def test_filecache(mock_spb_raw_run):
-    fc = get_global_filecache()
-    fc.clean()
-    run = RunDirectory(mock_spb_raw_run)
-    trains_iter = run.trains()
-    tid, data = next(trains_iter)
-    assert tid == 10000
-    device = 'SPB_IRU_CAM/CAM/SIDEMIC:daqOutput'
-    assert device in data
-    assert data[device]['data.image.pixels'].shape == (1024, 768)
-    assert len(fc._cache) == len(run.files)
-    fc.maxfiles = 3
-    for i in range(3):
-        tid, data = next(trains_iter)
-        assert tid == 10001 + i
-        for j in range(16):
-            device = f'SPB_DET_AGIPD1M-1/DET/{j}CH0:xtdf'
-            assert device in data
-            assert data[device]['image.data'].shape == (64, 2, 512, 128)
-        assert len(fc._cache) == 3
-
-    del run, trains_iter
-    assert len(fc._cache) == 0

--- a/extra_data/tests/test_run_files_map.py
+++ b/extra_data/tests/test_run_files_map.py
@@ -7,7 +7,7 @@ import pytest
 from .mockdata import write_file
 from .mockdata.xgm import XGM
 from extra_data import run_files_map, RunDirectory
-from extra_data.filecache import get_global_filecache
+from extra_data.filecache import extra_data_filecache
 
 def test_candidate_paths(tmp_path):
     # 'real' paths (like /gpfs/exfel/d)
@@ -71,8 +71,7 @@ def test_save_load_map(run_with_extra_file, tmp_path):
     assert isinstance(file_info['control_sources'], frozenset)
     assert isinstance(file_info['instrument_sources'], frozenset)
     
-    fc = get_global_filecache()
-    fc.force_close(extra_file)
+    extra_data_filecache.force_close(extra_file)
 
     # Modify a file; this should make the cache invalid
     with h5py.File(extra_file, 'r+') as f:

--- a/extra_data/tests/test_run_files_map.py
+++ b/extra_data/tests/test_run_files_map.py
@@ -72,7 +72,7 @@ def test_save_load_map(run_with_extra_file, tmp_path):
     assert isinstance(file_info['instrument_sources'], frozenset)
     
     fc = get_global_filecache()
-    fc.close(extra_file)
+    fc.force_close(extra_file)
 
     # Modify a file; this should make the cache invalid
     with h5py.File(extra_file, 'r+') as f:

--- a/extra_data/tests/test_run_files_map.py
+++ b/extra_data/tests/test_run_files_map.py
@@ -7,6 +7,7 @@ import pytest
 from .mockdata import write_file
 from .mockdata.xgm import XGM
 from extra_data import run_files_map, RunDirectory
+from extra_data.filecache import get_global_filecache
 
 def test_candidate_paths(tmp_path):
     # 'real' paths (like /gpfs/exfel/d)
@@ -69,6 +70,9 @@ def test_save_load_map(run_with_extra_file, tmp_path):
     assert isinstance(file_info['train_ids'], np.ndarray)
     assert isinstance(file_info['control_sources'], frozenset)
     assert isinstance(file_info['instrument_sources'], frozenset)
+    
+    fc = get_global_filecache()
+    fc.clean()
 
     # Modify a file; this should make the cache invalid
     with h5py.File(extra_file, 'r+') as f:

--- a/extra_data/tests/test_run_files_map.py
+++ b/extra_data/tests/test_run_files_map.py
@@ -72,7 +72,7 @@ def test_save_load_map(run_with_extra_file, tmp_path):
     assert isinstance(file_info['instrument_sources'], frozenset)
     
     fc = get_global_filecache()
-    fc.clean()
+    fc.close(extra_file)
 
     # Modify a file; this should make the cache invalid
     with h5py.File(extra_file, 'r+') as f:


### PR DESCRIPTION
This is a try to address the cause of #2

I implemented the file cache. It stores opened files in the hashed priority queue. Hash allows finding opened files by name. The priority queue is used to track the order of access to files. It the queue is full the new file pops the file accessed the longest time ago.

The file cache stores opened files wrapped in the special proxy object which intermediate the access to the real file from FileAccess. If file closed all FileAccess instances referenced this file may know that via this proxy object.

The interface is not transparent but requires minimal changes in FileAccess

The changes pass tests and work for me at very populated runs. But the behaviour in delayed reading (e.g. dask array or during iterations over trains) may be affected by the closing of files in file cache between the taking of dataset instance and actual reading. From another side, it is possible if the cache is smaller than the required number of files. It means such cases fail anyway even without file cache.