### PR TITLE
Allow selection of sources by any iterable of glob patterns

### DIFF
--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -901,7 +901,7 @@ class DataCollection:
                 for (src_glob, key_glob) in selection
             )
         else:
-            TypeError("Unknown selection type: {}".format(type(selection)))
+            raise TypeError("Unknown selection type: {}".format(type(selection)))
 
         return dict(res)
 

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -11,6 +11,7 @@ program. If not, see <https://opensource.org/licenses/BSD-3-Clause>
 """
 
 from collections import defaultdict
+from collections.abc import Iterable
 import datetime
 import fnmatch
 import h5py
@@ -894,7 +895,7 @@ class DataCollection:
 
                 res[source].update(keys or None)
 
-        elif isinstance(selection, list):
+        elif isinstance(selection, Iterable):
             # selection = [('src_glob', 'key_glob'), ...]
             res = union_selections(
                 self._select_glob(src_glob, key_glob)
@@ -944,7 +945,7 @@ class DataCollection:
             # Select data in the image group for any detector sources
             sel = run.select('*/DET/*', 'image.*')
 
-        2. With a list of (source, key) glob patterns::
+        2. With an iterable of (source, key) glob patterns::
 
             # Select image.data and image.mask for any detector sources
             sel = run.select([('*/DET/*', 'image.data'), ('*/DET/*', 'image.mask')])

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -942,12 +942,12 @@ class DataCollection:
         1. With two glob patterns (see below) for source and key names::
 
             # Select data in the image group for any detector sources
-            sel = run.select('*/DET/*, 'image.*')
+            sel = run.select('*/DET/*', 'image.*')
 
         2. With a list of (source, key) glob patterns::
 
             # Select image.data and image.mask for any detector sources
-            sel = run.select([('*/DET/*, 'image.data'), ('*/DET/*, 'image.mask')])
+            sel = run.select([('*/DET/*', 'image.data'), ('*/DET/*', 'image.mask')])
 
            Data is included if it matches any of the pattern pairs.
 


### PR DESCRIPTION
Currently, `DataCollection.select` only works exactly for a single string, a list of tuples or a dictionary. This excludes other forms of iterables, e.g. sets or generators. This PR checks for the abstract base class `Iterable` rather than `list` to extend it to any iterable of glob patterns. The other two interfaces of `select` remain unchainged.

Given that strings and dicts branch out before, only sensible iterables should remain here. The official docs [suggest ](https://docs.python.org/3/library/collections.abc.html#collections.abc.Iterable) an alternative way of checking for an iterable via try...iter...except, but this would only suceed additionally for weird custom types having \_\_getitem__, yet not \_\_iter__.

I fixed the docstring of `select` while I was at it and found an amusing bug actually that prevented a `TypeError` from being raised if any non-dict, list or string is passed.