### PR TITLE
Create Dask arrays with DatasetProxy objects

### DIFF
--- a/docs/dask_averaging.ipynb
+++ b/docs/dask_averaging.ipynb
@@ -40,7 +40,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e4e115d0e0db4cd3bbf59a8e1e5556b5",
+       "model_id": "039219ffa3c54a9e8a8fb32e40f6c563",
        "version_major": 2,
        "version_minor": 0
       },
@@ -58,6 +58,8 @@
     "\n",
     "cluster = SLURMCluster(\n",
     "    queue=partition,\n",
+    "    local_directory='/scratch',  # Local disk space for workers to use\n",
+    "    \n",
     "    # Resources per SLURM job (per node, the way SLURM is configured on Maxwell)\n",
     "    # processes=16 runs 16 Dask workers in a job, so each worker has 1 core & 32 GB RAM.\n",
     "    processes=16, cores=16, memory='512GB',\n",
@@ -124,7 +126,7 @@
      "output_type": "stream",
      "text": [
       "# of trains:    3392\n",
-      "Duration:       0:05:39.100000\n",
+      "Duration:       0:05:39.2\n",
       "First train ID: 79726751\n",
       "Last train ID:  79730142\n",
       "\n",
@@ -138,7 +140,7 @@
       "  - SPB_IRU_SIDEMIC_CAM:daqOutput\n",
       "  - SPB_XTD9_XGM/XGM/DOOCS:output\n",
       "\n",
-      "13 control sources:\n",
+      "13 control sources: (1 entry per train)\n",
       "  - ACC_SYS_DOOCS/CTRL/BEAMCONDITIONS\n",
       "  - SA1_XTD2_XGM/XGM/DOOCS\n",
       "  - SPB_IRU_AGIPD1M/PSC/HV\n",
@@ -279,7 +281,7 @@
        "</table>"
       ],
       "text/plain": [
-       "dask.array<concatenate, shape=(191872, 2, 512, 128), dtype=uint16, chunksize=(8192, 2, 512, 128)>"
+       "dask.array<concatenate, shape=(191872, 2, 512, 128), dtype=uint16, chunksize=(8192, 2, 512, 128), chunktype=numpy.ndarray>"
       ]
      },
      "execution_count": 6,
