### PR TITLE
allow integer for single train selection

### DIFF
--- a/extra_data/read_machinery.py
+++ b/extra_data/read_machinery.py
@@ -98,6 +98,8 @@ def _tid_to_slice_ix(tid, train_ids, stop=False):
 def select_train_ids(train_ids, sel):
     if isinstance(sel, by_index):
         sel = sel.value
+    elif isinstance(sel, int):
+        sel = slice(sel, sel+1, None)
 
     if isinstance(sel, by_id) and isinstance(sel.value, slice):
         # Slice by train IDs

--- a/extra_data/tests/test_keydata.py
+++ b/extra_data/tests/test_keydata.py
@@ -36,6 +36,10 @@ def test_select_trains(mock_spb_raw_run):
     assert len(sel2.files) == 0
     assert sel2.xarray().shape == (0,)
 
+    # Single train
+    sel3 = xgm_beam_x[32]
+    assert sel3.shape == (1,)
+
 
 def test_nodata(mock_fxe_raw_run):
     run = RunDirectory(mock_fxe_raw_run)


### PR DESCRIPTION
`select_trains` accepts `int` for `DataCollection` and `KeyData` for single train selection, e.g.:
```python3
xgm_intensity = run['SOME_DEVICE/XGM/DOOCS', 'IntensityTD']
xgm_i0 = xgm_intensity[0]
```