### PR TITLE
Add KeyData interface

### DIFF
--- a/extra_data/file_access.py
+++ b/extra_data/file_access.py
@@ -297,7 +297,7 @@ class FileAccess:
         else:
             raise SourceNameError(source)
 
-        if path in self.file:
+        if self.file.get(path, getclass=True) is h5py.Dataset:
             self._known_keys[source].add(key)
             return True
         return False

--- a/extra_data/keydata.py
+++ b/extra_data/keydata.py
@@ -20,7 +20,6 @@ class KeyData:
         Yields DataChunk objects.
         """
         for file in self.files:
-            file_has_data = False
             firsts, counts = file.get_index(self.source, self._key_group)
 
             # Of trains in this file, which are in selection
@@ -28,19 +27,10 @@ class KeyData:
 
             # Assemble contiguous chunks of data from this file
             for _from, _to in contiguous_regions(selected):
-                file_has_data = True
                 yield DataChunk(file, self.source, self.key,
                                 first=firsts[_from],
                                 train_ids=file.train_ids[_from:_to],
                                 counts=counts[_from:_to],
-                                )
-
-            if not file_has_data:
-                # Make an empty chunk to let e.g. get_array find the shape
-                yield DataChunk(file, self.source, self.key,
-                                first=np.uint64(0),
-                                train_ids=file.train_ids[:0],
-                                counts=counts[:0],
                                 )
 
     @property

--- a/extra_data/keydata.py
+++ b/extra_data/keydata.py
@@ -1,0 +1,153 @@
+import numpy as np
+
+class KeyData:
+    def __init__(self, source, key, data_chunks, section):
+        self.source = source
+        self.key = key
+        self.section = section
+
+        dim0 = 0
+        entry_shapes, dtypes = set(), set()
+        for chunk in data_chunks:
+            dim0 += chunk.total_count
+            entry_shapes.add(chunk.dataset.shape[1:])
+            dtypes.add(chunk.dataset.dtype)
+
+        if len(entry_shapes) > 1:
+            raise Exception("Mismatched data shapes: {}".format(entry_shapes))
+        if len(dtypes) > 1:
+            raise Exception("Mismatched dtypes: {}".format(dtypes))
+
+        self.dtype = dtypes.pop()
+        self.entry_shape = entry_shapes.pop()
+        self.shape = (dim0,) + self.entry_shape
+        self.ndim = len(self.shape)
+        # Sort chunks by train ID and discard any empty ones
+        self._data_chunks = sorted(
+            [c for c in data_chunks if c.total_count > 0],
+            key=lambda c: c.train_ids[0]
+        )
+        if self._data_chunks:
+            self.train_ids = np.concatenate([c.train_ids for c in self._data_chunks])
+        else:
+            self.train_ids = np.zeros(shape=(0,), dtype=np.uint64)
+
+    def __repr__(self):
+        return f"<extra_data.KeyData source={self.source!r} key={self.key!r} " \
+               f"for {len(self.train_ids)} trains"
+
+    @property
+    def _key_group(self):
+        """The part of the key needed to look up index data"""
+        if self.section == 'INSTRUMENT':
+            return self.key.partition('.')[0]
+        else:
+            return ''
+
+    @property
+    def _data_path(self):
+        return f"/{self.section}/{self.source}/{self.key.replace('.', '/')}"
+
+    def ndarray(self, roi=()):
+        if not isinstance(roi, tuple):
+            roi = (roi,)
+
+        # Find the shape of the array with the ROI applied
+        roi_dummy = np.zeros((0,) + self.entry_shape) # extra 0 dim: use less memory
+        roi_shape = roi_dummy[np.index_exp[:] + roi].shape[1:]
+
+        out = np.empty(self.shape[:1] + roi_shape, dtype=self.dtype)
+
+        # Read the data from each chunk into the result array
+        dest_cursor = 0
+        for chunk in self._data_chunks:
+            dest_chunk_end = dest_cursor + chunk.total_count
+
+            slices = (chunk.slice,) + roi
+            chunk.dataset.read_direct(
+                out[dest_cursor:dest_chunk_end], source_sel=slices
+            )
+            dest_cursor = dest_chunk_end
+
+        return out
+
+    def _trainid_index(self):
+        """A 1D array of train IDs, corresponding to self.shape[0]"""
+        chunks_trainids = [
+            np.repeat(chunk.train_ids, chunk.counts.astype(np.intp))
+            for chunk in self._data_chunks
+        ]
+        return np.concatenate(chunks_trainids)
+
+    def xarray(self, extra_dims=None, roi=()):
+        import xarray
+
+        ndarr = self.ndarray(roi=roi)
+
+        # Dimension labels
+        if extra_dims is None:
+            extra_dims = ['dim_%d' % i for i in range(ndarr.ndim - 1)]
+        dims = ['trainId'] + extra_dims
+
+        # Train ID index
+        coords = {}
+        if self.shape[0]:
+            coords = {'trainId': self._trainid_index()}
+
+        return xarray.DataArray(ndarr, dims=dims, coords=coords)
+
+    def series(self):
+        import pandas as pd
+
+        if self.ndim > 1:
+            raise TypeError("pandas Series are only available for 1D data")
+
+        name = self.source + '/' + self.key
+        if name.endswith('.value'):
+            name = name[:-6]
+
+        index = pd.Index(self._trainid_index(), name='trainId')
+        data = self.ndarray()
+        return pd.Series(data, name=name, index=index)
+
+    def dask_array(self, labelled=False):
+        import dask.array as da
+
+        chunks_darrs = []
+
+        for chunk in self._data_chunks:
+            chunk_dim0 = chunk.total_count
+            chunk_shape = (chunk_dim0,) + chunk.dataset.shape[1:]
+            itemsize = chunk.dataset.dtype.itemsize
+
+            # Find chunk size of maximum 2 GB. This is largely arbitrary:
+            # we want chunks small enough that each worker can have at least
+            # a couple in memory (Maxwell nodes have 256-768 GB in late 2019).
+            # But bigger chunks means less overhead.
+            # Empirically, making chunks 4 times bigger/smaller didn't seem to
+            # affect speed dramatically - but this could depend on many factors.
+            # TODO: optional user control of chunking
+            limit = 2 * 1024 ** 3
+            while np.product(chunk_shape) * itemsize > limit and chunk_dim0 > 1:
+                chunk_dim0 //= 2
+                chunk_shape = (chunk_dim0,) + chunk.dataset.shape[1:]
+
+            chunks_darrs.append(
+                da.from_array(
+                    chunk.file.dset_proxy(chunk.dataset_path), chunks=chunk_shape
+                )[chunk.slice]
+            )
+
+        dask_arr = da.concatenate(chunks_darrs, axis=0)
+
+        if labelled:
+            # Dimension labels
+            dims = ['trainId'] + ['dim_%d' % i for i in range(dask_arr.ndim - 1)]
+
+            # Train ID index
+            coords = {'trainId': self._trainid_index()}
+
+            import xarray
+            return xarray.DataArray(dask_arr, dims=dims, coords=coords)
+        else:
+            return dask_arr

--- a/extra_data/keydata.py
+++ b/extra_data/keydata.py
@@ -82,6 +82,9 @@ class KeyData:
             eshape=self.entry_shape,
         )
 
+    def __getitem__(self, item):
+        return self.select_trains(item)
+
     # Getting data as different kinds of array: -------------------------------
 
     def ndarray(self, roi=()):

--- a/extra_data/keydata.py
+++ b/extra_data/keydata.py
@@ -28,7 +28,7 @@ class KeyData:
             # Assemble contiguous chunks of data from this file
             for _from, _to in contiguous_regions(selected):
                 yield DataChunk(
-                    file, self._data_path,
+                    file, self.hdf5_data_path,
                     first=firsts[_from],
                     train_ids=file.train_ids[_from:_to],
                     counts=counts[_from:_to],
@@ -59,7 +59,8 @@ class KeyData:
             return ''
 
     @property
-    def _data_path(self):
+    def hdf5_data_path(self):
+        """The path to the relevant dataset within each HDF5 file"""
         return f"/{self.section}/{self.source}/{self.key.replace('.', '/')}"
 
     @property
@@ -208,9 +209,9 @@ class KeyData:
         firsts, counts = fa.get_index(self.source, self._key_group)
         first, count = firsts[ix], counts[ix]
         if count == 1:
-            return tid, fa.file[self._data_path][first]
+            return tid, fa.file[self.hdf5_data_path][first]
         else:
-            return tid, fa.file[self._data_path][first: first+count]
+            return tid, fa.file[self.hdf5_data_path][first: first+count]
 
     def train_from_index(self, i):
         return self.train_from_id(self.train_ids[i])

--- a/extra_data/keydata.py
+++ b/extra_data/keydata.py
@@ -86,9 +86,6 @@ class KeyData:
             dest_chunk_end = dest_cursor + chunk.total_count
 
             slices = (chunk.slice,) + roi
-            print("source sel", slices)
-            print("dest sel", dest_cursor, dest_chunk_end)
-            print("dest shape", out.shape)
             chunk.dataset.read_direct(
                 out[dest_cursor:dest_chunk_end], source_sel=slices
             )

--- a/extra_data/keydata.py
+++ b/extra_data/keydata.py
@@ -27,11 +27,12 @@ class KeyData:
 
             # Assemble contiguous chunks of data from this file
             for _from, _to in contiguous_regions(selected):
-                yield DataChunk(file, self.source, self.key,
-                                first=firsts[_from],
-                                train_ids=file.train_ids[_from:_to],
-                                counts=counts[_from:_to],
-                                )
+                yield DataChunk(
+                    file, self._data_path,
+                    first=firsts[_from],
+                    train_ids=file.train_ids[_from:_to],
+                    counts=counts[_from:_to],
+                )
 
     _cached_chunks = None
 

--- a/extra_data/read_machinery.py
+++ b/extra_data/read_machinery.py
@@ -103,6 +103,10 @@ class DataChunk:
         return slice(self.first, self.first + np.sum(self.counts))
 
     @property
+    def total_count(self):
+        return int(np.sum(self.counts, dtype=np.uint64))
+
+    @property
     def dataset_path(self):
         if self.source in self.file.instrument_sources:
             group = 'INSTRUMENT'

--- a/extra_data/read_machinery.py
+++ b/extra_data/read_machinery.py
@@ -125,11 +125,9 @@ def select_train_ids(train_ids, sel):
 
 class DataChunk:
     """Reference to a contiguous chunk of data for one or more trains."""
-
-    def __init__(self, file, source, key, first, train_ids, counts):
+    def __init__(self, file, dataset_path, first, train_ids, counts):
         self.file = file
-        self.source = source
-        self.key = key
+        self.dataset_path = dataset_path
         self.first = first
         self.train_ids = train_ids
         self.counts = counts
@@ -141,17 +139,6 @@ class DataChunk:
     @property
     def total_count(self):
         return int(np.sum(self.counts, dtype=np.uint64))
-
-    @property
-    def dataset_path(self):
-        if self.source in self.file.instrument_sources:
-            group = 'INSTRUMENT'
-        elif self.source in self.file.control_sources:
-            group = 'CONTROL'
-        else:
-            raise SourceNameError(self.source)
-
-        return '/{}/{}/{}'.format(group, self.source, self.key.replace('.', '/'))
 
     @property
     def dataset(self):

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -31,6 +31,7 @@ import time
 from warnings import warn
 
 from .exceptions import SourceNameError, PropertyNameError, TrainIDError
+from .keydata import KeyData
 from .read_machinery import (
     DETECTOR_SOURCE_RE,
     DataChunk,
@@ -225,6 +226,12 @@ class DataCollection:
 
     # Leave old name in case anything external was using it:
     _keys_for_source = keys_for_source
+
+    def _get_key_data(self, source, key):
+        self._check_field(source, key)
+        chunks = list(self._find_data_chunks(source, key))
+        section = 'INSTRUMENT' if source in self.instrument_sources else 'CONTROL'
+        return KeyData(source, key, data_chunks=chunks, section=section)
 
     def get_entry_shape(self, source, key):
         """Get the shape of a single data entry for the given source & key"""
@@ -558,69 +565,7 @@ class DataCollection:
             first 8 values from every train. If the data is 2D or more at
             each entry, selection looks like roi=np.s_[:8, 5:10] .
         """
