### PR TITLE
Partial update of mockdata and test to support file version 1.0

### DIFF
--- a/extra_data/tests/conftest.py
+++ b/extra_data/tests/conftest.py
@@ -8,82 +8,83 @@ from tempfile import TemporaryDirectory
 from . import make_examples
 
 
+@pytest.fixture(scope='session', params=['0.5', '1.0'])
+def format_version(request):
+    return request.param
+
+
 @pytest.fixture(scope='module')
-def mock_agipd_data():
+def mock_agipd_data(format_version):
     # This one uses the older index format
     # (first/last/status instead of first/count)
     with TemporaryDirectory() as td:
         path = osp.join(td, 'CORR-R9999-AGIPD07-S00000.h5')
-        make_examples.make_agipd_example_file(path)
+        make_examples.make_agipd_example_file(path, format_version=format_version)
         yield path
 
 
 @pytest.fixture(scope='module')
-def mock_lpd_data():
+def mock_lpd_data(format_version):
     with TemporaryDirectory() as td:
         path = osp.join(td, 'RAW-R9999-LPD00-S00000.h5')
-        make_examples.make_lpd_file(path)
+        make_examples.make_lpd_file(path, format_version=format_version)
         yield path
 
 
 @pytest.fixture(scope='module')
-def mock_fxe_control_data():
+def mock_fxe_control_data(format_version):
     with TemporaryDirectory() as td:
         path = osp.join(td, 'RAW-R0450-DA01-S00001.h5')
-        make_examples.make_fxe_da_file(path)
+        make_examples.make_fxe_da_file(path, format_version=format_version)
         yield path
 
 
 @pytest.fixture(scope='module')
-def mock_sa3_control_data():
+def mock_sa3_control_data(format_version):
     with TemporaryDirectory() as td:
         path = osp.join(td, 'RAW-R0450-DA01-S00001.h5')
-        make_examples.make_sa3_da_file(path)
+        make_examples.make_sa3_da_file(path, format_version=format_version)
         yield path
 
 
 @pytest.fixture(scope='module')
-def mock_sa3_control_data_fmt_1_0():
-    with TemporaryDirectory() as td:
-        path = osp.join(td, 'RAW-R0450-DA01-S00001.h5')
-        make_examples.make_sa3_da_file(path, format_version='1.0')
-        yield path
-
-
-@pytest.fixture(scope='module')
-def mock_spb_control_data_badname():
+def mock_spb_control_data_badname(format_version):
     with TemporaryDirectory() as td:
         path = osp.join(td, 'RAW-R0309-DA01-S00000.h5')
-        make_examples.make_data_file_bad_device_name(path)
+        make_examples.make_data_file_bad_device_name(path, format_version=format_version)
         yield path
 
 
 @pytest.fixture(scope='session')
-def mock_fxe_raw_run():
+def mock_fxe_raw_run(format_version):
     with TemporaryDirectory() as td:
-        make_examples.make_fxe_run(td)
+        make_examples.make_fxe_run(td, format_version=format_version)
         yield td
 
-@pytest.fixture(scope='session')
-def mock_spb_proc_run():
-    with TemporaryDirectory() as td:
-        make_examples.make_spb_run(td, raw=False)
-        yield td
 
 @pytest.fixture(scope='session')
-def mock_spb_raw_run():
+def mock_spb_proc_run(format_version):
     with TemporaryDirectory() as td:
-        make_examples.make_spb_run(td)
+        make_examples.make_spb_run(td, raw=False, format_version=format_version)
         yield td
 
+
 @pytest.fixture(scope='session')
-def mock_reduced_spb_proc_run():
+def mock_reduced_spb_proc_run(format_version):
     """Varying number of frames stored from AGIPD"""
     rng = np.random.RandomState(123)  # Fix seed
-
     with TemporaryDirectory() as td:
-        make_examples.make_reduced_spb_run(td, raw=False, rng=rng)
+        make_examples.make_reduced_spb_run(td, raw=False, rng=rng,
+                                           format_version=format_version)
         yield td
+
+
+@pytest.fixture(scope='session')
+def mock_spb_raw_run(format_version):
+    with TemporaryDirectory() as td:
+        make_examples.make_spb_run(td, format_version=format_version)
+        yield td
+
 
 @pytest.fixture(scope='session')
 def empty_h5_file():

