### PR TITLE
Add function to identify MPx detectors in data

### DIFF
--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -764,6 +764,8 @@ def identify_multimod_detectors(
     If ``single=True``, this returns a tuple of (detector_name, access_class),
     throwing ``ValueError`` if there isn't exactly 1 detector found.
     If ``single=False``, it returns a set of these tuples.
+
+    *clses* may be a list of acceptable detector classes to check.
     """
     if clses is None:
         clses = [AGIPD1M, DSSC1M, LPD1M]

--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -752,7 +752,9 @@ class LPD1M(MPxDetectorBase):
     module_shape = (256, 256)
 
 
-def identify_multimod_detectors(data, detector_name=None, kind=None, single=False):
+def identify_multimod_detectors(
+        data, detector_name=None, *, single=False, clses=None
+):
     """Identify multi-module detectors in the data
 
     Various detectors record data in a similar format, and we often want to
@@ -763,11 +765,8 @@ def identify_multimod_detectors(data, detector_name=None, kind=None, single=Fals
     throwing ``ValueError`` if there isn't exactly 1 detector found.
     If ``single=False``, it returns a set of these tuples.
     """
-    clses = [AGIPD1M, DSSC1M, LPD1M]
-    if kind is not None:
-        cls = globals()[kind]
-        assert cls in clses, cls
-        clses = [cls]
+    if clses is None:
+        clses = [AGIPD1M, DSSC1M, LPD1M]
 
     res = set()
     for cls in clses:

--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -641,7 +641,7 @@ class LPD1M(MPxDetectorBase):
     module_shape = (256, 256)
 
 
-def identify_mpx_detectors(data, detector_name=None, kind=None, single=False):
+def identify_multimod_detectors(data, detector_name=None, kind=None, single=False):
     """Identify multi-module detectors in the data
 
     Various detectors record data in a similar format, and we often want to

--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -639,3 +639,41 @@ class LPD1M(MPxDetectorBase):
     """
     _source_re = re.compile(r'(?P<detname>(.+)_LPD1M(.*))/DET/(\d+)CH')
     module_shape = (256, 256)
+
+
+def identify_mpx_detectors(data, detector_name=None, kind=None, single=False):
+    """Identify multi-module detectors in the data
+
+    Various detectors record data in a similar format, and we often want to
+    process whichever detector was used in a run. This tries to identify the
+    detector, so a user doesn't have to specify it manually.
+
+    If ``single=True``, this returns a tuple of (detector_name, access_class),
+    throwing ``ValueError`` if there isn't exactly 1 detector found.
+    If ``single=False``, it returns a set of these tuples.
+    """
+    clses = [AGIPD1M, DSSC1M, LPD1M]
+    if kind is not None:
+        cls = globals()[kind]
+        assert cls in clses, cls
+        clses = [cls]
+
+    res = set()
+    for cls in clses:
+        for source in data.instrument_sources:
+            m = cls._source_re.match(source)
+            if m:
+                name = m.group('detname')
+                if (detector_name is None) or (name == detector_name):
+                    res.add((name, cls))
+
+    if single:
+        if len(res) < 1:
+            raise ValueError("No detector sources identified in the data")
+        elif len(res) > 1:
+            raise ValueError("Multiple detectors identified: {}".format(
+                ", ".join(name for (name, _) in res)
+            ))
+        return res.pop()
+
+    return res

--- a/extra_data/tests/test_components.py
+++ b/extra_data/tests/test_components.py
@@ -305,6 +305,6 @@ def test_identify_multimod_detectors_multi(mock_fxe_raw_run, mock_spb_raw_run):
     with pytest.raises(ValueError):
         identify_multimod_detectors(combined, single=True)
 
-    name, cls = identify_multimod_detectors(combined, kind='AGIPD1M', single=True)
+    name, cls = identify_multimod_detectors(combined, single=True, clses=[AGIPD1M])
     assert name == 'SPB_DET_AGIPD1M-1'
     assert cls is AGIPD1M

--- a/extra_data/tests/test_components.py
+++ b/extra_data/tests/test_components.py
@@ -6,7 +6,7 @@ import pytest
 from testpath import assert_isfile
 
 from extra_data.reader import RunDirectory, by_id, by_index
-from extra_data.components import AGIPD1M, LPD1M, identify_mpx_detectors
+from extra_data.components import AGIPD1M, LPD1M, identify_multimod_detectors
 
 
 def test_get_array(mock_fxe_raw_run):
@@ -259,27 +259,27 @@ def test_write_virtual_cxi_reduced_data(mock_reduced_spb_proc_run, tmpdir):
         assert ds.shape[1:] == (16, 512, 128)
 
 
-def test_identify_mpx_detectors(mock_fxe_raw_run):
+def test_identify_multimod_detectors(mock_fxe_raw_run):
     run = RunDirectory(mock_fxe_raw_run)
-    name, cls = identify_mpx_detectors(run, single=True)
+    name, cls = identify_multimod_detectors(run, single=True)
     assert name == 'FXE_DET_LPD1M-1'
     assert cls is LPD1M
 
-    dets = identify_mpx_detectors(run, single=False)
+    dets = identify_multimod_detectors(run, single=False)
     assert dets == {(name, cls)}
 
 
-def test_identify_mpx_detectors_multi(mock_fxe_raw_run, mock_spb_raw_run):
+def test_identify_multimod_detectors_multi(mock_fxe_raw_run, mock_spb_raw_run):
     fxe_run = RunDirectory(mock_fxe_raw_run)
     spb_run = RunDirectory(mock_spb_raw_run)
     combined = fxe_run.select('*LPD1M*').union(spb_run)
 
-    dets = identify_mpx_detectors(combined, single=False)
+    dets = identify_multimod_detectors(combined, single=False)
     assert dets == {('FXE_DET_LPD1M-1', LPD1M), ('SPB_DET_AGIPD1M-1', AGIPD1M)}
 
     with pytest.raises(ValueError):
-        identify_mpx_detectors(combined, single=True)
+        identify_multimod_detectors(combined, single=True)
 
-    name, cls = identify_mpx_detectors(combined, kind='AGIPD1M', single=True)
+    name, cls = identify_multimod_detectors(combined, kind='AGIPD1M', single=True)
     assert name == 'SPB_DET_AGIPD1M-1'
     assert cls is AGIPD1M

--- a/extra_data/tests/test_components.py
+++ b/extra_data/tests/test_components.py
@@ -6,7 +6,7 @@ import pytest
 from testpath import assert_isfile
 
 from extra_data.reader import RunDirectory, by_id, by_index
-from extra_data.components import AGIPD1M, LPD1M
+from extra_data.components import AGIPD1M, LPD1M, identify_mpx_detectors
 
 
 def test_get_array(mock_fxe_raw_run):
@@ -257,3 +257,29 @@ def test_write_virtual_cxi_reduced_data(mock_reduced_spb_proc_run, tmpdir):
         det_grp = f['entry_1/instrument_1/detector_1']
         ds = det_grp['data']
         assert ds.shape[1:] == (16, 512, 128)
+
+
+def test_identify_mpx_detectors(mock_fxe_raw_run):
+    run = RunDirectory(mock_fxe_raw_run)
+    name, cls = identify_mpx_detectors(run, single=True)
+    assert name == 'FXE_DET_LPD1M-1'
+    assert cls is LPD1M
+
+    dets = identify_mpx_detectors(run, single=False)
+    assert dets == {(name, cls)}
+
+
+def test_identify_mpx_detectors_multi(mock_fxe_raw_run, mock_spb_raw_run):
+    fxe_run = RunDirectory(mock_fxe_raw_run)
+    spb_run = RunDirectory(mock_spb_raw_run)
+    combined = fxe_run.select('*LPD1M*').union(spb_run)
+
+    dets = identify_mpx_detectors(combined, single=False)
+    assert dets == {('FXE_DET_LPD1M-1', LPD1M), ('SPB_DET_AGIPD1M-1', AGIPD1M)}
+
+    with pytest.raises(ValueError):
+        identify_mpx_detectors(combined, single=True)
+
+    name, cls = identify_mpx_detectors(combined, kind='AGIPD1M', single=True)
+    assert name == 'SPB_DET_AGIPD1M-1'
+    assert cls is AGIPD1M


### PR DESCRIPTION
For things like creating virtual CXI files and appending detector modules for streaming (see #51), we want to work on whichever 'big detector' is present in the data. This aims to find that. I think @tmichela and @dallanto are likely to be interested.

What should it do when multiple detectors are found, but the tool only expects one? In this implementation, if you specify `single=True`, it will throw an error telling you about the detectors it found. You can specify e.g. `detector_name='FXE_DET_LPD1M-1'` or `kind='LPD1M'` to narrow down what it finds. I generally like this principle of refusing to guess, but it doesn mean that working code may break later if we add support for a new detector type.

Closes gh-41