-        import xarray
-
-        self._check_field(source, key)
-
-        if isinstance(roi, by_index):
-            roi = roi.value
-        if not isinstance(roi, tuple):
-            roi = (roi,)
-
-        chunks = sorted(
-            self._find_data_chunks(source, key),
-            key=lambda x: x.train_ids[0] if x.train_ids.size else 0,
-        )
-
-        # Figure out the shape of the result array, and the slice for each chunk
-        dest_dim0 = 0
-        dest_slices = []
-        shapes = set()
-        dtypes = set()
-
-        for chunk in chunks:
-            n = int(np.sum(chunk.counts, dtype=np.uint64))
-            dest_slices.append(slice(dest_dim0, dest_dim0 + n))
-            dest_dim0 += n
-            shapes.add(chunk.dataset.shape[1:])
-            dtypes.add(chunk.dataset.dtype)
-
-        if len(shapes) > 1:
-            raise Exception("Mismatched data shapes: {}".format(shapes))
-
-        if len(dtypes) > 1:
-            raise Exception("Mismatched dtypes: {}".format(dtypes))
-
-        # Find the shape of the array with the ROI applied
-        roi_dummy = np.zeros((0,) + shapes.pop()) # extra 0 dim: use less memory
-        roi_shape = roi_dummy[np.index_exp[:] + roi].shape[1:]
-
-        chunks_trainids = []
-        res = np.empty((dest_dim0,) + roi_shape, dtype=dtypes.pop())
-
-        # Read the data from each chunk into the result array
-        for chunk, dest_slice in zip(chunks, dest_slices):
-            if dest_slice.start == dest_slice.stop:
-                continue
-
-            chunks_trainids.append(
-                self._expand_trainids(chunk.counts, chunk.train_ids)
-            )
-
-            slices = (chunk.slice,) + roi
-            chunk.dataset.read_direct(res[dest_slice], source_sel=slices)
-
-        # Dimension labels
-        if extra_dims is None:
-            extra_dims = ['dim_%d' % i for i in range(res.ndim - 1)]
-        dims = ['trainId'] + extra_dims
-
-        # Train ID index
-        coords = {}
-        if dest_dim0:
-            coords = {'trainId': np.concatenate(chunks_trainids)}
-
-        return xarray.DataArray(res, dims=dims, coords=coords)
+        return self._get_key_data(source, key).xarray(extra_dims=extra_dims, roi=roi)
 
     def get_dask_array(self, source, key, labelled=False):
         """Get a Dask array for the specified data field.
@@ -646,54 +591,7 @@ class DataCollection:
             If True, label the train IDs for the data, returning an
             xarray.DataArray object wrapping a Dask array.
         """
