### PR TITLE
Fix issue with pandas 1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
 
 install:
   - make install
-  - pip install -U pytest  # pytest-cov needs a newer pytest
+  - pip install -U 'pytest<6'  # pytest-cov needs a newer pytest, but nbval currently fails with pytest 6
   - pip install codecov
 
 script:

--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -390,7 +390,7 @@ class MPxDetectorBase:
                 mod_arr = mod_arr.rename({'trainId': 'train_pulse'})
 
                 mod_arr.coords['train_pulse'] = pd.MultiIndex.from_arrays(
-                    [mod_arr.coords['train_pulse'], inner_ix],
+                    [mod_arr.coords['train_pulse'].values, inner_ix.values],
                     names=['trainId', subtrain_index]
                 )
 


### PR DESCRIPTION
Closes #81 

We were passing Xarray objects to pandas `MultiIndex.from_arrays()`, which worked previously, but no longer does. We don't need the Xarray metadata there, so we can just take the numpy arrays.