### PR TITLE
Upgrade pytest on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
 
 install:
   - make install
+  - pip install -U pytest  # pytest-cov needs a newer pytest
   - pip install codecov
 
 script:


### PR DESCRIPTION
Tests are failing because a newer version of pytest-cov gets installed and it requires a newer pytest.