### PR TITLE
Add unstack flag to get_array method

### DIFF
--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -332,7 +332,7 @@ class MPxDetectorBase:
           ID, by_index by index within the data being read. The default includes
           all pulses. Only used for per-train data.
         unstack_pulses: bool
-          Wheter to separate train and pulse dimensions.
+          Whether to separate train and pulse dimensions.
         """
         pulses = _check_pulse_selection(pulses)
 

--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -332,7 +332,7 @@ class MPxDetectorBase:
           ID, by_index by index within the data being read. The default includes
           all pulses. Only used for per-train data.
         unstack: bool
-          Wheter or not to separate train and pulse dimensions 
+          Wheter to separate train and pulse dimensions.
         """
         pulses = _check_pulse_selection(pulses)
 

--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -15,7 +15,7 @@ log = logging.getLogger(__name__)
 MAX_PULSES = 2700
 
 
-def _guess_axes(data, train_pulse_ids):
+def _guess_axes(data, train_pulse_ids, unstack):
     # Raw files have a spurious extra dimension
     if data.ndim >= 2 and data.shape[1] == 1:
         data = data[:, 0]
@@ -35,10 +35,13 @@ def _guess_axes(data, train_pulse_ids):
 
     arr = xarray.DataArray(data, {'train_pulse': train_pulse_ids}, dims=dims)
 
-    # Separate train & pulse dimensions, and arrange dimensions
-    # so that the data is contiguous in memory.
-    dim_order = ['train', 'pulse'] + dims[1:]
-    return arr.unstack('train_pulse').transpose(*dim_order)
+    if unstack:
+        # Separate train & pulse dimensions, and arrange dimensions
+        # so that the data is contiguous in memory.
+        dim_order = ['train', 'pulse'] + dims[1:]
+        return arr.unstack('train_pulse').transpose(*dim_order)
+    else:
+        return arr
 
 
 def _check_pulse_selection(pulses):
@@ -236,7 +239,7 @@ class MPxDetectorBase:
 
         return np.concatenate(positions)
 
-    def _get_module_pulse_data(self, source, key, pulses):
+    def _get_module_pulse_data(self, source, key, pulses, unstack):
         seq_arrays = []
         data_path = "/INSTRUMENT/{}/{}".format(source, key.replace('.', '/'))
         for f in self.data._source_index[source]:
@@ -296,7 +299,7 @@ class MPxDetectorBase:
 
                 data = f.file[data_path][data_positions]
 
-                arr = _guess_axes(data, index)
+                arr = _guess_axes(data, index, unstack)
 
                 seq_arrays.append(arr)
 
@@ -316,7 +319,7 @@ class MPxDetectorBase:
             sorted(non_empty, key=lambda a: a.coords['train'][0]), dim='train'
         )
 
-    def get_array(self, key, pulses=by_index[:]):
+    def get_array(self, key, pulses=by_index[:], unstack=True):
         """Get a labelled array of detector data
 
         Parameters
@@ -328,6 +331,8 @@ class MPxDetectorBase:
           Select the pulses to include from each train. by_id selects by pulse
           ID, by_index by index within the data being read. The default includes
           all pulses. Only used for per-train data.
+        unstack: bool
+          Wheter or not to separate train and pulse dimensions 
         """
         pulses = _check_pulse_selection(pulses)
 
@@ -337,7 +342,8 @@ class MPxDetectorBase:
             # At present, all the per-pulse data is stored in the 'image' key.
             # If that changes, this check will need to change as well.
             if key.startswith('image.'):
-                arrays.append(self._get_module_pulse_data(source, key, pulses))
+                arrays.append(self._get_module_pulse_data(
+                    source, key, pulses, unstack))
             else:
                 arrays.append(self.data.get_array(source, key))
             modnos.append(modno)
@@ -608,7 +614,7 @@ class MPxDetectorTrainIterator:
             # h5py fancy indexing needs a list, not an ndarray
             data_positions = list(first + positions)
 
