### PR TITLE
Fix unwanted file cache behavior caused by delayed garbage collection

### DIFF
--- a/extra_data/filecache.py
+++ b/extra_data/filecache.py
@@ -113,7 +113,21 @@ class FileCache(object):
         
 import resource
 
-def init_extra_data_filecache():
+def set_global_filecache(fc):
+    """
+    Sets new FileCache instance as a global file cache
+    """
+    global extra_data_filecache
+    extra_data_filecache = fc
+    
+def get_global_filecache():
+    """
+    Returns FileCache instance which is used as global file cache
+    """
+    global extra_data_filecache
+    return extra_data_filecache
+
+def init_global_filecache():
     # Raise the limit for open files (1024 -> 4096 on Maxwell)
     nofile = resource.getrlimit(resource.RLIMIT_NOFILE)
     resource.setrlimit(resource.RLIMIT_NOFILE, (nofile[1], nofile[1]))
@@ -121,4 +135,4 @@ def init_extra_data_filecache():
     global extra_data_filecache
     extra_data_filecache = FileCache(maxfiles)
 
-init_extra_data_filecache()
+init_global_filecache()

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -42,7 +42,7 @@ from .read_machinery import (
     find_proposal,
 )
 from .run_files_map import RunFilesMap
-from .filecache import get_global_filecache
+from . import filecache
 
 __all__ = [
     'H5File',
@@ -85,7 +85,6 @@ class FileAccess:
 
     def __init__(self, filename, _cache_info=None):
         self.filename = filename
-        self.__fc = get_global_filecache()
 
         if _cache_info:
             self.train_ids = _cache_info['train_ids']
@@ -111,9 +110,9 @@ class FileAccess:
     @property
     def file(self):
         if self.__file:
-            self.__fc.touch(self.filename)
+            filecache.extra_data_filecache.touch(self.filename)
         else:
-            self.__file = self.__fc.open(self.filename)
+            self.__file = filecache.extra_data_filecache.open(self.filename)
             
         return self.__file
 
@@ -172,15 +171,9 @@ class FileAccess:
     def __getstate__(self):
         """ Allows pickling `FileAccess` instance. """
         state = self.__dict__.copy()
-        del state['_FileAccess__fc']
         del state['_FileAccess__file']
         return state
     
-    def __setstate__(self, state):
-        """ Allows unpickling `FileAccess` instance. """
-        self.__dict__.update(state)
-        self.__fc = get_global_filecache()
-
     @property
     def all_sources(self):
         return self.control_sources | self.instrument_sources

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -79,7 +79,7 @@ class FileAccess:
     file: h5py.File
         Open h5py file object
     """
-    _file = None
+    __file = None
     _format_version = None
     metadata_fstat = None
 
@@ -113,17 +113,17 @@ class FileAccess:
 
     @property
     def file(self):
-        if self._file:
+        if self.__file:
             self.__fc.touch(self.filename)
         else:
-            self._file = self.__fc.open(self.filename)
+            self.__file = self.__fc.open(self.filename)
             
-        return self._file
+        return self.__file
 
     def close(self):
-        if self._file:
+        if self.__file:
             self.__fc.close(self.filename)
-            self._file = None
+            self.__file = None
 
     @property
     def format_version(self):
@@ -178,7 +178,7 @@ class FileAccess:
         """ Allows pickling `FileAccess` instance. """
         state = self.__dict__.copy()
         del state['_FileAccess__fc']
-        state['_file'] = None
+        del state['_FileAccess__file']
         return state
     
     def __setstate__(self, state):

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -108,9 +108,6 @@ class FileAccess:
         # {source: set(keys)} - including incomplete sets
         self._known_keys = defaultdict(set)
 
-    def __del__(self):
-        self.close()
-
     @property
     def file(self):
         if self.__file:
@@ -121,9 +118,7 @@ class FileAccess:
         return self.__file
 
     def close(self):
-        if self.__file:
-            self.__fc.close(self.filename)
-            self.__file = None
+        self.__file = None
 
     @property
     def format_version(self):

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -356,6 +356,15 @@ class DataCollection:
     def from_path(cls, path):
         files = [FileAccess(path)]
         return cls(files, ctx_closes=True)
+    
+    def _close_all_files(self):
+        # Close the files if this collection was created by opening them.
+        if self.ctx_closes:
+            for file in self.files:
+                file.close()
+    
+    def __del__(self):
+        self._close_all_files()
 
     def __enter__(self):
         if not self.ctx_closes:
@@ -368,10 +377,7 @@ class DataCollection:
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        # Close the files if this collection was created by opening them.
-        if self.ctx_closes:
-            for file in self.files:
-                file.close()
+        self._close_all_files()
 
     @property
     def all_sources(self):

--- a/extra_data/tests/test_filecache.py
+++ b/extra_data/tests/test_filecache.py
@@ -5,19 +5,19 @@ from extra_data.reader import DataCollection
 
 @pytest.fixture
 def filecache_512():
-    from extra_data.filecache import FileCache, set_global_filecache, get_global_filecache
-    orig_cache = get_global_filecache()
-    set_global_filecache(FileCache(512))
-    yield get_global_filecache()
-    set_global_filecache(orig_cache)
+    from extra_data import filecache
+    orig_cache = filecache.extra_data_filecache
+    filecache.extra_data_filecache = fc = filecache.FileCache(512)
+    yield fc
+    filecache.extra_data_filecache = orig_cache
 
 @pytest.fixture
 def filecache_3():
-    from extra_data.filecache import FileCache, set_global_filecache, get_global_filecache
-    orig_cache = get_global_filecache()
-    set_global_filecache(FileCache(3))
-    yield get_global_filecache()
-    set_global_filecache(orig_cache)
+    from extra_data import filecache
+    orig_cache = filecache.extra_data_filecache
+    filecache.extra_data_filecache = fc = filecache.FileCache(3)
+    yield fc
+    filecache.extra_data_filecache = orig_cache
 
 
 def test_filecache_large(mock_spb_raw_run, filecache_512):
@@ -46,7 +46,7 @@ def test_filecache_large(mock_spb_raw_run, filecache_512):
     assert device in data
     assert data[device]['data.image.pixels'].shape == (1024, 768)
     assert len(fc._cache) == nfiles
-
+    
     del run, trains_iter
     assert len(fc._cache) == 0
 

--- a/extra_data/tests/test_filecache.py
+++ b/extra_data/tests/test_filecache.py
@@ -5,25 +5,19 @@ from extra_data.reader import DataCollection
 
 @pytest.fixture
 def filecache_512():
-    from extra_data.filecache import extra_data_filecache
-    orig_cache = extra_data_filecache._cache
-    orig_maxfiles = extra_data_filecache.maxfiles
-    extra_data_filecache._cache = OrderedDict()
-    extra_data_filecache._maxfiles = 512
-    yield extra_data_filecache
-    extra_data_filecache._cache = orig_cache
-    extra_data_filecache._maxfiles = orig_maxfiles
+    from extra_data.filecache import FileCache, set_global_filecache, get_global_filecache
+    orig_cache = get_global_filecache()
+    set_global_filecache(FileCache(512))
+    yield get_global_filecache()
+    set_global_filecache(orig_cache)
 
 @pytest.fixture
 def filecache_3():
-    from extra_data.filecache import extra_data_filecache
-    orig_cache = extra_data_filecache._cache
-    orig_maxfiles = extra_data_filecache.maxfiles
-    extra_data_filecache._cache = OrderedDict()
-    extra_data_filecache._maxfiles = 3
-    yield extra_data_filecache
-    extra_data_filecache._cache = orig_cache
-    extra_data_filecache._maxfiles = orig_maxfiles
+    from extra_data.filecache import FileCache, set_global_filecache, get_global_filecache
+    orig_cache = get_global_filecache()
+    set_global_filecache(FileCache(3))
+    yield get_global_filecache()
+    set_global_filecache(orig_cache)
 
 
 def test_filecache_large(mock_spb_raw_run, filecache_512):
@@ -32,6 +26,18 @@ def test_filecache_large(mock_spb_raw_run, filecache_512):
     files = [os.path.join(mock_spb_raw_run, f) \
              for f in os.listdir(mock_spb_raw_run) if f.endswith('.h5')]
     run = DataCollection.from_paths(files)
+    
+    # estimate the number of files which should be open to read the first train
+    cnt, fix = {}, {}
+    for f in run.files:
+        a, b = os.path.basename(f.filename).rsplit('-',1)
+        try:
+            cnt[a] += 1
+        except KeyError:
+            cnt[a] = 1
+        if b == 'S00000.h5':
+            fix[a] = cnt[a] 
+    nfiles = sum(a for a in fix.values())
 
     trains_iter = run.trains()
     tid, data = next(trains_iter)
@@ -39,10 +45,10 @@ def test_filecache_large(mock_spb_raw_run, filecache_512):
     device = 'SPB_IRU_CAM/CAM/SIDEMIC:daqOutput'
     assert device in data
     assert data[device]['data.image.pixels'].shape == (1024, 768)
-    assert len(fc._cache) == len(run.files)
+    assert len(fc._cache) == nfiles
 
     del run, trains_iter
-    assert len(fc._cache) == 0    
+    assert len(fc._cache) == 0
 
 def test_filecache_small(mock_spb_raw_run, filecache_3):
     fc = filecache_3


### PR DESCRIPTION
Fix the cause #45  
- linking of `FileAccess` instance to the global `FileCache` instance at the creation time
- functions to get/set global `FileCache` instance
- in the test, correct estimation of the number of files in cache independent on files order in `DataCollection`

In addition, switching to weakref:
- switch `FileCache` to the usage of `weakref`
- explicit closing of files in `DataCollection` destructor

@takluyver could you please take a look?