### PR TITLE
Allow varying numbers of detector frames by train

### DIFF
--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -90,6 +90,9 @@ class MPxDetectorBase:
                  *, min_modules=1):
         if detector_name is None:
             detector_name = self._find_detector_name(data)
+        if min_modules <= 0:
+            raise ValueError("min_modules must be a positive integer, not "
+                             f"{min_modules!r}")
 
         source_to_modno = self._identify_sources(data, detector_name, modules)
 

--- a/extra_data/tests/conftest.py
+++ b/extra_data/tests/conftest.py
@@ -79,7 +79,7 @@ def mock_spb_raw_run():
 @pytest.fixture(scope='session')
 def mock_reduced_spb_proc_run():
     """Varying number of frames stored from AGIPD"""
-    rng = np.random.default_rng(123)  # Fix seed
+    rng = np.random.RandomState(123)  # Fix seed
 
     with TemporaryDirectory() as td:
         make_examples.make_reduced_spb_run(td, raw=False, rng=rng)

--- a/extra_data/tests/conftest.py
+++ b/extra_data/tests/conftest.py
@@ -1,6 +1,7 @@
 import os.path as osp
 
 import h5py
+import numpy as np
 import pytest
 from tempfile import TemporaryDirectory
 
@@ -73,6 +74,15 @@ def mock_spb_proc_run():
 def mock_spb_raw_run():
     with TemporaryDirectory() as td:
         make_examples.make_spb_run(td)
+        yield td
+
+@pytest.fixture(scope='session')
+def mock_reduced_spb_proc_run():
+    """Varying number of frames stored from AGIPD"""
+    rng = np.random.default_rng(123)  # Fix seed
+
+    with TemporaryDirectory() as td:
+        make_examples.make_reduced_spb_run(td, raw=False, rng=rng)
         yield td
 
 @pytest.fixture(scope='session')

--- a/extra_data/tests/make_examples.py
+++ b/extra_data/tests/make_examples.py
@@ -266,9 +266,9 @@ def make_reduced_spb_run(dir_path, raw=True, rng=None):
     # Counts across modules should be consistent
     prefix = 'RAW' if raw else 'CORR'
     if rng is None:
-        rng = np.random.default_rng()
+        rng = np.random.RandomState()
 
-    frame_counts = rng.integers(0, 20, size=64)
+    frame_counts = rng.randint(0, 20, size=64)
     for modno in range(16):
         path = osp.join(dir_path,
                         '{}-R0238-AGIPD{:0>2}-S00000.h5'.format(prefix, modno))

--- a/extra_data/tests/make_examples.py
+++ b/extra_data/tests/make_examples.py
@@ -261,6 +261,35 @@ def make_spb_run(dir_path, raw=True, sensor_size=(1024, 768)):
                  BaslerCam('SPB_IRU_CAM/CAM/SIDEMIC', sensor_size=sensor_size)
                ], ntrains=32, firsttrain=10032, chunksize=32)
 
+def make_reduced_spb_run(dir_path, raw=True, rng=None):
+    # Simulate reduced AGIPD data, with varying number of frames per train.
+    # Counts across modules should be consistent
+    prefix = 'RAW' if raw else 'CORR'
+    if rng is None:
+        rng = np.random.default_rng()
+
+    frame_counts = rng.integers(0, 20, size=64)
+    for modno in range(16):
+        path = osp.join(dir_path,
+                        '{}-R0238-AGIPD{:0>2}-S00000.h5'.format(prefix, modno))
+        write_file(path, [
+            AGIPDModule('SPB_DET_AGIPD1M-1/DET/{}CH0'.format(modno), raw=raw,
+                         frames_per_train=frame_counts)
+            ], ntrains=64, chunksize=32)
+    if not raw:
+        return
+    write_file(osp.join(dir_path, '{}-R0238-DA01-S00000.h5'.format(prefix)),
+               [ XGM('SA1_XTD2_XGM/DOOCS/MAIN'),
+                 XGM('SPB_XTD9_XGM/DOOCS/MAIN'),
+                 BaslerCam('SPB_IRU_CAM/CAM/SIDEMIC', sensor_size=(1024, 768))
+               ], ntrains=32, chunksize=32)
+
+    write_file(osp.join(dir_path, '{}-R0238-DA01-S00001.h5'.format(prefix)),
+               [ XGM('SA1_XTD2_XGM/DOOCS/MAIN'),
+                 XGM('SPB_XTD9_XGM/DOOCS/MAIN'),
+                 BaslerCam('SPB_IRU_CAM/CAM/SIDEMIC', sensor_size=(1024, 768))
+               ], ntrains=32, firsttrain=10032, chunksize=32)
+
 if __name__ == '__main__':
     make_agipd_example_file('agipd_example.h5')
     make_fxe_da_file('fxe_control_example.h5')

--- a/extra_data/tests/test_components.py
+++ b/extra_data/tests/test_components.py
@@ -62,6 +62,48 @@ def test_get_array_pulse_indexes(mock_fxe_raw_run):
     assert arr.shape == (16, 3, 4, 256, 256)
 
 
