### PR TITLE
Check if firsts dataset has any entry

### DIFF
--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -1141,12 +1141,17 @@ class DataCollection:
         """Show information about the selected data.
         """
         # time info
-        first_train = self.train_ids[0]
-        last_train = self.train_ids[-1]
-        train_count = len(self.train_ids)
-        seconds, deciseconds = divmod((last_train - first_train + 1), 10)
-        span_txt = '{}.{}'.format(datetime.timedelta(seconds=seconds),
-                                  int(deciseconds))
+        if len(self.train_ids) == 0:
+            first_train = last_train = '-'
+            train_count = 0
+            span_txt = '0.0'
+        else:
+            first_train = self.train_ids[0]
+            last_train = self.train_ids[-1]
+            train_count = len(self.train_ids)
+            seconds, deciseconds = divmod((last_train - first_train + 1), 10)
+            span_txt = '{}.{}'.format(datetime.timedelta(seconds=seconds),
+                                      int(deciseconds))
 
         detector_modules = {}
         for source in self.detector_sources:

--- a/extra_data/tests/conftest.py
+++ b/extra_data/tests/conftest.py
@@ -83,3 +83,10 @@ def empty_h5_file():
             pass
 
         yield path
+
+@pytest.fixture(scope='session')
+def mock_empty_file_valid():
+    with TemporaryDirectory() as td:
+        path = osp.join(td, 'RAW-R0450-DA01-S00002.h5')
+        make_examples.make_sa3_da_file(path, ntrains=0)
+        yield path

--- a/extra_data/tests/conftest.py
+++ b/extra_data/tests/conftest.py
@@ -85,7 +85,7 @@ def empty_h5_file():
         yield path
 
 @pytest.fixture(scope='session')
-def mock_empty_file_valid():
+def mock_empty_file():
     with TemporaryDirectory() as td:
         path = osp.join(td, 'RAW-R0450-DA01-S00002.h5')
         make_examples.make_sa3_da_file(path, ntrains=0)

--- a/extra_data/tests/make_examples.py
+++ b/extra_data/tests/make_examples.py
@@ -161,7 +161,7 @@ def make_fxe_da_file(path):
         GECCamera('FXE_XAD_GEC/CAM/CAMERA'),
     ], ntrains=400, chunksize=200)
 
