### PR TITLE
Allow slicing without by_index wrapper

### DIFF
--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -44,7 +44,7 @@ def _guess_axes(data, train_pulse_ids):
 def _check_pulse_selection(pulses):
     """Check and normalise a pulse selection"""
     if not isinstance(pulses, (by_id, by_index)):
-        raise TypeError("pulses selection should be by_id or by_index object")
+        pulses = by_index[pulses]
 
     val = pulses.value
 
@@ -316,7 +316,7 @@ class MPxDetectorBase:
             sorted(non_empty, key=lambda a: a.coords['train'][0]), dim='train'
         )
 
-    def get_array(self, key, pulses=by_index[:]):
+    def get_array(self, key, pulses=np.s_[:]):
         """Get a labelled array of detector data
 
         Parameters
@@ -324,7 +324,7 @@ class MPxDetectorBase:
 
         key: str
           The data to get, e.g. 'image.data' for pixel values.
-        pulses: by_id or by_index
+        pulses: slice, array, by_id or by_index
           Select the pulses to include from each train. by_id selects by pulse
           ID, by_index by index within the data being read. The default includes
           all pulses. Only used for per-train data.
@@ -391,13 +391,13 @@ class MPxDetectorBase:
 
         return xarray.concat(arrays, pd.Index(modnos, name='module'))
 
-    def trains(self, pulses=by_index[:]):
+    def trains(self, pulses=np.s_[:]):
         """Iterate over trains for detector data.
 
         Parameters
         ----------
 
-        pulses: by_index or by_id
+        pulses: slice, array, by_index or by_id
           Select which pulses to include for each train.
           The default is to include all pulses.
 

--- a/extra_data/tests/test_components.py
+++ b/extra_data/tests/test_components.py
@@ -97,12 +97,14 @@ def test_get_array_pulse_indexes_reduced_data(mock_reduced_spb_proc_run):
     arr = det.get_array('image.data', pulses=by_index[:0])
     assert arr.shape == (16, 0, 0, 512, 128)
 
-    arr = det.get_array('image.data', pulses=by_index[5:])
+    arr = det.get_array('image.data', pulses=np.s_[5:])
     assert (arr.coords['pulse'] >= 5).all()
 
     arr = det.get_array('image.data', pulses=by_index[[1, 7, 15, 23]])
     assert np.isin(arr.coords['pulse'], [1, 7, 15, 23]).all()
 
+    arr = det.get_array('image.data', pulses=[1, 7, 15, 23])
+    assert np.isin(arr.coords['pulse'], [1, 7, 15, 23]).all()
 
 def test_get_dask_array(mock_fxe_raw_run):
     run = RunDirectory(mock_fxe_raw_run)

--- a/extra_data/tests/test_reader_mockdata.py
+++ b/extra_data/tests/test_reader_mockdata.py
@@ -392,9 +392,9 @@ def test_run_get_array_roi(mock_fxe_raw_run):
 
 def test_run_get_array_multiple_per_train(mock_fxe_raw_run):
     run = RunDirectory(mock_fxe_raw_run)
-    sel = run.select_trains(by_index[:2])
+    sel = run.select_trains(np.s_[:2])
     arr = sel.get_array(
-        'FXE_DET_LPD1M-1/DET/6CH0:xtdf', 'image.data', roi=by_index[:, 10:20, 20:40]
+        'FXE_DET_LPD1M-1/DET/6CH0:xtdf', 'image.data', roi=np.s_[:, 10:20, 20:40]
     )
     assert isinstance(arr, DataArray)
     assert arr.shape == (256, 1, 10, 20)


### PR DESCRIPTION
Following discussion with @philsmt, I think we can make common slicing operations more convenient by allowing slice objects (easily made with [`np.s_`](https://numpy.org/doc/stable/reference/generated/numpy.s_.html)) or arrays where we previously required `by_index` objects.

This applies to:

- `run.select_trains()`
- `run.get_array()` (*roi* parameter)
- Various methods on big detector access classes to select ranges of pulses.