### PR TITLE
Fix writing frames from corrected data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
 
 install:
   - make install
-  - pip install -U pytest<6  # pytest-cov needs a newer pytest, but nbval currently fails with pytest 6
+  - pip install -U 'pytest<6'  # pytest-cov needs a newer pytest, but nbval currently fails with pytest 6
   - pip install codecov
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
 
 install:
   - make install
-  - pip install -U pytest  # pytest-cov needs a newer pytest
+  - pip install -U pytest<6  # pytest-cov needs a newer pytest, but nbval currently fails with pytest 6
   - pip install codecov
 
 script:

--- a/extra_data/tests/test_components.py
+++ b/extra_data/tests/test_components.py
@@ -284,6 +284,26 @@ def test_write_selected_frames(mock_spb_raw_run, tmp_path):
         }
 
 
+def test_write_selected_frames_proc(mock_spb_proc_run, tmp_path):
+    run = RunDirectory(mock_spb_proc_run)
+    det = AGIPD1M(run)
+
+    trains = np.repeat(np.arange(10000, 10010), 3)
+    pulses = np.tile([0, 1, 5], 10)
+    test_file = str(tmp_path / 'sel_frames.h5')
+    det.write_frames(test_file, trains, pulses)
+    assert_isfile(test_file)
+
+    with H5File(test_file) as f:
+        np.testing.assert_array_equal(
+            f.get_array('SPB_DET_AGIPD1M-1/DET/0CH0:xtdf', 'image.pulseId'),
+            pulses
+        )
+        assert f.instrument_sources == {
+            f'SPB_DET_AGIPD1M-1/DET/{i}CH0:xtdf' for i in range(16)
+        }
+
+
 def test_identify_multimod_detectors(mock_fxe_raw_run):
     run = RunDirectory(mock_fxe_raw_run)
     name, cls = identify_multimod_detectors(run, single=True)

--- a/extra_data/writer.py
+++ b/extra_data/writer.py
@@ -27,6 +27,10 @@ class FileWriter:
             src_ds1 = self.data._source_index[source][0].file[path]
             self.file.create_dataset_like(
                 path, src_ds1, shape=(nentries,) + src_ds1.shape[1:],
+                # Corrected detector data has maxshape==shape, but if any max
+                # dim is smaller than the chunk size, h5py complains. Making
+                # the first dimension unlimited avoids this.
+                maxshape=(None,) + src_ds1.shape[1:],
             )
             if source in self.data.instrument_sources:
                 self.data_sources.add(f"INSTRUMENT/{source}/{key.partition('.')[0]}")

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(name="EXtra-data",
           'karabo-bridge >=0.6',
           'matplotlib',
           'numpy',
-          'pandas',
+          'pandas <1.1',  # https://github.com/European-XFEL/EXtra-data/issues/81
           'psutil',
           'scipy',
           'xarray',


### PR DESCRIPTION
Whereas the raw data has an unlimited first dimension, the proc data has the maximum shape the same as the actual data shape. This causes a problem when we try to create the image datasets with 0 length originally, because the length is less than the chunk size. The easiest way to avoid this is to always set maxshape to offer an unlimited first dimension.

Closes gh-80.

A couple of dependency changes seem to have broken our tests. I've restricted versions of pytest and pandas for now; I'll work on fixing those issues separately.