--- a/extra_data/tests/make_examples.py
+++ b/extra_data/tests/make_examples.py
@@ -4,20 +4,23 @@ import os.path as osp
 import numpy as np
 
 from .mockdata import write_file
-from .mockdata.xgm import XGM
-from .mockdata.gec_camera import GECCamera
-from .mockdata.basler_camera import BaslerCamera as BaslerCam
 from .mockdata.adc import ADC
-from .mockdata.uvlamp import UVLamp
-from .mockdata.motor import Motor
-from .mockdata.tsens import TemperatureSensor
-from .mockdata.imgfel import IMGFELCamera, IMGFELMotor
-from .mockdata.gauge import Gauge
+from .mockdata.base import write_base_index
+from .mockdata.basler_camera import BaslerCamera as BaslerCam
 from .mockdata.dctrl import DCtrl
-from .mockdata.mpod import MPOD
 from .mockdata.detectors import AGIPDModule, LPDModule
+from .mockdata.gauge import Gauge
+from .mockdata.gec_camera import GECCamera
+from .mockdata.imgfel import IMGFELCamera, IMGFELMotor
+from .mockdata.motor import Motor
+from .mockdata.mpod import MPOD
+from .mockdata.tsens import TemperatureSensor
+from .mockdata.uvlamp import UVLamp
+from .mockdata.xgm import XGM
+
 
 vlen_bytes = h5py.special_dtype(vlen=bytes)
+
 
 def make_metadata(h5file, data_sources, chunksize=16):
     N = len(data_sources)
@@ -37,20 +40,8 @@ def make_metadata(h5file, data_sources, chunksize=16):
                                        dtype=vlen_bytes, maxshape=(None,))
     devices_ds[:len(data_sources)] = devices
 
-def write_train_ids(f, path, N, chunksize=16):
-    """Make a dataset of fake train IDs at the given path
 
-    Real train IDs are much larger (~10^9), so hopefully these won't be mistaken
-    for real ones.
-    """
-    if N % chunksize:
-        Npad = N + chunksize - (N % chunksize)
-    else:
-        Npad = N
-    ds = f.create_dataset(path, (Npad,), 'u8', maxshape=(None,))
-    ds[:N] = np.arange(10000, 10000 + N)
-
-def make_agipd_example_file(path):
+def make_agipd_example_file(path, format_version='0.5'):
     """Make the structure of a data file from the AGIPD detector
 
     Based on /gpfs/exfel/d/proc/XMPL/201750/p700000/r0803/CORR-R0803-AGIPD07-S00000.h5
@@ -76,7 +67,7 @@ def make_agipd_example_file(path):
         d[:250] = train_ids
 
     # INDEX - matching up data to train IDs
-    write_train_ids(f, 'INDEX/trainId', 250)
+    write_base_index(f, 250, format_version=format_version)
     for ch in channels:
         grp_name = 'INDEX/SPB_DET_AGIPD1M-1/DET/7CH0:xtdf/%s/' % ch
         first = f.create_dataset(grp_name + 'first', (256,), 'u8', maxshape=(None,))
@@ -149,7 +140,7 @@ def make_agipd_example_file(path):
     f.create_dataset('INSTRUMENT/SPB_DET_AGIPD1M-1/DET/7CH0:xtdf/trailer/status',
                         (256,), 'u8', maxshape=(None,))  # Empty in example
 
-def make_fxe_da_file(path):
+def make_fxe_da_file(path, format_version='0.5'):
     """Make the structure of a file with non-detector data from the FXE experiment
 
     Based on .../FXE/201830/p900023/r0450/RAW-R0450-DA01-S00001.h5
@@ -159,7 +150,7 @@ def make_fxe_da_file(path):
         XGM('SA1_XTD2_XGM/DOOCS/MAIN'),
         XGM('SPB_XTD9_XGM/DOOCS/MAIN'),
         GECCamera('FXE_XAD_GEC/CAM/CAMERA'),
