### PR TITLE
KeyData: get data counts

### DIFF
--- a/extra_data/keydata.py
+++ b/extra_data/keydata.py
@@ -95,6 +95,27 @@ class KeyData:
     def __getitem__(self, item):
         return self.select_trains(item)
 
+    def get_data_counts(self):
+        """Get a count of data points in each train.
+
+        Returns a pandas series with an index of train IDs.
+        """
+        import pandas as pd
+
+        seq_series = []
+
+        for f in self.files:
+            if self.section == 'CONTROL':
+                counts = np.ones(len(f.train_ids), dtype=np.uint64)
+            else:
+                _, counts = f.get_index(self.source, self._key_group)
+            seq_series.append(pd.Series(counts, index=f.train_ids))
+
+        ser = pd.concat(sorted(seq_series, key=lambda s: s.index[0]))
+        # Select out only the train IDs of interest
+        train_ids = ser.index.intersection(self.train_ids)
+        return ser.loc[train_ids]
+
     # Getting data as different kinds of array: -------------------------------
 
     def ndarray(self, roi=()):

--- a/extra_data/keydata.py
+++ b/extra_data/keydata.py
@@ -95,7 +95,7 @@ class KeyData:
     def __getitem__(self, item):
         return self.select_trains(item)
 
-    def get_data_counts(self):
+    def data_counts(self):
         """Get a count of data points in each train.
 
         Returns a pandas series with an index of train IDs.

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -409,23 +409,7 @@ class DataCollection:
         key: str
             Key of parameter within that device, e.g. "image.data".
         """
-        import pandas as pd
-
-        self._check_field(source, key)
-        seq_series = []
-
-        for f in self._source_index[source]:
-            if source in self.control_sources:
-                counts = np.ones(len(f.train_ids), dtype=np.uint64)
-            else:
-                group = key.partition('.')[0]
-                _, counts = f.get_index(source, group)
-            seq_series.append(pd.Series(counts, index=f.train_ids))
-
-        ser = pd.concat(sorted(seq_series, key=lambda s: s.index[0]))
-        # Select out only the train IDs of interest
-        train_ids = ser.index.intersection(self.train_ids)
-        return ser.loc[train_ids]
+        return self._get_key_data(source, key).get_data_counts()
 
     def get_series(self, source, key):
         """Return a pandas Series for a particular data field.

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -409,7 +409,7 @@ class DataCollection:
         key: str
             Key of parameter within that device, e.g. "image.data".
         """
-        return self._get_key_data(source, key).get_data_counts()
+        return self._get_key_data(source, key).data_counts()
 
     def get_series(self, source, key):
         """Return a pandas Series for a particular data field.

--- a/extra_data/tests/make_examples.py
+++ b/extra_data/tests/make_examples.py
@@ -269,8 +269,7 @@ def make_reduced_spb_run(dir_path, raw=True, rng=None, format_version='0.5'):
             AGIPDModule('SPB_DET_AGIPD1M-1/DET/{}CH0'.format(modno), raw=raw,
                          frames_per_train=frame_counts)
             ], ntrains=64, chunksize=32, format_version=format_version)
-    if not raw:
-        return
+
     write_file(osp.join(dir_path, '{}-R0238-DA01-S00000.h5'.format(prefix)),
                [ XGM('SA1_XTD2_XGM/DOOCS/MAIN'),
                  XGM('SPB_XTD9_XGM/DOOCS/MAIN'),

--- a/extra_data/tests/test_keydata.py
+++ b/extra_data/tests/test_keydata.py
@@ -86,7 +86,7 @@ def test_get_train(mock_spb_raw_run):
         xgm_beam_x.train_from_index(9999)
 
 
-def test_get_data_count(mock_reduced_spb_proc_run):
+def test_data_counts(mock_reduced_spb_proc_run):
     run = RunDirectory(mock_reduced_spb_proc_run)
 
     # control data

--- a/extra_data/tests/test_keydata.py
+++ b/extra_data/tests/test_keydata.py
@@ -84,3 +84,23 @@ def test_get_train(mock_spb_raw_run):
 
     with pytest.raises(IndexError):
         xgm_beam_x.train_from_index(9999)
+
+
+def test_get_data_count(mock_reduced_spb_proc_run):
+    run = RunDirectory(mock_reduced_spb_proc_run)
+
+    # control data
+    xgm_beam_x = run['SPB_XTD9_XGM/DOOCS/MAIN', 'beamPosition.ixPos.value']
+    count = xgm_beam_x.get_data_counts()
+    assert count.index.tolist() == xgm_beam_x.train_ids
+    assert (count.values == 1).all()
+
+    # intrument data
+    camera = run['SPB_IRU_CAM/CAM/SIDEMIC:daqOutput', 'data.image.pixels']
+    count = camera.get_data_counts()
+    assert count.index.tolist() == camera.train_ids
+
+    mod = run['SPB_DET_AGIPD1M-1/DET/0CH0:xtdf', 'image.data']
+    count = mod.get_data_counts()
+    assert count.index.tolist() == mod.train_ids
+    assert count.values.sum() == mod.shape[0]

--- a/extra_data/tests/test_keydata.py
+++ b/extra_data/tests/test_keydata.py
@@ -91,16 +91,16 @@ def test_get_data_count(mock_reduced_spb_proc_run):
 
     # control data
     xgm_beam_x = run['SPB_XTD9_XGM/DOOCS/MAIN', 'beamPosition.ixPos.value']
-    count = xgm_beam_x.get_data_counts()
+    count = xgm_beam_x.data_counts()
     assert count.index.tolist() == xgm_beam_x.train_ids
     assert (count.values == 1).all()
 
     # intrument data
     camera = run['SPB_IRU_CAM/CAM/SIDEMIC:daqOutput', 'data.image.pixels']
-    count = camera.get_data_counts()
+    count = camera.data_counts()
     assert count.index.tolist() == camera.train_ids
 
     mod = run['SPB_DET_AGIPD1M-1/DET/0CH0:xtdf', 'image.data']
-    count = mod.get_data_counts()
+    count = mod.data_counts()
     assert count.index.tolist() == mod.train_ids
     assert count.values.sum() == mod.shape[0]

--- a/extra_data/tests/test_reader_mockdata.py
+++ b/extra_data/tests/test_reader_mockdata.py
@@ -636,3 +636,10 @@ def test_permission():
 def test_empty_file_info(mock_empty_file, capsys):
     f = H5File(mock_empty_file)
     f.info()  # smoke test
+
+
+def test_get_data_counts(mock_spb_raw_run):
+    run = RunDirectory(mock_spb_raw_run)
+    count = run.get_data_counts('SPB_XTD9_XGM/DOOCS/MAIN', 'beamPosition.ixPos.value')
+    assert count.index.tolist() == run.train_ids
+    assert (count.values == 1).all()


### PR DESCRIPTION
Implements `get_data_counts` in `KeyData`: Get a count of data points in each train.

closes #91 