### PR TITLE
Add --detail option to lsxfel

### DIFF
--- a/extra_data/lsxfel.py
+++ b/extra_data/lsxfel.py
@@ -83,7 +83,7 @@ def main(argv=None):
         prog='lsxfel', description="Summarise XFEL data in files or folders"
     )
     ap.add_argument('paths', nargs='*', help="Files/folders to look at")
-    ap.add_argument('--source', action='append',
+    ap.add_argument('--detail', action='append',
         help="Show details on keys & data for specified sources. "
              "This can slow down lsxfel considerably. "
              "Wildcard patterns like '*/XGM/*' are allowed, though you may "

--- a/extra_data/lsxfel.py
+++ b/extra_data/lsxfel.py
@@ -102,7 +102,7 @@ def main(argv=None):
             contents = sorted(os.listdir(path))
             if any(f.endswith('.h5') for f in contents):
                 # Run directory
-                describe_run(path, args.source)
+                describe_run(path, args.detail)
             elif any(re.match(r'r\d+', f) for f in contents):
                 # Proposal directory, containing runs
                 print(basename, ": Proposal data directory")
@@ -123,7 +123,7 @@ def main(argv=None):
                 print(basename, ": Unrecognised directory")
         elif os.path.isfile(path):
             if path.endswith('.h5'):
-                describe_file(path, args.source)
+                describe_file(path, args.detail)
             else:
                 print(basename, ": Unrecognised file")
                 return 2

--- a/extra_data/lsxfel.py
+++ b/extra_data/lsxfel.py
@@ -83,7 +83,7 @@ def main(argv=None):
         prog='lsxfel', description="Summarise XFEL data in files or folders"
     )
     ap.add_argument('paths', nargs='*', help="Files/folders to look at")
-    ap.add_argument('--detail', action='append',
+    ap.add_argument('--detail', action='append', default=[],
         help="Show details on keys & data for specified sources. "
              "This can slow down lsxfel considerably. "
              "Wildcard patterns like '*/XGM/*' are allowed, though you may "

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -1219,7 +1219,7 @@ class DataCollection:
                 else:
                     entry_info = ""
                 dt = self.get_dtype(s, k)
-                print(f"{prefix}{k}\t{dt.name}{entry_info}")
+                print(f"{prefix}{k}\t[{dt.name}{entry_info}]")
 
         non_detector_inst_srcs = self.instrument_sources - self.detector_sources
         print(len(non_detector_inst_srcs), 'instrument sources (excluding detectors):')

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -1214,12 +1214,8 @@ class DataCollection:
             """Detail for a group of keys"""
             for k in keys:
                 entry_shape = self.get_entry_shape(s, k)
-                if entry_shape:
-                    shape_dtl = " × ".join(str(n) for n in entry_shape)
-                else:
-                    shape_dtl = "scalar"
                 dt = self.get_dtype(s, k)
-                print(f"{prefix}{k} ({dt.name}: {shape_dtl} entries)")
+                print(f"{prefix}{k}\t{dt.name}, entry shape {entry_shape}")
 
         non_detector_inst_srcs = self.instrument_sources - self.detector_sources
         print(len(non_detector_inst_srcs), 'instrument sources (excluding detectors):')
@@ -1238,14 +1234,13 @@ class DataCollection:
 
 
         print()
-        print(len(self.control_sources), 'control sources:')
+        print(len(self.control_sources), 'control sources: (1 entry per train)')
         for s in sorted(self.control_sources):
             print('  -', s)
-            if not any(p.match(s) for p in details_sources_re):
-                continue
+            if any(p.match(s) for p in details_sources_re):
+                # Detail for control sources: list keys
+                keys_detail(s, self.keys_for_source(s), prefix='    - ')
 
-            # Detail for control sources: list keys
-            keys_detail(s, self.keys_for_source(s), prefix='    - ')
         print()
 
     def detector_info(self, source):

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -1243,7 +1243,7 @@ class DataCollection:
             print('  -', s)
             if any(p.match(s) for p in details_sources_re):
                 # Detail for control sources: list keys
-                keys_detail(s, self.keys_for_source(s), prefix='    - ')
+                keys_detail(s, sorted(self.keys_for_source(s)), prefix='    - ')
 
         print()
 

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -1214,8 +1214,12 @@ class DataCollection:
             """Detail for a group of keys"""
             for k in keys:
                 entry_shape = self.get_entry_shape(s, k)
+                if entry_shape:
+                    entry_info = f", entry shape {entry_shape}"
+                else:
+                    entry_info = ""
                 dt = self.get_dtype(s, k)
-                print(f"{prefix}{k}\t{dt.name}, entry shape {entry_shape}")
+                print(f"{prefix}{k}\t{dt.name}{entry_info}")
 
         non_detector_inst_srcs = self.instrument_sources - self.detector_sources
         print(len(non_detector_inst_srcs), 'instrument sources (excluding detectors):')


### PR DESCRIPTION
This allows specifying source patterns to show more detail, like `--detail '*/XGM/*'` (see #29). The details include:

- Names of keys for that source, with data type and entry shape
- For instrument data:
  - Number & percentage of trains with data
  - Maximum number of entries in one train (typically this is the standard data rate)

As expected, this can make lsxfel significantly slower - it has to open the relevant files and read metadata, even if the cache file exists. With the 'overview file' idea, it should be able to access only that one file, which would help.

<details>
<summary>Example output</summary>

```
% lsxfel /gpfs/exfel/exp/XMPL/201750/p700000/raw/r0019 --detail '*/XGM/*' --detail '*/MDL/*'
r0019 : Run directory

# of trains:    3687
Duration:       0:06:08.7
First train ID: 560376002
Last train ID:  560379688

0 detector modules ()

3 instrument sources (excluding detectors):
  - SA3_XTD10_XGM/XGM/DOOCS:output
    - data:
      data for 3687 trains (100.00%), up to 1 entries per train
      - data.intensityAUXSa1TD	[float32, entry shape (1000,)]
      - data.intensityAUXSa3TD	[float32, entry shape (1000,)]
      - data.intensityAUXTD	[float32, entry shape (1000,)]
      - data.intensitySa1SigmaTD	[float32, entry shape (1000,)]
      - data.intensitySa1TD	[float32, entry shape (1000,)]
      - data.intensitySa3SigmaTD	[float32, entry shape (1000,)]
      - data.intensitySa3TD	[float32, entry shape (1000,)]
      - data.intensitySigmaTD	[float32, entry shape (1000,)]
      - data.intensityTD	[float32, entry shape (1000,)]
      - data.trainId	[uint64]
      - data.xSa1SigmaTD	[float32, entry shape (1000,)]
      - data.xSa1TD	[float32, entry shape (1000,)]
      - data.xSa3SigmaTD	[float32, entry shape (1000,)]
      - data.xSa3TD	[float32, entry shape (1000,)]
      - data.xSigmaTD	[float32, entry shape (1000,)]
      - data.xTD	[float32, entry shape (1000,)]
      - data.ySa1SigmaTD	[float32, entry shape (1000,)]
      - data.ySa1TD	[float32, entry shape (1000,)]
      - data.ySa3SigmaTD	[float32, entry shape (1000,)]
      - data.ySa3TD	[float32, entry shape (1000,)]
      - data.ySigmaTD	[float32, entry shape (1000,)]
      - data.yTD	[float32, entry shape (1000,)]
  - SQS_DAQ_SCAN/MDL/KARABACON:output
    - data:
      data for 11 trains (0.30%), up to 1 entries per train
      - data.pos0	[float64]
      - data.pos1	[float64]
      - data.pos2	[float64]
      - data.pos3	[float64]
      - data.trainId	[uint64]
      - data.y0	[float64]
      - data.y1	[float64]
      - data.y2	[float64]
      - data.y3	[float64]
      - data.y4	[float64]
      - data.y5	[float64]
  - SQS_DIGITIZER_UTC1/ADC/1:network

28 control sources: (1 entry per train)
  - FUSION_CDG
  - P_GATT
  - SA3_XTD10_DOOCS/BAM/LCAT1932M_TL
  - SA3_XTD10_DOOCS/BAM/LCAT1932S_TL
  - SA3_XTD10_DOOCS/BAM/LCAT414_B2
  - SA3_XTD10_GATT/MDL/GATT_TRANSMISSION_MONITOR
    - connected.value	[uint8]
    - connected.timestamp	[uint64]
    - Third_h_Estimated_pulse_E.timestamp	[uint64]
    - Third_h_Tr_N2_d20.value	[float64]
    - Tr_N2_d20.value	[float64]
    - Third_h_Tr_Ar_d20_d12_d6.timestamp	[uint64]
    - Tr_Ar_d20_d12.timestamp	[uint64]
    - Third_h_Estimated_Tr.timestamp	[uint64]
    - Tr_Ar_d20.value	[float64]
    - GATT_Ap_Value.timestamp	[uint64]
    - Third_h_Estimated_Tr_pulse_E.value	[float64]
    - Tr_N2_d20_d12_d6.timestamp	[uint64]
    - Tr_N2_d20.timestamp	[uint64]
    - Third_h_Tr_Ar_d20.value	[float64]
    - Estimated_Tr.timestamp	[uint64]
    - Third_h_Tr_N2_d20_d12_d6.value	[float64]
    - Eff_Tr_pulse_E.timestamp	[uint64]
    - Estimated_Tr_pulse_E.value	[float64]
    - Tr_Ar_d20_d12.value	[float64]
    - Tr_N2_d20_d12.value	[float64]
    - GATT_Ap_Value.value	[int32]
    - Tr_Effective.value	[float64]
    - Estimated_pulse_E.timestamp	[uint64]
    - Third_h_Tr_Ar_d20_d12.value	[float64]
    - Third_h_Estimated_pulse_E.value	[float64]
    - Third_h_Tr_Ar_d20.timestamp	[uint64]
    - Third_h_Tr_Ar_d20_d12_d6.value	[float64]
    - Third_h_Tr_N2_d20_d12_d6.timestamp	[uint64]
    - Estimated_Tr.value	[float64]
    - Tr_Ar_d20_d12_d6.value	[float64]
    - x_3h.value	[float64]
    - Tr_Ar_d20_d12_d6.timestamp	[uint64]
    - Estimated_pulse_E.value	[float64]
    - Energy.timestamp	[uint64]
    - Third_h_Tr_Ar_d20_d12.timestamp	[uint64]
    - Third_h_Tr_N2_d20.timestamp	[uint64]
    - Eff_Tr_pulse_E.value	[float64]
    - Third_h_Estimated_Tr.value	[float64]
    - Third_h_Tr_N2_d20_d12.value	[float64]
    - Tr_N2_d20_d12_d6.value	[float64]
    - Tr_N2_d20_d12.timestamp	[uint64]
    - Estimated_Tr_pulse_E.timestamp	[uint64]
    - Energy.value	[float64]
    - Tr_Effective.timestamp	[uint64]
    - Tr_Ar_d20.timestamp	[uint64]
    - Third_h_Estimated_Tr_pulse_E.timestamp	[uint64]
    - Third_h_Tr_N2_d20_d12.timestamp	[uint64]
    - x_3h.timestamp	[uint64]
  - SA3_XTD10_MONO/MDL/PHOTON_ENERGY
    - actualWavelength.timestamp	[uint64]
    - M.timestamp	[uint64]
    - connected.value	[uint8]
    - connected.timestamp	[uint64]
    - limitBetaHigh.value	[float64]
    - targetEnergy.value	[float64]
    - enableBacklashCompensation.timestamp	[uint64]
    - speedFast.timestamp	[uint64]
    - gamma.timestamp	[uint64]
    - limitBetaHigh.timestamp	[uint64]
    - targetBeta.timestamp	[uint64]
    - backlashCompensationLength.timestamp	[uint64]
    - actualEnergy.value	[float64]
    - k.timestamp	[uint64]
    - strokeSlowMax.value	[float64]
    - delta.timestamp	[uint64]
    - deltaHE.timestamp	[uint64]
    - dispersion.timestamp	[uint64]
    - encoderOffset.timestamp	[uint64]
    - linearToAngular.timestamp	[uint64]
    - enableTwoSpeedMotion.timestamp	[uint64]
    - enableBacklashCompensation.value	[uint8]
    - betaDeadband.timestamp	[uint64]
    - k.value	[float64]
    - actualEnergy.timestamp	[uint64]
    - speedSlow.timestamp	[uint64]
    - M.value	[int32]
    - speedSlow.value	[float64]
    - gamma.value	[float64]
    - actualWavelength.value	[float64]
    - targetBeta.value	[float64]
    - actualBeta.timestamp	[uint64]
    - deltaLE.value	[float64]
    - actualBeta.value	[float64]
    - delta.value	[float64]
    - linearToAngular.value	[float64]
    - deltaHE.value	[float64]
    - enableTwoSpeedMotion.value	[uint8]
    - deltaLE.timestamp	[uint64]
    - targetEnergy.timestamp	[uint64]
    - backlashCompensationLength.value	[float64]
    - targetWavelength.value	[float64]
    - strokeSlowMax.timestamp	[uint64]
    - strokeSlowMaxAng.timestamp	[uint64]
    - actualAlpha.value	[float64]
    - targetWavelength.timestamp	[uint64]
    - betaDeadband.value	[float64]
    - maxAttempts.timestamp	[uint64]
    - speedFast.value	[float64]
    - strokeSlowMaxAng.value	[float64]
    - dispersion.value	[float64]
    - encoderOffset.value	[float64]
    - maxAttempts.value	[int32]
    - actualAlpha.timestamp	[uint64]
  - SA3_XTD10_UND/DOOCS/PHOTON_ENERGY
  - SA3_XTD10_VAC/GAUGE/G30510C
  - SA3_XTD10_XGM/XGM/DOOCS
    - current.bottom.rangeCode.timestamp	[uint64]
    - gasDosing.pressureSetPoint.value	[float32]
    - pulseEnergy.gammaUsed.timestamp	[uint64]
    - hv.hamph.timestamp	[uint64]
    - signalAdaption.dig.value	[int32]
    - controlData.slowTrainSa3.value	[float32]
    - pressure.pressureFiltered.value	[float32]
    - gasSupply.gasTypeId.value	[int32]
    - pulseEnergy.pressure.timestamp	[uint64]
    - pulseEnergy.wavelengthUsed.timestamp	[uint64]
    - current.right.rangeCode.value	[int32]
    - reconnectInterval.value	[uint32]
    - current.top.rangeCode.value	[int32]
    - pressure.gasType.timestamp	[uint64]
    - gasDosing.pressureSetPoint.timestamp	[uint64]
    - current.top.output.value	[float32]
    - pressure.rd.value	[float32]
    - pulseEnergy.usedGasType.timestamp	[uint64]
    - hv.repeller.value	[float32]
    - gasDosing.measuredPressure.value	[float32]
    - hv.hampv.value	[float32]
    - hv.hamph.value	[float32]
    - beamPosition.iyPos.timestamp	[uint64]
    - pulseEnergy.crossUsed.timestamp	[uint64]
    - controlData.gmdNotMeasuring.timestamp	[uint64]
    - pulseEnergy.currentSum.value	[float32]
    - pulseEnergy.conversion.timestamp	[uint64]
    - pulseEnergy.numberOfBunches.timestamp	[uint64]
    - beamPosition.ixPos.timestamp	[uint64]
    - pulseEnergy.photonFluxSigma.value	[float32]
    - current.right.output.value	[float32]
    - controlData.slowTrainSa1.timestamp	[uint64]
    - pulseEnergy.photonFluxW.timestamp	[uint64]
    - current.top.output.timestamp	[uint64]
    - current.left.output.value	[float32]
    - pressure.pressure1.timestamp	[uint64]
    - pulseEnergy.photonFluxWSigma.timestamp	[uint64]
    - gasSupply.gasTypeId.timestamp	[uint64]
    - pulseEnergy.photonFluxWSigma.value	[float32]
    - pulseEnergy.numberOfSa3BunchesActual.value	[int32]
    - current.left.output.timestamp	[uint64]
    - pulseEnergy.photonFluxSigma.timestamp	[uint64]
    - gasDosing.measuredPressure.timestamp	[uint64]
    - pulseEnergy.currentSum.timestamp	[uint64]
    - pulseEnergy.numberOfSa3BunchesActual.timestamp	[uint64]
    - hv.hampv.timestamp	[uint64]
    - pressure.rsp.timestamp	[uint64]
    - pollingInterval.value	[int32]
    - pulseEnergy.gammaUsed.value	[float32]
    - pulseEnergy.photonFlux.timestamp	[uint64]
    - controlData.slowTrain.value	[float32]
    - current.right.rangeCode.timestamp	[uint64]
    - gasSupply.gsdCompatId.value	[int32]
    - gasSupply.gsdCompatId.timestamp	[uint64]
    - pulseEnergy.numberOfSa1BunchesActual.timestamp	[uint64]
    - beamPosition.iyPos.value	[float32]
    - pollingInterval.timestamp	[uint64]
    - hv.repeller.timestamp	[uint64]
    - controlData.slowTrain.timestamp	[uint64]
    - current.bottom.output.value	[float32]
    - pulseEnergy.gmdError.value	[int32]
    - pulseEnergy.conversion.value	[float64]
    - reconnectInterval.timestamp	[uint64]
    - pulseEnergy.wavelengthUsed.value	[float32]
    - pressure.gasType.value	[int32]
    - pulseEnergy.photonFluxW.value	[float32]
    - controlData.gmdNotMeasuring.value	[int32]
    - pressure.pressureFiltered.timestamp	[uint64]
    - pressure.rd.timestamp	[uint64]
    - pulseEnergy.photonFlux.value	[float32]
    - beamPosition.ixPos.value	[float32]
    - pressure.rsp.value	[float32]
    - controlData.slowTrainSa1.value	[float32]
    - current.top.rangeCode.timestamp	[uint64]
    - pressure.dcr.value	[float32]
    - pulseEnergy.crossUsed.value	[float32]
    - pulseEnergy.pressure.value	[float32]
    - pulseEnergy.numberOfSa1BunchesActual.value	[int32]
    - pulseEnergy.numberOfBunchesActual.timestamp	[uint64]
    - pulseEnergy.numberOfBunchesActual.value	[int32]
    - current.bottom.output.timestamp	[uint64]
    - pulseEnergy.numberOfBunches.value	[float32]
    - pulseEnergy.gmdError.timestamp	[uint64]
    - pressure.dcr.timestamp	[uint64]
    - controlData.slowTrainSa3.timestamp	[uint64]
    - pulseEnergy.temperature.value	[float32]
    - current.left.rangeCode.timestamp	[uint64]
    - pulseEnergy.temperature.timestamp	[uint64]
    - current.bottom.rangeCode.value	[int32]
    - signalAdaption.dig.timestamp	[uint64]
    - pulseEnergy.usedGasType.value	[int32]
    - current.left.rangeCode.value	[int32]
    - pressure.pressure1.value	[float32]
    - current.right.output.timestamp	[uint64]
  - SQS_AQS_MOLB/GAUGE/STAGE_1
  - SQS_AQS_MOLB/GAUGE/STAGE_2
  - SQS_AQS_MOLB/GAUGE/STAGE_3
  - SQS_AQS_VAC/GAUGE/F1
  - SQS_AQS_VAC/GAUGE/F1P
  - SQS_DAQ_SCAN/MDL/KARABACON
    - use_daq.value	[uint8]
    - use_daq.timestamp	[uint64]
    - pauseEachStep.value	[uint8]
    - recorder.isConnected.timestamp	[uint64]
    - isConfigured.timestamp	[uint64]
    - recorder.daqTimeout.value	[float32]
    - recorder.waitConfig.timestamp	[uint64]
    - actualStep.timestamp	[uint64]
    - startPoints.timestamp	[uint64]
    - recorder.daqTimeout.timestamp	[uint64]
    - reset.value	[uint8]
    - steps.value	[int32, entry shape (1000,)]
    - stopPoints.timestamp	[uint64]
    - recorder.isConnected.value	[uint8]
    - acquisitionTime.value	[float32]
    - recorder.waitConfig.value	[float32]
    - startPoints.value	[float32, entry shape (1000,)]
    - pauseEachStep.timestamp	[uint64]
    - stopPoints.value	[float32, entry shape (1000,)]
    - stream.value	[uint8]
    - bidirectional.timestamp	[uint64]
    - configureTriggers.value	[uint8]
    - stream.timestamp	[uint64]
    - actualStep.value	[int32]
    - bidirectional.value	[uint8]
    - reset.timestamp	[uint64]
    - acquisitionTime.timestamp	[uint64]
    - configureTriggers.timestamp	[uint64]
    - steps.timestamp	[uint64]
    - isConfigured.value	[uint8]
  - SQS_DIAG1_VAC/GAUGE/DOWNSTR_ST1
  - SQS_DIAG1_VAC/GAUGE/DOWNSTR_ST2
  - SQS_DIAG1_VAC/GAUGE/DOWNSTR_ST3
  - SQS_DIAG1_VAC/GAUGE/UPSTR_ATT
  - SQS_DIAG1_VAC/GAUGE/UPSTR_BIU
  - SQS_DIAG1_VAC/GAUGE/XGM_INLET
  - SQS_DPU_VAC/GAUGE/DOWNSTR
  - SQS_DPU_VAC/GAUGE/MID
  - SQS_DPU_VAC/GAUGE/UPSTR
  - SQS_KBS_VAC/GAUGE/HFM
  - SQS_KBS_VAC/GAUGE/VFM
  - SQS_RR_UTC/TSYS/TIMESERVER
```
</details>