-        import dask.array as da
-        chunks = sorted(
-            self._find_data_chunks(source, key),
-            key=lambda x: x.train_ids[0] if x.train_ids.size else 0,
-        )
-
-        chunks_darrs = []
-        chunks_trainids = []
-
-        for chunk in chunks:
-            chunk_dim0 = int(np.sum(chunk.counts))
-            chunk_shape = (chunk_dim0,) + chunk.dataset.shape[1:]
-            itemsize = chunk.dataset.dtype.itemsize
-
-            # Find chunk size of maximum 2 GB. This is largely arbitrary:
-            # we want chunks small enough that each worker can have at least
-            # a couple in memory (Maxwell nodes have 256-768 GB in late 2019).
-            # But bigger chunks means less overhead.
-            # Empirically, making chunks 4 times bigger/smaller didn't seem to
-            # affect speed dramatically - but this could depend on many factors.
-            # TODO: optional user control of chunking
-            limit = 2 * 1024 ** 3
-            while np.product(chunk_shape) * itemsize > limit and chunk_dim0 > 1:
-                chunk_dim0 //= 2
-                chunk_shape = (chunk_dim0,) + chunk.dataset.shape[1:]
-
-            chunks_darrs.append(
-                da.from_array(
-                    chunk.file.dset_proxy(chunk.dataset_path), chunks=chunk_shape
-                )[chunk.slice]
-            )
-            chunks_trainids.append(
-                self._expand_trainids(chunk.counts, chunk.train_ids)
-            )
-
-        dask_arr = da.concatenate(chunks_darrs, axis=0)
-
-        if labelled:
-            # Dimension labels
-            dims = ['trainId'] + ['dim_%d' % i for i in range(dask_arr.ndim - 1)]
-
-            # Train ID index
-            coords = {'trainId': np.concatenate(chunks_trainids)}
-
-            import xarray
-            return xarray.DataArray(dask_arr, dims=dims, coords=coords)
-        else:
-            return dask_arr
+        return self._get_key_data(source, key).dask_array(labelled=labelled)
 
     def union(self, *others):
         """Join the data in this collection with one or more others.

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -565,6 +565,9 @@ class DataCollection:
             first 8 values from every train. If the data is 2D or more at
             each entry, selection looks like roi=np.s_[:8, 5:10] .
         """
