### PR TITLE
FIX: validate run when a file cannot be opened

### DIFF
--- a/extra_data/tests/test_validation.py
+++ b/extra_data/tests/test_validation.py
@@ -1,4 +1,5 @@
 import os.path as osp
+from pathlib import Path
 
 from h5py import File
 from pytest import fixture, raises
@@ -29,6 +30,16 @@ def data_aggregator_file():
 def test_validate_run(mock_fxe_raw_run):
     rv = RunValidator(mock_fxe_raw_run)
     rv.validate()
+
+
+def test_file_error(mock_fxe_raw_run):
+    not_readable = Path(mock_fxe_raw_run) / 'notReadable.h5'
+    not_readable.touch(mode=0o066)
+
+    problems = RunValidator(mock_fxe_raw_run).run_checks()
+    assert len(problems) == 1
+    assert problems[0]['msg'] == 'Could not open file'
+    assert problems[0]['file'] == str(not_readable)
 
 
 def test_zeros_in_train_ids(agipd_file):

--- a/extra_data/validation.py
+++ b/extra_data/validation.py
@@ -169,12 +169,13 @@ def progress_bar(done, total, suffix=' '):
 
 def _check_file(args):
     runpath, filename = args
+    filepath = osp.join(runpath, filename)
     problems = []
     try:
-        fa = FileAccess(osp.join(runpath, filename))
+        fa = FileAccess(filepath)
     except Exception as e:
         problems.append(
-            dict(msg="Could not open file", file=path, error=e)
+            dict(msg="Could not open file", file=filepath, error=e)
         )
         return filename, None, problems
     else:


### PR DESCRIPTION
Overlooked that the path to the file was not defined when an error is raised while opening a file in the validation code.

@daviddoji 