-def make_sa3_da_file(path, format_version='0.5'):
+def make_sa3_da_file(path, ntrains=500, format_version='0.5'):
     """Make the structure of a file with non-detector data from SASE3 tunnel
 
     Based on .../SA3/201830/p900026/r0317/RAW-R0317-DA01-S00000.h5
@@ -196,7 +196,7 @@ def make_sa3_da_file(path, format_version='0.5'):
         IMGFELMotor('SA3_XTD10_IMGFEL/MOTOR/FILTER'),
         IMGFELMotor('SA3_XTD10_IMGFEL/MOTOR/SCREEN'),
         MPOD('SA3_XTD10_MCP/MCPS/MPOD'),
-    ], ntrains=500, chunksize=50, format_version=format_version)
+    ], ntrains=ntrains, chunksize=50, format_version=format_version)
 
 def make_data_file_bad_device_name(path):
     """Not all devices have the Karabo standard A/B/C naming convention"""

--- a/extra_data/tests/mockdata/base.py
+++ b/extra_data/tests/mockdata/base.py
@@ -59,7 +59,9 @@ class DeviceBase:
         if self.nsamples is None:
             self.nsamples = self.ntrains
 
-        if self.nsamples == 0:
+        if self.ntrains == 0:
+            first, count, trainids = [], [], []
+        elif self.nsamples == 0:
             first = count = 0
             trainids = []
         elif self.nsamples < self.ntrains:
@@ -99,7 +101,8 @@ class DeviceBase:
             # INSTRUMENT
             tid = f.create_dataset('INSTRUMENT/%s/trainId' % dev_chan,
                                    (Npad,), 'u8', maxshape=(None,))
-            tid[:self.nsamples] = trainids
+            if len(trainids) > 0:
+                tid[:self.nsamples] = trainids
             for (topic, datatype, dims) in self.instrument_keys:
                 f.create_dataset('INSTRUMENT/%s/%s' % (dev_chan, topic),
                                  (Npad,) + dims, datatype, maxshape=((None,) + dims))

--- a/extra_data/tests/test_reader_mockdata.py
+++ b/extra_data/tests/test_reader_mockdata.py
@@ -629,9 +629,4 @@ def test_permission():
 
 def test_empty_file_info(mock_empty_file, capsys):
     f = H5File(mock_empty_file)
-    f.info()
-    out, err = capsys.readouterr()
-    assert '# of trains:    0' in out
-    assert 'Duration:       0.0' in out
-    assert 'First train ID: -' in out
-    assert 'Last train ID:  -' in out
+    f.info()  # smoke test

--- a/extra_data/tests/test_reader_mockdata.py
+++ b/extra_data/tests/test_reader_mockdata.py
@@ -625,3 +625,13 @@ def test_permission():
         run = RunDirectory(d)
     assert "Permission denied" in str(excinfo.value)
     assert d in str(excinfo.value)
+
+
+def test_empty_file_info(mock_empty_file_valid, capsys):
+    f = H5File(mock_empty_file_valid)
+    f.info()
+    out, err = capsys.readouterr()
+    assert '# of trains:    0' in out
+    assert 'Duration:       0.0' in out
+    assert 'First train ID: -' in out
+    assert 'Last train ID:  -' in out

--- a/extra_data/tests/test_reader_mockdata.py
+++ b/extra_data/tests/test_reader_mockdata.py
@@ -627,8 +627,8 @@ def test_permission():
     assert d in str(excinfo.value)
 
 
-def test_empty_file_info(mock_empty_file_valid, capsys):
-    f = H5File(mock_empty_file_valid)
+def test_empty_file_info(mock_empty_file, capsys):
+    f = H5File(mock_empty_file)
     f.info()
     out, err = capsys.readouterr()
     assert '# of trains:    0' in out

--- a/extra_data/tests/test_validation.py
+++ b/extra_data/tests/test_validation.py
@@ -26,14 +26,6 @@ def data_aggregator_file():
         yield path
 
 
-@fixture(scope='function')
-def mock_empty_file():
-    with TemporaryDirectory() as td:
-        path = osp.join(td, 'RAW-R0450-DA02-S00001.h5')
-        make_examples.make_sa3_da_file(path, ntrains=0)
-        yield path
-
-
 def test_validate_run(mock_fxe_raw_run):
     rv = RunValidator(mock_fxe_raw_run)
     rv.validate()

--- a/extra_data/tests/test_validation.py
+++ b/extra_data/tests/test_validation.py
@@ -26,6 +26,14 @@ def data_aggregator_file():
         yield path
 
 
+@fixture(scope='function')
+def mock_empty_file():
+    with TemporaryDirectory() as td:
+        path = osp.join(td, 'RAW-R0450-DA02-S00001.h5')
+        make_examples.make_sa3_da_file(path, ntrains=0)
+        yield path
+
+
 def test_validate_run(mock_fxe_raw_run):
     rv = RunValidator(mock_fxe_raw_run)
     rv.validate()
@@ -139,3 +147,7 @@ def test_gaps(agipd_file):
     assert problem['msg'] == 'Gaps (1) in index, e.g. at 1 (0 + 64 < 128)'
     assert problem['dataset'] == 'INDEX/SPB_DET_AGIPD1M-1/DET/0CH0:xtdf/image'
     assert 'RAW-R0239-AGIPD00-S00000.h5' in problem['file']
+
+
+def test_file_without_data(mock_empty_file):
+    FileValidator(FileAccess(mock_empty_file)).validate()

--- a/extra_data/validation.py
+++ b/extra_data/validation.py
@@ -136,7 +136,8 @@ class FileValidator:
 
 
 def check_index_contiguous(firsts, counts, record):
-    probs = []
+    if firsts.size == 0:
+        return  # no data in this dataset
 
     if firsts[0] != 0:
         record("Index doesn't start at 0")
@@ -156,8 +157,6 @@ def check_index_contiguous(firsts, counts, record):
         record("Overlaps ({}) in index, e.g. at {} ({} + {} > {})".format(
             overlap_ixs.size, pos, firsts[pos], counts[pos], firsts[pos + 1]
         ))
-
-    return probs
 
 
 def progress_bar(done, total, suffix=' '):


### PR DESCRIPTION
Validation failed on some files when a dataset has not data at all. Example: `/gpfs/exfel/exp/FXE/202030/p900121/raw/r0300/RAW-R0300-JNGFR01-S00000.h5`

At the moment it skips completely the contiguity check for this dataset, but I guess that at some point we should think of adding functionalities to feedback this kind of cases to the users. It is not an error as the file is readable, but knowing that a data source hasn't recorded anything is probably useful information.