+def test_get_array_pulse_id_reduced_data(mock_reduced_spb_proc_run):
+    run = RunDirectory(mock_reduced_spb_proc_run)
+    det = AGIPD1M(run.select_trains(by_index[:3]))
+    arr = det.get_array('image.data', pulses=by_id[0])
+    assert arr.shape == (16, 3, 1, 512, 128)
+    assert (arr.coords['pulse'] == 0).all()
+
+    arr = det.get_array('image.data', pulses=by_id[:5])
+    assert (arr.coords['pulse'] < 5).all()
+
+    # Empty selection
+    arr = det.get_array('image.data', pulses=by_id[:0])
+    assert arr.shape == (16, 0, 0, 512, 128)
+
+    arr = det.get_array('image.data', pulses=by_id[5:])
+    assert (arr.coords['pulse'] >= 5).all()
+
+    arr = det.get_array('image.data', pulses=by_id[[1, 7, 15, 23]])
+    assert np.isin(arr.coords['pulse'], [1, 7, 15, 23]).all()
+
+
+def test_get_array_pulse_indexes_reduced_data(mock_reduced_spb_proc_run):
+    run = RunDirectory(mock_reduced_spb_proc_run)
+    det = AGIPD1M(run.select_trains(by_index[:3]))
+    arr = det.get_array('image.data', pulses=by_index[0])
+    assert arr.shape == (16, 3, 1, 512, 128)
+    assert (arr.coords['pulse'] == 0).all()
+
+    arr = det.get_array('image.data', pulses=by_index[:5])
+    assert (arr.coords['pulse'] < 5).all()
+
+    # Empty selection
+    arr = det.get_array('image.data', pulses=by_index[:0])
+    assert arr.shape == (16, 0, 0, 512, 128)
+
+    arr = det.get_array('image.data', pulses=by_index[5:])
+    assert (arr.coords['pulse'] >= 5).all()
+
+    arr = det.get_array('image.data', pulses=by_index[[1, 7, 15, 23]])
+    assert np.isin(arr.coords['pulse'], [1, 7, 15, 23]).all()
+
+
 def test_get_dask_array(mock_fxe_raw_run):
     run = RunDirectory(mock_fxe_raw_run)
     det = LPD1M(run)
@@ -80,6 +122,18 @@ def test_get_dask_array(mock_fxe_raw_run):
 
     arr_cellid = det.get_dask_array('image.data', subtrain_index='cellId')
     assert arr_cellid.coords['cellId'].shape == (480 * 128,)
+
+
+def test_get_dask_array_reduced_data(mock_reduced_spb_proc_run):
+    run = RunDirectory(mock_reduced_spb_proc_run)
+    det = AGIPD1M(run)
+    arr = det.get_dask_array('image.data')
+
+    assert arr.shape[2:] == (512, 128)
+    assert arr.dims == ('module', 'train_pulse', 'dim_0', 'dim_1')
+    np.testing.assert_array_equal(arr.coords['module'], np.arange(16))
+    assert np.isin(arr.coords['trainId'], np.arange(10000, 10480)).all()
+    assert np.isin(arr.coords['pulseId'], np.arange(0, 20)).all()
 
 
 def test_iterate(mock_fxe_raw_run):

--- a/extra_data/tests/test_components.py
+++ b/extra_data/tests/test_components.py
@@ -184,3 +184,22 @@ def test_write_virtual_cxi_raw_data(mock_fxe_raw_run, tmpdir, caplog):
     test_file = osp.join(str(tmpdir), 'test.cxi')
     det.write_virtual_cxi(test_file)
     assert_isfile(test_file)
+
+    with h5py.File(test_file, 'r') as f:
+        det_grp = f['entry_1/instrument_1/detector_1']
+        ds = det_grp['data']
+        assert ds.shape[1:] == (16, 1, 256, 256)
+
+
+def test_write_virtual_cxi_reduced_data(mock_reduced_spb_proc_run, tmpdir):
+    run = RunDirectory(mock_reduced_spb_proc_run)
+    det = AGIPD1M(run)
+
+    test_file = osp.join(str(tmpdir), 'test.cxi')
+    det.write_virtual_cxi(test_file)
+    assert_isfile(test_file)
+
+    with h5py.File(test_file, 'r') as f:
+        det_grp = f['entry_1/instrument_1/detector_1']
+        ds = det_grp['data']
+        assert ds.shape[1:] == (16, 512, 128)

--- a/extra_data/write_cxi.py
+++ b/extra_data/write_cxi.py
@@ -29,17 +29,17 @@ class VirtualCXIWriter:
 
         self.modulenos = sorted(detdata.modno_to_source)
 
-        train_ids = detdata.train_ids
-        frames_per_train = detdata.frames_per_train
-        ntrains = np.uint64(len(train_ids))
-        self.nframes = ntrains * frames_per_train
-        log.info("%d frames per train, %d frames in total",
-                     frames_per_train, self.nframes)
+        frame_counts = detdata.frame_counts
+        self.nframes = frame_counts.sum()
+        log.info("Up to %d frames per train, %d frames in total",
+                 frame_counts.max(), self.nframes)
 
-        self.train_ids_perframe = np.repeat(train_ids, frames_per_train)
+        self.train_ids_perframe = np.repeat(
+            frame_counts.index.values, frame_counts.values.astype(np.intp)
+        )
 
-        positions = np.arange(0, ntrains, dtype=np.uint64) * frames_per_train
-        self.train_id_to_ix = dict(zip(train_ids, positions))
+        # cumulative sum gives the end of each train, subtract to get start
+        self.train_id_to_ix = frame_counts.cumsum() - frame_counts
 
     @property
     def nmodules(self):


### PR DESCRIPTION
This is a first step to facilitate data reduction: removing the assumption that detector data has the same number of frames in each train. We still enforce that all modules with data for a train must have the same number of entries within that train.

Much of the changes here are to the tests to make sure this is working.

cc @dallanto @egorsobolev (but no need to look at it right now - enjoy your weekend)