### PR TITLE
Renaming karabo-data-valitate -> extra-data-validate

### DIFF
--- a/extra_data/validation.py
+++ b/extra_data/validation.py
@@ -272,7 +272,7 @@ def main(argv=None):
     if argv is None:
         argv = sys.argv[1:]
 
-    ap = ArgumentParser(prog='karabo-data-validate')
+    ap = ArgumentParser(prog='extra-data-validate')
     ap.add_argument('path', help="HDF5 file or run directory of HDF5 files.")
     args = ap.parse_args(argv)
 


### PR DESCRIPTION
By mistake, I found this small bug in the help message when one does not pass a path to ```extra-data-validate```

![image](https://user-images.githubusercontent.com/4411314/90401190-e41fd480-e09d-11ea-9fc7-d893aaba3acb.png)