@@ -334,22 +336,22 @@
     {
      "data": {
       "text/plain": [
-       "[dask.array<mean_agg-aggregate, shape=(64, 512, 128), dtype=float32, chunksize=(64, 512, 128)>,\n",
-       " dask.array<mean_agg-aggregate, shape=(64, 512, 128), dtype=float32, chunksize=(64, 512, 128)>,\n",
-       " dask.array<mean_agg-aggregate, shape=(64, 512, 128), dtype=float32, chunksize=(64, 512, 128)>,\n",
-       " dask.array<mean_agg-aggregate, shape=(64, 512, 128), dtype=float32, chunksize=(64, 512, 128)>,\n",
-       " dask.array<mean_agg-aggregate, shape=(64, 512, 128), dtype=float32, chunksize=(64, 512, 128)>,\n",
-       " dask.array<mean_agg-aggregate, shape=(64, 512, 128), dtype=float32, chunksize=(64, 512, 128)>,\n",
-       " dask.array<mean_agg-aggregate, shape=(64, 512, 128), dtype=float32, chunksize=(64, 512, 128)>,\n",
-       " dask.array<mean_agg-aggregate, shape=(64, 512, 128), dtype=float32, chunksize=(64, 512, 128)>,\n",
-       " dask.array<mean_agg-aggregate, shape=(64, 512, 128), dtype=float32, chunksize=(64, 512, 128)>,\n",
-       " dask.array<mean_agg-aggregate, shape=(64, 512, 128), dtype=float32, chunksize=(64, 512, 128)>,\n",
-       " dask.array<mean_agg-aggregate, shape=(64, 512, 128), dtype=float32, chunksize=(64, 512, 128)>,\n",
-       " dask.array<mean_agg-aggregate, shape=(64, 512, 128), dtype=float32, chunksize=(64, 512, 128)>,\n",
-       " dask.array<mean_agg-aggregate, shape=(64, 512, 128), dtype=float32, chunksize=(64, 512, 128)>,\n",
-       " dask.array<mean_agg-aggregate, shape=(64, 512, 128), dtype=float32, chunksize=(64, 512, 128)>,\n",
-       " dask.array<mean_agg-aggregate, shape=(64, 512, 128), dtype=float32, chunksize=(64, 512, 128)>,\n",
-       " dask.array<mean_agg-aggregate, shape=(64, 512, 128), dtype=float32, chunksize=(64, 512, 128)>]"
+       "[dask.array<mean_agg-aggregate, shape=(64, 512, 128), dtype=float32, chunksize=(64, 512, 128), chunktype=numpy.ndarray>,\n",
+       " dask.array<mean_agg-aggregate, shape=(64, 512, 128), dtype=float32, chunksize=(64, 512, 128), chunktype=numpy.ndarray>,\n",
+       " dask.array<mean_agg-aggregate, shape=(64, 512, 128), dtype=float32, chunksize=(64, 512, 128), chunktype=numpy.ndarray>,\n",
+       " dask.array<mean_agg-aggregate, shape=(64, 512, 128), dtype=float32, chunksize=(64, 512, 128), chunktype=numpy.ndarray>,\n",
+       " dask.array<mean_agg-aggregate, shape=(64, 512, 128), dtype=float32, chunksize=(64, 512, 128), chunktype=numpy.ndarray>,\n",
+       " dask.array<mean_agg-aggregate, shape=(64, 512, 128), dtype=float32, chunksize=(64, 512, 128), chunktype=numpy.ndarray>,\n",
+       " dask.array<mean_agg-aggregate, shape=(64, 512, 128), dtype=float32, chunksize=(64, 512, 128), chunktype=numpy.ndarray>,\n",
+       " dask.array<mean_agg-aggregate, shape=(64, 512, 128), dtype=float32, chunksize=(64, 512, 128), chunktype=numpy.ndarray>,\n",
+       " dask.array<mean_agg-aggregate, shape=(64, 512, 128), dtype=float32, chunksize=(64, 512, 128), chunktype=numpy.ndarray>,\n",
+       " dask.array<mean_agg-aggregate, shape=(64, 512, 128), dtype=float32, chunksize=(64, 512, 128), chunktype=numpy.ndarray>,\n",
+       " dask.array<mean_agg-aggregate, shape=(64, 512, 128), dtype=float32, chunksize=(64, 512, 128), chunktype=numpy.ndarray>,\n",
+       " dask.array<mean_agg-aggregate, shape=(64, 512, 128), dtype=float32, chunksize=(64, 512, 128), chunktype=numpy.ndarray>,\n",
+       " dask.array<mean_agg-aggregate, shape=(64, 512, 128), dtype=float32, chunksize=(64, 512, 128), chunktype=numpy.ndarray>,\n",
+       " dask.array<mean_agg-aggregate, shape=(64, 512, 128), dtype=float32, chunksize=(64, 512, 128), chunktype=numpy.ndarray>,\n",
+       " dask.array<mean_agg-aggregate, shape=(64, 512, 128), dtype=float32, chunksize=(64, 512, 128), chunktype=numpy.ndarray>,\n",
+       " dask.array<mean_agg-aggregate, shape=(64, 512, 128), dtype=float32, chunksize=(64, 512, 128), chunktype=numpy.ndarray>]"
       ]
      },
      "execution_count": 8,
@@ -466,7 +468,7 @@
        "</table>"
       ],
       "text/plain": [
-       "dask.array<stack, shape=(16, 64, 512, 128), dtype=float32, chunksize=(1, 64, 512, 128)>"
+       "dask.array<stack, shape=(16, 64, 512, 128), dtype=float32, chunksize=(1, 64, 512, 128), chunktype=numpy.ndarray>"
       ]
      },
      "execution_count": 9,
@@ -499,8 +501,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 16.2 s, sys: 1.24 s, total: 17.4 s\n",
-      "Wall time: 1min 37s\n"
+      "CPU times: user 29.5 s, sys: 1.99 s, total: 31.4 s\n",
+      "Wall time: 1min 50s\n"
      ]
     }
    ],

--- a/extra_data/read_machinery.py
+++ b/extra_data/read_machinery.py
@@ -103,7 +103,7 @@ class DataChunk:
         return slice(self.first, self.first + np.sum(self.counts))
 
     @property
-    def dataset(self):
+    def dataset_path(self):
         if self.source in self.file.instrument_sources:
             group = 'INSTRUMENT'
         elif self.source in self.file.control_sources:
@@ -111,9 +111,11 @@ class DataChunk:
         else:
             raise SourceNameError(self.source)
 
-        return self.file.file[
-            '/{}/{}/{}'.format(group, self.source, self.key.replace('.', '/'))
-        ]
+        return '/{}/{}/{}'.format(group, self.source, self.key.replace('.', '/'))
+
+    @property
+    def dataset(self):
+        return self.file.file[self.dataset_path]
 
 
 # contiguous_regions() by Joe Kington on Stackoverflow

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -674,7 +674,9 @@ class DataCollection:
                 chunk_shape = (chunk_dim0,) + chunk.dataset.shape[1:]
 
             chunks_darrs.append(
-                da.from_array(chunk.dataset, chunks=chunk_shape)[chunk.slice]
+                da.from_array(
+                    chunk.file.dset_proxy(chunk.dataset_path), chunks=chunk_shape
+                )[chunk.slice]
             )
             chunks_trainids.append(
                 self._expand_trainids(chunk.counts, chunk.train_ids)


### PR DESCRIPTION
Avoid storing or trying to pickle an h5py Dataset object. cc @philsmt - this does appear to fix the pickling errors for me.

Closes gh-57