+        if isinstance(roi, by_index):
+            roi = roi.value
+
         return self._get_key_data(source, key).xarray(extra_dims=extra_dims, roi=roi)
 
     def get_dask_array(self, source, key, labelled=False):

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -233,6 +233,12 @@ class DataCollection:
         section = 'INSTRUMENT' if source in self.instrument_sources else 'CONTROL'
         return KeyData(source, key, data_chunks=chunks, section=section)
 
+    def __getitem__(self, item):
+        if isinstance(item, tuple) and len(item) == 2:
+            return self._get_key_data(*item)
+
+        raise TypeError("Expected data[source, key]")
+
     def get_entry_shape(self, source, key):
         """Get the shape of a single data entry for the given source & key"""
         self._check_field(source, key)

--- a/extra_data/tests/test_keydata.py
+++ b/extra_data/tests/test_keydata.py
@@ -1,0 +1,36 @@
+import numpy as np
+
+from extra_data import RunDirectory
+
+def test_get_keydata(mock_spb_raw_run):
+    run = RunDirectory(mock_spb_raw_run)
+    print(run.instrument_sources)
+    am0 = run['SPB_DET_AGIPD1M-1/DET/0CH0:xtdf', 'image.data']
+    assert len(am0.files) == 1
+    assert am0.section == 'INSTRUMENT'
+    assert am0.entry_shape == (2, 512, 128)
+    assert am0.ndim == 4
+    assert am0.dtype == np.dtype('u2')
+
+    xgm_beam_x = run['SPB_XTD9_XGM/DOOCS/MAIN', 'beamPosition.ixPos.value']
+    assert len(xgm_beam_x.files) == 2
+    assert xgm_beam_x.section == 'CONTROL'
+    assert xgm_beam_x.entry_shape == ()
+    assert xgm_beam_x.ndim == 1
+    assert xgm_beam_x.dtype == np.dtype('f4')
+
+def test_select_trains(mock_spb_raw_run):
+    run = RunDirectory(mock_spb_raw_run)
+    xgm_beam_x = run['SPB_XTD9_XGM/DOOCS/MAIN', 'beamPosition.ixPos.value']
+    assert xgm_beam_x.shape == (64,)
+
+    sel1 = xgm_beam_x.select_trains(np.s_[:20])
+    assert sel1.shape == (20,)
+    assert len(sel1.files) == 1
+
+    # Empty selection
+    sel2 = xgm_beam_x.select_trains(np.s_[80:])
+    assert sel2.shape == (0,)
+    assert len(sel2.files) == 0
+    assert sel2.xarray().shape == (0,)
+

