### PR TITLE
starting commit: add Jungfrau class inheriting from MPxDetectorBase; …

### DIFF
--- a/extra_data/cli/make_virtual_cxi.py
+++ b/extra_data/cli/make_virtual_cxi.py
@@ -13,6 +13,11 @@ log = logging.getLogger(__name__)
 
 
 def _get_detector(data, min_modules, modules=None):
+    if modules != None and ',' in modules:
+        try:  
+            modules = [int(x) for x in modules.split(',')]
+        except ValueError:
+            modules=None
     for cls in (AGIPD1M, LPD1M, JUNGFRAU):
         try:
             return cls(data, min_modules=min_modules, modules=modules)
@@ -36,8 +41,8 @@ def main(argv=None):
         help="Include trains where at least N modules have data (default 9)"
     )
     ap.add_argument(
-        '--n_modules', type=int, default=8,
-        help="Expect this flexibly assembled detector to have N modules"
+        '--modules', type=str, default='',
+        help="String encoding a sequence of modules, e.g. 1,2,3,4"
     )
     args = ap.parse_args(argv)
     out_file = args.output
@@ -73,7 +78,7 @@ def main(argv=None):
 
     log.info("Reading run directory %s", run_dir)
     run = RunDirectory(run_dir)
-    det = _get_detector(run, args.min_modules, modules=args.n_modules)
+    det = _get_detector(run, args.min_modules, modules=args.modules)
     if det is None:
         sys.exit("No AGIPD or LPD sources found in {!r}".format(run_dir))
 

--- a/extra_data/cli/make_virtual_cxi.py
+++ b/extra_data/cli/make_virtual_cxi.py
@@ -6,16 +6,16 @@ import re
 import sys
 
 from extra_data import RunDirectory
-from extra_data.components import AGIPD1M, LPD1M
+from extra_data.components import AGIPD1M, LPD1M, JUNGFRAU
 from extra_data.exceptions import SourceNameError
 
 log = logging.getLogger(__name__)
 
 
-def _get_detector(data, min_modules):
-    for cls in (AGIPD1M, LPD1M):
+def _get_detector(data, min_modules, modules=None):
+    for cls in (AGIPD1M, LPD1M, JUNGFRAU):
         try:
-            return cls(data, min_modules=min_modules)
+            return cls(data, min_modules=min_modules, modules=modules)
         except SourceNameError:
             continue
 
@@ -34,6 +34,10 @@ def main(argv=None):
     ap.add_argument(
         '--min-modules', type=int, default=9, metavar='N',
         help="Include trains where at least N modules have data (default 9)"
+    )
+    ap.add_argument(
+        '--n_modules', type=int, default=8,
+        help="Expect this flexibly assembled detector to have N modules"
     )
     args = ap.parse_args(argv)
     out_file = args.output
@@ -69,7 +73,7 @@ def main(argv=None):
 
     log.info("Reading run directory %s", run_dir)
     run = RunDirectory(run_dir)
-    det = _get_detector(run, args.min_modules)
+    det = _get_detector(run, args.min_modules, modules=args.n_modules)
     if det is None:
         sys.exit("No AGIPD or LPD sources found in {!r}".format(run_dir))
 

--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -90,12 +90,13 @@ class MPxDetectorBase:
                  *, min_modules=1):
         if detector_name is None:
             detector_name = self._find_detector_name(data)
+        print(' ### detector name:', detector_name)
         if min_modules <= 0:
             raise ValueError("min_modules must be a positive integer, not "
                              f"{min_modules!r}")
 
         source_to_modno = self._identify_sources(data, detector_name, modules)
-
+        print(' ### sources:', source_to_modno)
         data = data.select([(src, '*') for src in source_to_modno])
         self.detector_name = detector_name
         self.source_to_modno = source_to_modno
@@ -103,7 +104,8 @@ class MPxDetectorBase:
         # pandas' missing-data handling converts the data to floats if there
         # are any gaps - so fill them with 0s and convert back to uint64.
         mod_data_counts = pd.DataFrame({
-            src: data.get_data_counts(src, 'image.data')
+            #src: data.get_data_counts(src, 'image.data')
+            src: data.get_data_counts(src, 'data.adc')
             for src in source_to_modno
         }).fillna(0).astype(np.uint64)
 
@@ -149,7 +151,8 @@ class MPxDetectorBase:
 
     @staticmethod
     def _identify_sources(data, detector_name=None, modules=None):
-        detector_re = re.compile(re.escape(detector_name) + r'/DET/(\d+)CH')
+        #detector_re = re.compile(re.escape(detector_name) + r'/DET/(\d+)CH')
+        detector_re = re.compile(re.escape(detector_name) + r'/DET/MODULE_(\d+)')
         source_to_modno = {}
         for source in data.instrument_sources:
             m = detector_re.match(source)

--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -639,3 +639,23 @@ class LPD1M(MPxDetectorBase):
     """
     _source_re = re.compile(r'(?P<detname>(.+)_LPD1M(.*))/DET/(\d+)CH')
     module_shape = (256, 256)
+
+
+class JUNGFRAU(MPxDetectorBase):
+    """An interface to JUNGFRAU data.
+    Parameters
+    ----------
+    data: DataCollection
+      A data collection, e.g. from RunDirectory.
+    modules: set of ints, optional
+      Detector module numbers to use. By default, all available modules
+      are used.
+    detector_name: str, optional
+      Name of a detector, e.g. 'SPB_IRDA_JNGFR'. This is only needed
+      if the dataset includes more than one JUNGFRAU detector.
+    min_modules: int
+      Include trains where at least n modules have data. Default is 1.
+    """
+    _source_re = re.compile(r'(?P<detname>(.+)_JNGFR(.*))/DET/MODULE_(\d+)')
+    module_shape = (1024, 512)
+


### PR DESCRIPTION
@takluyver  
Hi Thomas, I had a start by trying to follow your recommendations in the e-mail. To pass n_modules, I use the ``modules=`` parameter as the base class constructor (``__init__``) seems to expect it this way.  
From the front-end POV, that's another optional CLI argument, passed to ``get_detector()``.  
I have a conceptual problem with the detector name as in the ``re()`` expressions, though:  
The data aggregator source name in ``/gpfs/exfel/exp/SPB/201922/p002566/proc/r0061`` HDF5 files are like: ``SPB_IRDA_JNGFR/DET/MODULE_1:daqOutput`` and I cannot easily relate this to the scheme used for AGIPD-1M.