### PR TITLE
Check that timestamps on control data is always increasing

### DIFF
--- a/extra_data/validation.py
+++ b/extra_data/validation.py
@@ -28,7 +28,7 @@ class ValidationError(Exception):
 
 
 class FileValidator:
-    def __init__(self, file: FileAccess):
+    def __init__(self, file: FileAccess, timestamp=False):
         self.file = file
         self.filename = file.filename
         self.problems = []

--- a/extra_data/validation.py
+++ b/extra_data/validation.py
@@ -28,7 +28,7 @@ class ValidationError(Exception):
 
 
 class FileValidator:
-    def __init__(self, file: FileAccess, timestamp=False):
+    def __init__(self, file: FileAccess):
         self.file = file
         self.filename = file.filename
         self.problems = []

--- a/extra_data/validation.py
+++ b/extra_data/validation.py
@@ -28,10 +28,9 @@ class ValidationError(Exception):
 
 
 class FileValidator:
-    def __init__(self, file: FileAccess, timestamp=False):
+    def __init__(self, file: FileAccess):
         self.file = file
         self.filename = file.filename
-        self.extras = {'timestamp': timestamp}
         self.problems = []
 
     def validate(self):
@@ -43,9 +42,7 @@ class FileValidator:
         self.problems = []
         self.check_indices()
         self.check_trainids()
-        for check, do in self.extras.items():
-            if do:
-                getattr(self, f'check_{check}')()
+        self.check_timestamps()
 
         return self.problems
 
@@ -159,7 +156,9 @@ class FileValidator:
 
         check_index_contiguous(first, count, record)
 
-    def check_timestamp(self):
+    def check_timestamps(self):
+        """Check that CONTROL value's timestamps are monotonically increasing.
+        """
         for source in self.file.control_sources:
             for key in self.file.get_keys(source):
                 if not key.endswith('.timestamp'):
@@ -329,10 +328,6 @@ def main(argv=None):
 
     ap = ArgumentParser(prog='extra-data-validate')
     ap.add_argument('path', help="HDF5 file or run directory of HDF5 files.")
-    ap.add_argument(
-        '-ts', '--timestamp', action='store_true',
-        help='check that timestamps are increasing on control data sources'
-    )
     args = ap.parse_args(argv)
 
     path = args.path


### PR DESCRIPTION
I've got a request from IT to check that all timestamps are always increasing (or not changing if the value isn't updated).

This PR checks all timestamps  for all `CONTROL` datasets and check if a timestamp is decreasing, or a timestamp has a zero value before the last train.

There is a run example with a case of decreasing timestamp: /gpfs/exfel/exp/SPB/202031/p900145/raw/r0952/RAW-R0952-DA01-S00000.h5 (data is on the online cluster).

~~I'd like to ask if someone has a good strategy for 'additional' checks like this one? Or should it be part of the overall checks?~~
Any view @takluyver ? 

I need to benchmark this to see the impact of reading all control datasets.
edit: Impact is negligeable on the few tests I ran, so just running it by default.