### PR TITLE
Add require_all parameter for det.trains()

### DIFF
--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -407,6 +407,9 @@ class MPxDetectorBase:
         pulses: slice, array, by_index or by_id
           Select which pulses to include for each train.
           The default is to include all pulses.
+        require_all: bool
+          If True (default), skip trains where any of the selected detector
+          modules are missing data.
 
         Yields
         ------

--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -398,7 +398,7 @@ class MPxDetectorBase:
 
         return xarray.concat(arrays, pd.Index(modnos, name='module'))
 
-    def trains(self, pulses=np.s_[:]):
+    def trains(self, pulses=np.s_[:], require_all=True):
         """Iterate over trains for detector data.
 
         Parameters
@@ -416,7 +416,7 @@ class MPxDetectorBase:
           arrays.
         """
         pulses = _check_pulse_selection(pulses)
-        return MPxDetectorTrainIterator(self, pulses)
+        return MPxDetectorTrainIterator(self, pulses, require_all=require_all)
 
     def write_virtual_cxi(self, filename, fillvalues=None):
         """Write a virtual CXI file to access the detector data.


### PR DESCRIPTION
It turns out the machinery was already there for this parameter, it just wasn't being used.

@daviddoji can you check if this works for your use case?

Fixes #71 - at least as far as we can without breaking the API for existing code.