-    ], ntrains=400, chunksize=200)
+    ], ntrains=400, chunksize=200, format_version=format_version)
 
 def make_sa3_da_file(path, ntrains=500, format_version='0.5'):
     """Make the structure of a file with non-detector data from SASE3 tunnel
@@ -198,23 +189,23 @@ def make_sa3_da_file(path, ntrains=500, format_version='0.5'):
         MPOD('SA3_XTD10_MCP/MCPS/MPOD'),
     ], ntrains=ntrains, chunksize=50, format_version=format_version)
 
-def make_data_file_bad_device_name(path):
+def make_data_file_bad_device_name(path, format_version='0.5'):
     """Not all devices have the Karabo standard A/B/C naming convention"""
     write_file(path, [
         BaslerCam('SPB_IRU_SIDEMIC_CAM', sensor_size=(1000, 1000))
-    ], ntrains=500, chunksize=50)
+    ], ntrains=500, chunksize=50, format_version=format_version)
 
-def make_agipd_file(path):
+def make_agipd_file(path, format_version='0.5'):
     write_file(path, [
         AGIPDModule('SPB_DET_AGIPD1M-1/DET/0CH0', frames_per_train=64)
-    ], ntrains=486, chunksize=32)
+    ], ntrains=486, chunksize=32, format_version=format_version)
 
-def make_lpd_file(path):
+def make_lpd_file(path, format_version='0.5'):
     write_file(path, [
         LPDModule('FXE_DET_LPD1M-1/DET/0CH0', frames_per_train=128)
-    ], ntrains=480, chunksize=32)
+    ], ntrains=480, chunksize=32, format_version=format_version)
 
-def make_fxe_run(dir_path, raw=True):
+def make_fxe_run(dir_path, raw=True, format_version='0.5'):
     prefix = 'RAW' if raw else 'CORR'
     for modno in range(16):
         path = osp.join(dir_path,
@@ -222,7 +213,7 @@ def make_fxe_run(dir_path, raw=True):
         write_file(path, [
             LPDModule('FXE_DET_LPD1M-1/DET/{}CH0'.format(modno), raw=raw,
                       frames_per_train=128)
-        ], ntrains=480, chunksize=32)
+        ], ntrains=480, chunksize=32, format_version=format_version)
     if not raw:
         return
     write_file(osp.join(dir_path, 'RAW-R0450-DA01-S00000.h5'), [
@@ -230,15 +221,15 @@ def make_fxe_run(dir_path, raw=True):
         XGM('SPB_XTD9_XGM/DOOCS/MAIN'),
         GECCamera('FXE_XAD_GEC/CAM/CAMERA'),
         GECCamera('FXE_XAD_GEC/CAM/CAMERA_NODATA', nsamples=0),
-    ], ntrains=400, chunksize=200)
+    ], ntrains=400, chunksize=200, format_version=format_version)
     write_file(osp.join(dir_path, '{}-R0450-DA01-S00001.h5'.format(prefix)), [
         XGM('SA1_XTD2_XGM/DOOCS/MAIN'),
         XGM('SPB_XTD9_XGM/DOOCS/MAIN'),
         GECCamera('FXE_XAD_GEC/CAM/CAMERA'),
         GECCamera('FXE_XAD_GEC/CAM/CAMERA_NODATA', nsamples=0),
-    ], ntrains=80, firsttrain=10400, chunksize=200)
+    ], ntrains=80, firsttrain=10400, chunksize=200, format_version=format_version)
 
-def make_spb_run(dir_path, raw=True, sensor_size=(1024, 768)):
+def make_spb_run(dir_path, raw=True, sensor_size=(1024, 768), format_version='0.5'):
     prefix = 'RAW' if raw else 'CORR'
     for modno in range(16):
         path = osp.join(dir_path,
@@ -246,22 +237,23 @@ def make_spb_run(dir_path, raw=True, sensor_size=(1024, 768)):
         write_file(path, [
             AGIPDModule('SPB_DET_AGIPD1M-1/DET/{}CH0'.format(modno), raw=raw,
                          frames_per_train=64)
-            ], ntrains=64, chunksize=32)
+            ], ntrains=64, chunksize=32, format_version=format_version)
     if not raw:
         return
     write_file(osp.join(dir_path, '{}-R0238-DA01-S00000.h5'.format(prefix)),
                [ XGM('SA1_XTD2_XGM/DOOCS/MAIN'),
                  XGM('SPB_XTD9_XGM/DOOCS/MAIN'),
                  BaslerCam('SPB_IRU_CAM/CAM/SIDEMIC', sensor_size=sensor_size)
-               ], ntrains=32, chunksize=32)
+               ], ntrains=32, chunksize=32, format_version=format_version)
 
     write_file(osp.join(dir_path, '{}-R0238-DA01-S00001.h5'.format(prefix)),
                [ XGM('SA1_XTD2_XGM/DOOCS/MAIN'),
                  XGM('SPB_XTD9_XGM/DOOCS/MAIN'),
                  BaslerCam('SPB_IRU_CAM/CAM/SIDEMIC', sensor_size=sensor_size)
-               ], ntrains=32, firsttrain=10032, chunksize=32)
+               ], ntrains=32, firsttrain=10032, chunksize=32,
+               format_version=format_version)
 
-def make_reduced_spb_run(dir_path, raw=True, rng=None):
+def make_reduced_spb_run(dir_path, raw=True, rng=None, format_version='0.5'):
     # Simulate reduced AGIPD data, with varying number of frames per train.
     # Counts across modules should be consistent
     prefix = 'RAW' if raw else 'CORR'
@@ -275,20 +267,21 @@ def make_reduced_spb_run(dir_path, raw=True, rng=None):
         write_file(path, [
             AGIPDModule('SPB_DET_AGIPD1M-1/DET/{}CH0'.format(modno), raw=raw,
                          frames_per_train=frame_counts)
-            ], ntrains=64, chunksize=32)
+            ], ntrains=64, chunksize=32, format_version=format_version)
     if not raw:
         return
     write_file(osp.join(dir_path, '{}-R0238-DA01-S00000.h5'.format(prefix)),
                [ XGM('SA1_XTD2_XGM/DOOCS/MAIN'),
                  XGM('SPB_XTD9_XGM/DOOCS/MAIN'),
                  BaslerCam('SPB_IRU_CAM/CAM/SIDEMIC', sensor_size=(1024, 768))
-               ], ntrains=32, chunksize=32)
+               ], ntrains=32, chunksize=32, format_version=format_version)
 
     write_file(osp.join(dir_path, '{}-R0238-DA01-S00001.h5'.format(prefix)),
                [ XGM('SA1_XTD2_XGM/DOOCS/MAIN'),
                  XGM('SPB_XTD9_XGM/DOOCS/MAIN'),
                  BaslerCam('SPB_IRU_CAM/CAM/SIDEMIC', sensor_size=(1024, 768))
-               ], ntrains=32, firsttrain=10032, chunksize=32)
+               ], ntrains=32, firsttrain=10032, chunksize=32,
+               format_version=format_version)
 
 if __name__ == '__main__':
     make_agipd_example_file('agipd_example.h5')

--- a/extra_data/tests/mockdata/base.py
+++ b/extra_data/tests/mockdata/base.py
@@ -186,7 +186,7 @@ def write_base_index(f, N, first=10000, chunksize=16, format_version='0.5'):
 
     if format_version != '0.5':
         # flag
-        ds = f.create_dataset('INDEX/flag', (Npad,), 'u4', maxshape=(None,))
+        ds = f.create_dataset('INDEX/flag', (Npad,), 'i4', maxshape=(None,))
         ds[:N] = np.ones(N)
 
         # timestamps

--- a/extra_data/tests/mockdata/base.py
+++ b/extra_data/tests/mockdata/base.py
@@ -162,7 +162,7 @@ def write_metadata(h5file, data_sources, chunksize=16, format_version='0.5'):
         # get sequence number
         fname_pattern = r'^(RAW|CORR)\-R\d+\-.*\-S(\d+).h5$'
         match = re.match(fname_pattern, osp.basename(h5file.filename))
-        sequence = int(match[1]) if match is not None else 0
+        sequence = int(match[2]) if match is not None else 0
         h5file.create_dataset('METADATA/sequenceNumber', dtype=np.uint32,
                               data=[sequence])
         h5file['METADATA/updateDate'] = [

--- a/extra_data/tests/mockdata/base.py
+++ b/extra_data/tests/mockdata/base.py
@@ -1,5 +1,10 @@
+from datetime import datetime
+import os.path as osp
+import re
+
 import h5py
 import numpy as np
+
 
 class DeviceBase:
     # Override these in subclasses
@@ -142,9 +147,27 @@ def write_metadata(h5file, data_sources, chunksize=16, format_version='0.5'):
 
     if format_version != '0.5':
         h5file['METADATA/dataFormatVersion'] = [format_version.encode('ascii')]
+        now = datetime.utcnow().replace(microsecond=0).strftime('%Y%m%dT%H%M%SZ')
+        h5file['METADATA/creationDate'] = [now.encode('ascii')]
+        h5file['METADATA/daqLibrary'] = [b'1.9.0']
+        h5file['METADATA/karaboFramework'] = [b'2.7.0']
+        h5file.create_dataset('METADATA/proposalNumber', dtype=np.uint32, data=[700000])
+        h5file.create_dataset('METADATA/runNumber', dtype=np.uint32, data=[1])
+        h5file['METADATA/runType'] = [b'Test DAQ']
+        h5file['METADATA/sample'] = [b'No Sample']
+        print(osp.basename(h5file.filename))
+        # get sequence number
+        fname_pattern = r'^(RAW|CORR)\-R\d+\-.*\-S(\d+).h5$'
+        match = re.match(fname_pattern, osp.basename(h5file.filename))
+        sequence = int(match.groups()[1]) if match is not None else 0
+        h5file.create_dataset('METADATA/sequenceNumber', dtype=np.uint32, data=[sequence])
+        h5file['METADATA/updateDate'] = [now.encode('ascii')]
 
-def write_train_ids(f, path, N, first=10000, chunksize=16):
-    """Make a dataset of fake train IDs at the given path
+
+def write_base_index(f, N, first=10000, chunksize=16, format_version='0.5'):
+    """Make base datasets in the files index
+
+    3 dataset are created: flag, timestamp, trainId
 
     Real train IDs are much larger (~10^9), so hopefully these won't be mistaken
     for real ones.
@@ -153,5 +176,18 @@ def write_train_ids(f, path, N, first=10000, chunksize=16):
         Npad = N + chunksize - (N % chunksize)
     else:
         Npad = N
-    ds = f.create_dataset(path, (Npad,), 'u8', maxshape=(None,))
+
+    if format_version != '0.5':
+        # flag
+        ds = f.create_dataset('INDEX/flag', (Npad,), 'u4', maxshape=(None,))
+        ds[:N] = np.ones(N)
+
+        # timestamps
+        ds = f.create_dataset('INDEX/timestamp', (Npad,), 'u8', maxshape=(None,))
+        # timestamps are stored as a single uint64 with nanoseconds resolution
+        ts = datetime.utcnow().timestamp() * 10**9
+        ds[:N] = [ts + i * 10**8 for i in range(N)]
+
+    # trainIds
+    ds = f.create_dataset('INDEX/trainId', (Npad,), 'u8', maxshape=(None,))
     ds[:N] = np.arange(first, first + N)

--- a/extra_data/tests/mockdata/base.py
+++ b/extra_data/tests/mockdata/base.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 import os.path as osp
 import re
 
@@ -147,11 +147,15 @@ def write_metadata(h5file, data_sources, chunksize=16, format_version='0.5'):
 
     if format_version != '0.5':
         h5file['METADATA/dataFormatVersion'] = [format_version.encode('ascii')]
-        now = datetime.utcnow().replace(microsecond=0).strftime('%Y%m%dT%H%M%SZ')
-        h5file['METADATA/creationDate'] = [now.encode('ascii')]
+        now = datetime.utcnow().replace(microsecond=0)
+        updated_time = now + timedelta(minutes=5)
+        h5file['METADATA/creationDate'] = [
+            now.strftime('%Y%m%dT%H%M%SZ').encode('ascii')
+        ]
         h5file['METADATA/daqLibrary'] = [b'1.9.0']
         h5file['METADATA/karaboFramework'] = [b'2.7.0']
-        h5file.create_dataset('METADATA/proposalNumber', dtype=np.uint32, data=[700000])
+        h5file.create_dataset('METADATA/proposalNumber', dtype=np.uint32,
+                              data=[700000])
         h5file.create_dataset('METADATA/runNumber', dtype=np.uint32, data=[1])
         h5file['METADATA/runType'] = [b'Test DAQ']
         h5file['METADATA/sample'] = [b'No Sample']
@@ -159,9 +163,12 @@ def write_metadata(h5file, data_sources, chunksize=16, format_version='0.5'):
         # get sequence number
         fname_pattern = r'^(RAW|CORR)\-R\d+\-.*\-S(\d+).h5$'
         match = re.match(fname_pattern, osp.basename(h5file.filename))
-        sequence = int(match.groups()[1]) if match is not None else 0
-        h5file.create_dataset('METADATA/sequenceNumber', dtype=np.uint32, data=[sequence])
-        h5file['METADATA/updateDate'] = [now.encode('ascii')]
+        sequence = int(match[1]) if match is not None else 0
+        h5file.create_dataset('METADATA/sequenceNumber', dtype=np.uint32,
+                              data=[sequence])
+        h5file['METADATA/updateDate'] = [
+            updated_time.strftime('%Y%m%dT%H%M%SZ').encode('ascii')
+        ]
 
 
 def write_base_index(f, N, first=10000, chunksize=16, format_version='0.5'):

--- a/extra_data/tests/mockdata/base.py
+++ b/extra_data/tests/mockdata/base.py
@@ -159,7 +159,6 @@ def write_metadata(h5file, data_sources, chunksize=16, format_version='0.5'):
         h5file.create_dataset('METADATA/runNumber', dtype=np.uint32, data=[1])
         h5file['METADATA/runType'] = [b'Test DAQ']
         h5file['METADATA/sample'] = [b'No Sample']
-        print(osp.basename(h5file.filename))
         # get sequence number
         fname_pattern = r'^(RAW|CORR)\-R\d+\-.*\-S(\d+).h5$'
         match = re.match(fname_pattern, osp.basename(h5file.filename))

--- a/extra_data/tests/mockdata/mkfile.py
+++ b/extra_data/tests/mockdata/mkfile.py
@@ -1,13 +1,13 @@
 import h5py
-from .base import write_train_ids, write_metadata
+from .base import write_base_index, write_metadata
 
 def write_file(filename, devices, ntrains, firsttrain=10000, chunksize=200,
                format_version='0.5'):
     f = h5py.File(filename, 'w')
     f.create_group('RUN')  # Add this, even if it's left empty
 
-    write_train_ids(f, 'INDEX/trainId', ntrains, first=firsttrain,
-                    chunksize=chunksize)
+    write_base_index(f, ntrains, first=firsttrain, chunksize=chunksize,
+                     format_version=format_version)
 
     data_sources = []
     for dev in devices:

--- a/extra_data/tests/test_reader_mockdata.py
+++ b/extra_data/tests/test_reader_mockdata.py
@@ -603,18 +603,15 @@ def test_open_run(mock_spb_raw_run, mock_spb_proc_run, tmpdir):
             open_run(proposal=2012, run=999)
 
 
-def test_open_file_format_0_5(mock_sa3_control_data):
+def test_open_file(mock_sa3_control_data):
     f = H5File(mock_sa3_control_data)
     file_access = f.files[0]
-    assert file_access.format_version == '0.5'
+    assert file_access.format_version in ('0.5', '1.0')
     assert 'SA3_XTD10_VAC/TSENS/S30180K' in f.control_sources
-
-
-def test_open_file_format_1_0(mock_sa3_control_data_fmt_1_0):
-    f = H5File(mock_sa3_control_data_fmt_1_0)
-    file_access = f.files[0]
-    assert file_access.format_version == '1.0'
-    assert 'SA3_XTD10_VAC/TSENS/S30180K' in f.control_sources
+    if file_access.format_version == '0.5':
+        assert 'METADATA/dataSourceId' in file_access.file
+    else:
+        assert 'METADATA/dataSources/dataSourceId' in file_access.file
 
 
 def test_permission():


### PR DESCRIPTION
- `mockdata` generates files closer to the real files (for version 1.0)
- run test on both format version (0.5, 1.0)

(spinoff from #39)