### PR TITLE
FIX: Components Dask array dtype 

### DIFF
--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -320,7 +320,17 @@ class MPxDetectorBase:
             dim=('train' if unstack_pulses else 'train_pulse'),
         )
 
-    def get_array(self, key, pulses=np.s_[:], unstack_pulses=True):
+    @staticmethod
+    def _fill_value(value, dtype):
+        if value is None:
+            if dtype.kind != 'f':
+                return 0
+            else:
+                return np.nan
+        return value
+
+    def get_array(self, key, pulses=np.s_[:], unstack_pulses=True,
+                  fill_value=None, join='outer'):
         """Get a labelled array of detector data
 
         Parameters
@@ -334,6 +344,20 @@ class MPxDetectorBase:
           all pulses. Only used for per-train data.
         unstack_pulses: bool
           Whether to separate train and pulse dimensions.
+        fill_value: int or float, optional
+            Value to use for missing values. If None (default) the fill value
+            is 0 for integers and np.nan for floats.
+        join: str, optional
+            String indicating how to combine detector modules in the new array:
+            - “outer”: use the union of object indexes
+            - “inner”: use the intersection of object indexes
+            - “left”: use indexes from the first object with each dimension
+            - “right”: use indexes from the last object with each dimension
+            - “exact”: instead of aligning, raise ValueError when indexes to be
+                aligned are not equal
+            - “override”: if indexes are of same size, rewrite indexes to be
+                those of the first object with that dimension. Indexes for the
+                same dimension must have the same size in all objects.
         """
         pulses = _check_pulse_selection(pulses)
 
@@ -349,9 +373,15 @@ class MPxDetectorBase:
                 arrays.append(self.data.get_array(source, key))
             modnos.append(modno)
 
-        return xarray.concat(arrays, pd.Index(modnos, name='module'))
+        return xarray.concat(
+            arrays,
+            pd.Index(modnos, name='module'),
+            fill_value=self._fill_value(fill_value, arrays[0].dtype),
+            join=join
+        )
 
-    def get_dask_array(self, key, subtrain_index='pulseId'):
+    def get_dask_array(self, key, subtrain_index='pulseId', fill_value=None,
+                       join='outer'):
         """Get a labelled Dask array of detector data
 
         Dask does lazy, parallelised computing, and can work with large data
@@ -369,6 +399,20 @@ class MPxDetectorBase:
           other devices, but depends on how the detector was manually configured
           when the data was taken. Cell ID refers to the memory cell used for
           that frame in the detector hardware.
+        fill_value: int or float, optional
+            Value to use for missing values. If None (default) the fill value
+            is 0 for integers and np.nan for floats.
+        join: str, optional
+            String indicating how to combine detector modules in the new array:
+            - “outer”: use the union of object indexes
+            - “inner”: use the intersection of object indexes
+            - “left”: use indexes from the first object with each dimension
+            - “right”: use indexes from the last object with each dimension
+            - “exact”: instead of aligning, raise ValueError when indexes to be
+                aligned are not equal
+            - “override”: if indexes are of same size, rewrite indexes to be
+                those of the first object with that dimension. Indexes for the
+                same dimension must have the same size in all objects.
         """
         if subtrain_index not in {'pulseId', 'cellId'}:
             raise ValueError("subtrain_index must be 'pulseId' or 'cellId'")
@@ -397,8 +441,12 @@ class MPxDetectorBase:
             arrays.append(mod_arr)
 
         # set the fill_value to prevent xarray from changing the dtype to float
-        fill_value = 0 if arrays[0].dtype.kind != 'f' else xarray.core.dtypes.NA
-        return xarray.concat(arrays, pd.Index(modnos, name='module'), fill_value=fill_value)
+        return xarray.concat(
+            arrays,
+            pd.Index(modnos, name='module'),
+            fill_value=self._fill_value(fill_value, arrays[0].dtype),
+            join=join
+        )
 
     def trains(self, pulses=np.s_[:], require_all=True):
         """Iterate over trains for detector data.

--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -396,7 +396,9 @@ class MPxDetectorBase:
 
             arrays.append(mod_arr)
 
-        return xarray.concat(arrays, pd.Index(modnos, name='module'))
+        # set the fill_value to prevent xarray from changing the dtype to float
+        fill_value = 0 if arrays[0].dtype.kind != 'f' else xr.core.dtypes.NA
+        return xarray.concat(arrays, pd.Index(modnos, name='module'), fill_value=fill_value)
 
     def trains(self, pulses=np.s_[:], require_all=True):
         """Iterate over trains for detector data.

--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -397,7 +397,7 @@ class MPxDetectorBase:
             arrays.append(mod_arr)
 
         # set the fill_value to prevent xarray from changing the dtype to float
-        fill_value = 0 if arrays[0].dtype.kind != 'f' else xr.core.dtypes.NA
+        fill_value = 0 if arrays[0].dtype.kind != 'f' else xarray.core.dtypes.NA
         return xarray.concat(arrays, pd.Index(modnos, name='module'), fill_value=fill_value)
 
     def trains(self, pulses=np.s_[:], require_all=True):

--- a/extra_data/tests/test_components.py
+++ b/extra_data/tests/test_components.py
@@ -20,6 +20,7 @@ def test_get_array(mock_fxe_raw_run):
 
     arr = det.get_array('image.data', pulses=by_index[:10], unstack_pulses=False)
     assert arr.shape == (16, 30, 256, 256)
+    assert arr.dtype == np.uint16
     assert arr.dims == ('module', 'train_pulse', 'slow_scan', 'fast_scan')
 
 def test_get_array_pulse_id(mock_fxe_raw_run):

--- a/extra_data/tests/test_components.py
+++ b/extra_data/tests/test_components.py
@@ -23,6 +23,11 @@ def test_get_array(mock_fxe_raw_run):
     assert arr.dtype == np.uint16
     assert arr.dims == ('module', 'train_pulse', 'slow_scan', 'fast_scan')
 
+    # fill value
+    with pytest.raises(ValueError):
+        det.get_array('image.data', fill_value=np.nan)
+
+
 def test_get_array_pulse_id(mock_fxe_raw_run):
     run = RunDirectory(mock_fxe_raw_run)
     det = LPD1M(run.select_trains(by_index[:3]))

--- a/extra_data/tests/test_components.py
+++ b/extra_data/tests/test_components.py
@@ -116,6 +116,7 @@ def test_get_dask_array(mock_fxe_raw_run):
 
     assert isinstance(arr.data, da.Array)
     assert arr.shape == (16, 480 * 128, 1, 256, 256)
+    assert arr.dtype == np.uint16
     assert arr.dims == ('module', 'train_pulse', 'dim_0', 'dim_1', 'dim_2')
     np.testing.assert_array_equal(arr.coords['module'], np.arange(16))
     np.testing.assert_array_equal(


### PR DESCRIPTION
While playing with dask, I realized that the dtype of the array returned by `get_dask_array` changed the data type to `float64`.

This ensure the the datatype is kept as in the source arrays by setting the fill value to `0` for arrays of dtype != `float`