### PR TITLE
Root test fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ data
 /dist/
 /docs/_build/
 .ipynb_checkpoints/
+.venv/

--- a/extra_data/tests/test_reader_mockdata.py
+++ b/extra_data/tests/test_reader_mockdata.py
@@ -615,6 +615,11 @@ def test_open_file(mock_sa3_control_data):
 
 
 def test_permission():
+    #  If users is root then `PermissionError` won't be raised, so set the euid
+    #  to standard user so the tests work correctly
+    if os.geteuid() == 0:
+        os.seteuid(1000)
+
     d = mkdtemp()
     os.chmod(d, not stat.S_IRUSR)
     with pytest.raises(PermissionError) as excinfo:

--- a/extra_data/tests/test_reader_mockdata.py
+++ b/extra_data/tests/test_reader_mockdata.py
@@ -617,9 +617,11 @@ def test_open_file(mock_sa3_control_data):
 def test_permission():
     #  If users is root then `PermissionError` won't be raised, set the euid to
     #  standard user so the tests work correctly
-    original_euid = os.geteuid()
-    if original_euid == 0:
-        os.seteuid(1000)
+    euid_was_root = False
+    if hasattr(os, 'seteuid'):
+        if os.geteuid() == 0:
+            os.seteuid(1000)
+            euid_was_root = True
 
     d = mkdtemp()
     os.chmod(d, not stat.S_IRUSR)
@@ -628,8 +630,8 @@ def test_permission():
     assert "Permission denied" in str(excinfo.value)
     assert d in str(excinfo.value)
 
-    if original_euid != os.geteuid():
-        os.seteuid(original_euid)
+    if euid_was_root:
+        os.seteuid(0)
 
 
 def test_empty_file_info(mock_empty_file, capsys):

--- a/extra_data/tests/test_reader_mockdata.py
+++ b/extra_data/tests/test_reader_mockdata.py
@@ -615,9 +615,10 @@ def test_open_file(mock_sa3_control_data):
 
 
 def test_permission():
-    #  If users is root then `PermissionError` won't be raised, so set the euid
-    #  to standard user so the tests work correctly
-    if os.geteuid() == 0:
+    #  If users is root then `PermissionError` won't be raised, set the euid to
+    #  standard user so the tests work correctly
+    original_euid = os.geteuid()
+    if original_euid == 0:
         os.seteuid(1000)
 
     d = mkdtemp()
@@ -626,6 +627,9 @@ def test_permission():
         run = RunDirectory(d)
     assert "Permission denied" in str(excinfo.value)
     assert d in str(excinfo.value)
+
+    if original_euid != os.geteuid():
+        os.seteuid(original_euid)
 
 
 def test_empty_file_info(mock_empty_file, capsys):

--- a/extra_data/tests/test_reader_mockdata.py
+++ b/extra_data/tests/test_reader_mockdata.py
@@ -614,12 +614,9 @@ def test_open_file(mock_sa3_control_data):
         assert 'METADATA/dataSources/dataSourceId' in file_access.file
 
 
+@pytest.mark.skipif(hasattr(os, 'geteuid') and os.geteuid() == 0,
+                    reason="cannot run permission tests as root")
 def test_permission():
-    #  If users is root then `PermissionError` won't be raised, set the euid to
-    #  standard user so the tests work correctly
-    if hasattr(os, 'geteuid') and os.geteuid() == 0:
-        pytest.skip("cannot run permission tests as root")
-
     d = mkdtemp()
     os.chmod(d, not stat.S_IRUSR)
     with pytest.raises(PermissionError) as excinfo:

--- a/extra_data/tests/test_reader_mockdata.py
+++ b/extra_data/tests/test_reader_mockdata.py
@@ -617,11 +617,8 @@ def test_open_file(mock_sa3_control_data):
 def test_permission():
     #  If users is root then `PermissionError` won't be raised, set the euid to
     #  standard user so the tests work correctly
-    euid_was_root = False
-    if hasattr(os, 'seteuid'):
-        if os.geteuid() == 0:
-            os.seteuid(1000)
-            euid_was_root = True
+    if hasattr(os, 'geteuid') and os.geteuid() == 0:
+        pytest.skip("cannot run permission tests as root")
 
     d = mkdtemp()
     os.chmod(d, not stat.S_IRUSR)
@@ -629,9 +626,6 @@ def test_permission():
         run = RunDirectory(d)
     assert "Permission denied" in str(excinfo.value)
     assert d in str(excinfo.value)
-
-    if euid_was_root:
-        os.seteuid(0)
 
 
 def test_empty_file_info(mock_empty_file, capsys):


### PR DESCRIPTION
Minor change to the `test_permission` test. Checks if user is root, and if it is then euid is set to 1000 for the test and reverted back at the end.

Could we make a patch release to 1.2.1 for this test so that I can include the fix in my spack package?