### PR TITLE
Fix zero-length arrays when data is missing in TrainIterator

### DIFF
--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -1257,7 +1257,7 @@ class TrainIterator:
                 first, count = firsts[pos], counts[pos]
                 if count == 1:
                     source_data[key] = ds[first]
-                else:
+                elif count > 0:
                     source_data[key] = ds[first : first + count]
 
         return res

--- a/extra_data/tests/make_examples.py
+++ b/extra_data/tests/make_examples.py
@@ -150,6 +150,7 @@ def make_fxe_da_file(path, format_version='0.5'):
         XGM('SA1_XTD2_XGM/DOOCS/MAIN'),
         XGM('SPB_XTD9_XGM/DOOCS/MAIN'),
         GECCamera('FXE_XAD_GEC/CAM/CAMERA'),
+        GECCamera('FXE_XAD_GEC/CAM/CAMERA_NODATA', nsamples=0)
     ], ntrains=400, chunksize=200, format_version=format_version)
 
 def make_sa3_da_file(path, ntrains=500, format_version='0.5'):

--- a/extra_data/tests/test_reader_mockdata.py
+++ b/extra_data/tests/test_reader_mockdata.py
@@ -68,6 +68,8 @@ def test_iterate_trains_fxe(mock_fxe_control_data):
             assert train_id in range(10000, 10400)
             assert 'SA1_XTD2_XGM/DOOCS/MAIN' in data.keys()
             assert 'beamPosition.ixPos.value' in data['SA1_XTD2_XGM/DOOCS/MAIN']
+            assert 'data.image.pixels' in data['FXE_XAD_GEC/CAM/CAMERA:daqOutput']
+            assert 'data.image.pixels' not in data['FXE_XAD_GEC/CAM/CAMERA_NODATA:daqOutput']
 
 
 def test_iterate_file_select_trains(mock_fxe_control_data):


### PR DESCRIPTION
When data is missing for a particular train and `require_all=False` (the default), `TrainIterator._assemble_data` slices an array of zero length out of the dataset. The resulting data shape is odd and ugly, e.g. (0, 1024, 1024) for a pnCCD image. This tiny change will cause the corresponding key to be absent in the data dictionary instead.