-        return _guess_axes(ds[data_positions], train_pulse_ids)
+        return _guess_axes(ds[data_positions], train_pulse_ids, unstack=unstack)
 
     def _select_pulse_ids(self, pulse_ids):
         """Select pulses by ID

--- a/extra_data/tests/test_components.py
+++ b/extra_data/tests/test_components.py
@@ -18,7 +18,7 @@ def test_get_array(mock_fxe_raw_run):
     assert arr.shape == (16, 3, 128, 256, 256)
     assert arr.dims == ('module', 'train', 'pulse', 'slow_scan', 'fast_scan')
 
-    arr = det.get_array('image.data', pulses=by_index[0], unstack=False)
+    arr = det.get_array('image.data', pulses=by_index[0], unstack_pulse=False)
     assert arr.shape == (16, 384, 256, 256)
 
 

--- a/extra_data/tests/test_components.py
+++ b/extra_data/tests/test_components.py
@@ -20,7 +20,7 @@ def test_get_array(mock_fxe_raw_run):
 
     arr = det.get_array('image.data', pulses=by_index[0], unstack_pulses=False)
     assert arr.shape == (16, 384, 256, 256)
-
+    assert arr.dims == ('module', 'train_pulse', 'slow_scan', 'fast_scan')
 
 def test_get_array_pulse_id(mock_fxe_raw_run):
     run = RunDirectory(mock_fxe_raw_run)

--- a/extra_data/tests/test_components.py
+++ b/extra_data/tests/test_components.py
@@ -18,7 +18,7 @@ def test_get_array(mock_fxe_raw_run):
     assert arr.shape == (16, 3, 128, 256, 256)
     assert arr.dims == ('module', 'train', 'pulse', 'slow_scan', 'fast_scan')
 
-    arr = det.get_array('image.data', pulses=by_index[0], unstack_pulse=False)
+    arr = det.get_array('image.data', pulses=by_index[0], unstack_pulses=False)
     assert arr.shape == (16, 384, 256, 256)
 
 

--- a/extra_data/tests/test_components.py
+++ b/extra_data/tests/test_components.py
@@ -107,7 +107,7 @@ def test_get_array_pulse_indexes_reduced_data(mock_reduced_spb_proc_run):
 def test_get_array_as_xarray(mock_fxe_raw_run):
     run = RunDirectory(mock_fxe_raw_run)
     det = LPD1M(run.select_trains(by_index[:3]))
-    arr = det.get_array('image.data', pulses=by_index[0], unstack=False)
+    arr = det.get_array('image.data', pulses=by_index[0], unstack_pulses=False)
     assert arr.shape == (16, 3, 1, 256, 256)
     assert (arr.coords['pulse'] == 0).all()
 

--- a/extra_data/tests/test_components.py
+++ b/extra_data/tests/test_components.py
@@ -104,6 +104,14 @@ def test_get_array_pulse_indexes_reduced_data(mock_reduced_spb_proc_run):
     assert np.isin(arr.coords['pulse'], [1, 7, 15, 23]).all()
 
 
+def test_get_array_as_xarray(mock_fxe_raw_run):
+    run = RunDirectory(mock_fxe_raw_run)
+    det = LPD1M(run.select_trains(by_index[:3]))
+    arr = det.get_array('image.data', pulses=by_index[0], unstack=False)
+    assert arr.shape == (16, 3, 1, 256, 256)
+    assert (arr.coords['pulse'] == 0).all()
+
+
 def test_get_dask_array(mock_fxe_raw_run):
     run = RunDirectory(mock_fxe_raw_run)
     det = LPD1M(run)

--- a/extra_data/tests/test_components.py
+++ b/extra_data/tests/test_components.py
@@ -18,6 +18,9 @@ def test_get_array(mock_fxe_raw_run):
     assert arr.shape == (16, 3, 128, 256, 256)
     assert arr.dims == ('module', 'train', 'pulse', 'slow_scan', 'fast_scan')
 
+    arr = det.get_array('image.data', pulses=by_index[0], unstack=False)
+    assert arr.shape == (16, 384, 256, 256)
+
 
 def test_get_array_pulse_id(mock_fxe_raw_run):
     run = RunDirectory(mock_fxe_raw_run)
@@ -102,14 +105,6 @@ def test_get_array_pulse_indexes_reduced_data(mock_reduced_spb_proc_run):
 
     arr = det.get_array('image.data', pulses=by_index[[1, 7, 15, 23]])
     assert np.isin(arr.coords['pulse'], [1, 7, 15, 23]).all()
-
-
-def test_get_array_as_xarray(mock_fxe_raw_run):
-    run = RunDirectory(mock_fxe_raw_run)
-    det = LPD1M(run.select_trains(by_index[:3]))
-    arr = det.get_array('image.data', pulses=by_index[0], unstack_pulses=False)
-    assert arr.shape == (16, 3, 1, 256, 256)
-    assert (arr.coords['pulse'] == 0).all()
 
 
 def test_get_dask_array(mock_fxe_raw_run):


### PR DESCRIPTION
Hopefully this will solve the reindexing ValueErrors when the pulseIds have all the same values for a particular run