--- a/extra_data/tests/test_keydata.py
+++ b/extra_data/tests/test_keydata.py
@@ -36,6 +36,25 @@ def test_select_trains(mock_spb_raw_run):
     assert len(sel2.files) == 0
     assert sel2.xarray().shape == (0,)
 
+
+def test_nodata(mock_fxe_raw_run):
+    run = RunDirectory(mock_fxe_raw_run)
+    cam_pix = run['FXE_XAD_GEC/CAM/CAMERA_NODATA:daqOutput', 'data.image.pixels']
+
+    assert cam_pix.train_ids == list(range(10000, 10480))
+    assert len(cam_pix.files) == 2
+    assert cam_pix.shape == (0, 255, 1024)
+
+    arr = cam_pix.xarray()
+    assert arr.shape == (0, 255, 1024)
+    assert arr.dtype == np.dtype('u2')
+
+    assert list(cam_pix.trains()) == []
+    tid, data = cam_pix.train_from_id(10010)
+    assert tid == 10010
+    assert data.shape == (0, 255, 1024)
+
+
 def test_iter_trains(mock_spb_raw_run):
     run = RunDirectory(mock_spb_raw_run)
     xgm_beam_x = run['SPB_XTD9_XGM/DOOCS/MAIN', 'beamPosition.ixPos.value']

