### PR TITLE
Add names to xarray results

### DIFF
--- a/extra_data/keydata.py
+++ b/extra_data/keydata.py
@@ -162,6 +162,9 @@ class KeyData:
         if name is None:
             name = f'{self.source}.{self.key}'
 
+            if name.endswith('.value') and self.section == 'CONTROL':
+                name = name[:-6]
+
         return xarray.DataArray(ndarr, dims=dims, coords=coords, name=name)
 
     def series(self):

--- a/extra_data/keydata.py
+++ b/extra_data/keydata.py
@@ -133,17 +133,17 @@ class KeyData:
         ]
         return np.concatenate(chunks_trainids)
 
-    def xarray(self, extra_dims=None, name=None, roi=()):
+    def xarray(self, extra_dims=None, roi=(), name=None):
         """Load this data as a labelled xarray.DataArray.
 
         The first dimension is labelled with train IDs. Other dimensions may be
         named by passing a list of names to *extra_dims*.
 
-        The array's name may be given by *name*, by default the source and key
-        is joined by a dot.
-
         *roi* may be a ``numpy.s_[]`` expression to load e.g. only part of each
         image from a camera.
+
+        The array's name may be given by *name*, by default the source and key
+        is joined by a dot.
         """
         import xarray
 

--- a/extra_data/keydata.py
+++ b/extra_data/keydata.py
@@ -175,7 +175,7 @@ class KeyData:
             raise TypeError("pandas Series are only available for 1D data")
 
         name = self.source + '/' + self.key
-        if name.endswith('.value'):
+        if name.endswith('.value') and self.section == 'CONTROL':
             name = name[:-6]
 
         index = pd.Index(self._trainid_index(), name='trainId')

--- a/extra_data/keydata.py
+++ b/extra_data/keydata.py
@@ -133,11 +133,14 @@ class KeyData:
         ]
         return np.concatenate(chunks_trainids)
 
-    def xarray(self, extra_dims=None, roi=()):
+    def xarray(self, extra_dims=None, name=None, roi=()):
         """Load this data as a labelled xarray.DataArray.
 
         The first dimension is labelled with train IDs. Other dimensions may be
         named by passing a list of names to *extra_dims*.
+
+        The array's name may be given by *name*, by default the source and key
+        is joined by a dot.
 
         *roi* may be a ``numpy.s_[]`` expression to load e.g. only part of each
         image from a camera.
@@ -156,7 +159,10 @@ class KeyData:
         if self.shape[0]:
             coords = {'trainId': self._trainid_index()}
 
-        return xarray.DataArray(ndarr, dims=dims, coords=coords)
+        if name is None:
+            name = f'{self.source}.{self.key}'
+
+        return xarray.DataArray(ndarr, dims=dims, coords=coords, name=name)
 
     def series(self):
         """Load this data as a pandas Series. Only for 1D data."""

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -535,7 +535,7 @@ class DataCollection:
 
         return pd.concat(series, axis=1)
 
-    def get_array(self, source, key, extra_dims=None, roi=()):
+    def get_array(self, source, key, extra_dims=None, name=None, roi=()):
         """Return a labelled array for a particular data field.
 
         ::
@@ -558,6 +558,9 @@ class DataCollection:
             Name extra dimensions in the array. The first dimension is
             automatically called 'train'. The default for extra dimensions
             is dim_0, dim_1, ...
+        name: str
+            Name the array itself. The default is the source and key joined
+            by a dot.
         roi: slice, tuple of slices, or by_index
             The region of interest. This expression selects data in all
             dimensions apart from the first (trains) dimension. If the data
@@ -568,7 +571,8 @@ class DataCollection:
         if isinstance(roi, by_index):
             roi = roi.value
 
-        return self._get_key_data(source, key).xarray(extra_dims=extra_dims, roi=roi)
+        return self._get_key_data(source, key).xarray(
+            extra_dims=extra_dims, name=name, roi=roi)
 
     def get_dask_array(self, source, key, labelled=False):
         """Get a Dask array for the specified data field.

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -535,7 +535,7 @@ class DataCollection:
 
         return pd.concat(series, axis=1)
 
-    def get_array(self, source, key, extra_dims=None, name=None, roi=()):
+    def get_array(self, source, key, extra_dims=None, roi=(), name=None):
         """Return a labelled array for a particular data field.
 
         ::
@@ -558,21 +558,21 @@ class DataCollection:
             Name extra dimensions in the array. The first dimension is
             automatically called 'train'. The default for extra dimensions
             is dim_0, dim_1, ...
-        name: str
-            Name the array itself. The default is the source and key joined
-            by a dot.
         roi: slice, tuple of slices, or by_index
             The region of interest. This expression selects data in all
             dimensions apart from the first (trains) dimension. If the data
             holds a 1D array for each entry, roi=np.s_[:8] would get the
             first 8 values from every train. If the data is 2D or more at
             each entry, selection looks like roi=np.s_[:8, 5:10] .
+        name: str
+            Name the array itself. The default is the source and key joined
+            by a dot.
         """
         if isinstance(roi, by_index):
             roi = roi.value
 
         return self._get_key_data(source, key).xarray(
-            extra_dims=extra_dims, name=name, roi=roi)
+            extra_dims=extra_dims, roi=roi, name=name)
 
     def get_dask_array(self, source, key, labelled=False):
         """Get a Dask array for the specified data field.

--- a/extra_data/tests/test_reader_mockdata.py
+++ b/extra_data/tests/test_reader_mockdata.py
@@ -337,16 +337,22 @@ def test_file_get_array_control_roi(mock_sa3_control_data):
     assert arr.coords['trainId'][0] == 10000
 
 
-def test_run_get_array(mock_fxe_raw_run):
+@pytest.mark.parametrize('name_in, name_out', [
+    (None, 'SA1_XTD2_XGM/DOOCS/MAIN:output.data.intensityTD'),
+    ('SA1_XGM', 'SA1_XGM')
+], ids=['defaultName', 'explicitName'])
+def test_run_get_array(mock_fxe_raw_run, name_in, name_out):
     run = RunDirectory(mock_fxe_raw_run)
     arr = run.get_array(
-        'SA1_XTD2_XGM/DOOCS/MAIN:output', 'data.intensityTD', extra_dims=['pulse']
+        'SA1_XTD2_XGM/DOOCS/MAIN:output', 'data.intensityTD',
+        extra_dims=['pulse'], name=name_in
     )
 
     assert isinstance(arr, DataArray)
     assert arr.dims == ('trainId', 'pulse')
     assert arr.shape == (480, 1000)
     assert arr.coords['trainId'][0] == 10000
+    assert arr.name == name_out
 
 
 def test_run_get_array_empty(mock_fxe_raw_run):


### PR DESCRIPTION
The `xarray.DataArray`s returned by `KeyData.xarray()` or `DataCollection.get_array()` don't have an explicit name set, causing functions like `xarray.merge` to fail when converting to a `xarray.Dataset`. This PR uses `{source}.{key}` as the array name by default with an optional argument added to specify a custom name. 