### PR TITLE
Stack from xarray

### DIFF
--- a/extra_data/stacking.py
+++ b/extra_data/stacking.py
@@ -134,12 +134,13 @@ def stack_detector_data(train, data, axis=-3, modules=16, fillvalue=None,
 
 def stack_from_xarray(xrdata, axis=-3, modules=16, fillvalue=None,
                       real_array=True):
-    """Stack data from a xarray.
+    """Stack detector data from an xarray DataArray.
 
     Parameters
     ----------
-    xrdata: xarray
+    xrdata: xarray.DataArray
         (Big) detector data. Expected dims are:
+        ('module', 'dim_1', 'dim_2', 'dim_3', 'dim_4'). e.g.:
         ('module', 'train', 'pulse', 'slow_scan', 'fast_scan')
     axis: int
         Array axis on which you wish to stack (default is -3).
@@ -156,8 +157,8 @@ def stack_from_xarray(xrdata, axis=-3, modules=16, fillvalue=None,
 
     Returns
     -------
-    stack: numpy.array
-        Stacked data for requested data path.
+    stack: numpy.ndarray
+        Stacked data in an unlabelled array.
     """
     modno_arrays = {}
     for modno in xrdata.module.values:

--- a/extra_data/tests/test_stacking.py
+++ b/extra_data/tests/test_stacking.py
@@ -168,4 +168,4 @@ def test_stack_from_xarray():
                         dims=dims, coords=coords)
 
     comb = stack_from_xarray(data)
-    assert comb.shape == (2, 2, 16, 8, 8)
+    assert comb.shape == (2, 2, 16, 10, 10)

--- a/extra_data/tests/test_stacking.py
+++ b/extra_data/tests/test_stacking.py
@@ -1,7 +1,8 @@
 import numpy as np
 import pytest
+import xarray as xr
 
-from extra_data import RunDirectory, stack_data, stack_detector_data
+from extra_data import RunDirectory, stack_data, stack_detector_data, stack_from_xarray
 from extra_data.stacking import StackView
 
 def test_stack_data(mock_fxe_raw_run):
@@ -155,3 +156,16 @@ def test_stackview_squeeze():
 
     with pytest.raises(np.AxisError):
         sv.squeeze(axis=4)
+
+def test_stack_from_xarray():
+    coords = {'module': np.arange(2),
+              'train': np.arange(2),
+              'pulse': np.arange(2)
+    }
+    dims = ['module', 'train', 'pulse', 'slow_scan', 'fast_scan']
+    
+    data = xr.DataArray(np.zeros(800).reshape(2,2,2,10,10),
+                        dims=dims, coords=coords)
+
+    comb = stack_from_xarray(data)
+    assert comb.shape == (2, 2, 16, 8, 8)

--- a/extra_data/tests/test_stacking.py
+++ b/extra_data/tests/test_stacking.py
@@ -158,13 +158,13 @@ def test_stackview_squeeze():
         sv.squeeze(axis=4)
 
 def test_stack_from_xarray():
-    coords = {'module': np.arange(2),
+    coords = {'module': np.array([0, 2, 3]),
               'train': np.arange(2),
               'pulse': np.arange(2)
     }
     dims = ['module', 'train', 'pulse', 'slow_scan', 'fast_scan']
     
-    data = xr.DataArray(np.zeros(800).reshape(2,2,2,10,10),
+    data = xr.DataArray(np.zeros((3, 2, 2, 10, 10)),
                         dims=dims, coords=coords)
 
     comb = stack_from_xarray(data)


### PR DESCRIPTION
As discussed with @takluyver , the new 'stack_from_xarray' method will make it possible to stack (big) detector data from an existing xarray.
The method is basically the same as 'stack_detector_data', so we could simplify both.