--- a/extra_data/tests/test_keydata.py
+++ b/extra_data/tests/test_keydata.py
@@ -26,12 +26,12 @@ def test_select_trains(mock_spb_raw_run):
     xgm_beam_x = run['SPB_XTD9_XGM/DOOCS/MAIN', 'beamPosition.ixPos.value']
     assert xgm_beam_x.shape == (64,)
 
-    sel1 = xgm_beam_x.select_trains(np.s_[:20])
+    sel1 = xgm_beam_x[:20]  # Equivalent to .select_trains(np.s_[:20])
     assert sel1.shape == (20,)
     assert len(sel1.files) == 1
 
     # Empty selection
-    sel2 = xgm_beam_x.select_trains(np.s_[80:])
+    sel2 = xgm_beam_x[80:]
     assert sel2.shape == (0,)
     assert len(sel2.files) == 0
     assert sel2.xarray().shape == (0,)


### PR DESCRIPTION
As outlined in #55, this would allow for things like:

```python
# Current:
run.get_array("SA3_XTD10_PES/ADC/1:network", "digitizers.channel_4_A.raw.samples")
# Hypothetical:
run["SA3_XTD10_PES/ADC/1:network", "digitizers.channel_4_A.raw.samples"].xarray()
```

Questions:

- Should this also have a method like `.select_trains()`, duplicating some functionality of `DataCollection`? Or is it OK to do `run.select_trains(...)[source, key]`?
- Should this also have methods to get data by train, including iterating over trains or getting a train by ID?
- Should getting the KeyData object (doing `run[source, key]`) look at all of the sequence files to know how much data is available & for which trains, or should it only do this on demand? For 'get array' style operations, it's simplest to examine all the chunks up front, but if you're just getting the dtype or the entry shape, or getting data train-by-train, we could just open one file.
  - If we do use virtual overview files (#69), this is less of an issue, because we only need to read metadata & indexes up front, and this is all in the overview file.