### PR TITLE
Unpin pandas & pytest versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
 
 install:
   - make install
-  - pip install -U 'pytest<6'  # pytest-cov needs a newer pytest, but nbval currently fails with pytest 6
+  - pip install -U pytest  # pytest-cov needs a newer pytest
   - pip install codecov
 
 script:

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(name="EXtra-data",
           'karabo-bridge >=0.6',
           'matplotlib',
           'numpy',
-          'pandas <1.1',  # https://github.com/European-XFEL/EXtra-data/issues/81
+          'pandas',
           'psutil',
           'scipy',
           'xarray',


### PR DESCRIPTION
- #83 fixed the pandas compatibility issue
- https://github.com/computationalmodelling/nbval/pull/152 fixed running with pytest 6