### PR TITLE
Accept DataCollection and KeyData for source selection

### DIFF
--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -615,7 +615,10 @@ class DataCollection:
                 if source not in self.all_sources:
                     raise SourceNameError(source)
 
-                res[source].update(keys or None)
+                if keys:
+                    res[source].update(keys)
+                else:
+                    res[source] = None
 
         elif isinstance(selection, Iterable):
             # selection = [('src_glob', 'key_glob'), ...]

--- a/extra_data/tests/test_keydata.py
+++ b/extra_data/tests/test_keydata.py
@@ -104,3 +104,12 @@ def test_data_counts(mock_reduced_spb_proc_run):
     count = mod.data_counts()
     assert count.index.tolist() == mod.train_ids
     assert count.values.sum() == mod.shape[0]
+
+
+def test_select_by(mock_spb_raw_run):
+    run = RunDirectory(mock_spb_raw_run)
+    am0 = run['SPB_DET_AGIPD1M-1/DET/0CH0:xtdf', 'image.data']
+
+    subrun = run.select(am0)
+    assert subrun.all_sources == {am0.source}
+    assert subrun.keys_for_source(am0.source) == {am0.key}

--- a/extra_data/tests/test_reader_mockdata.py
+++ b/extra_data/tests/test_reader_mockdata.py
@@ -477,6 +477,10 @@ def test_select(mock_fxe_raw_run):
         print(source)
         assert set(source_data.keys()) == {'image.pulseId', 'metadata'}
 
+    sel2 = run.select(sel)
+    assert 'SPB_XTD9_XGM/DOOCS/MAIN' not in sel2.control_sources
+    assert 'FXE_DET_LPD1M-1/DET/0CH0:xtdf' in sel2.instrument_sources
+
 
 def test_deselect(mock_fxe_raw_run):
     run = RunDirectory(mock_fxe_raw_run)
@@ -492,6 +496,10 @@ def test_deselect(mock_fxe_raw_run):
     assert xtd9_xgm in sel.control_sources
     assert 'beamPosition.ixPos.value' not in sel.selection[xtd9_xgm]
     assert 'beamPosition.iyPos.value' in sel.selection[xtd9_xgm]
+
+    sel = run.deselect(run.select('*_XGM/DOOCS*'))
+    assert xtd9_xgm not in sel.control_sources
+    assert 'FXE_DET_LPD1M-1/DET/0CH0:xtdf' in sel.instrument_sources
 
 
 def test_select_trains(mock_fxe_raw_run):


### PR DESCRIPTION
Somewhat related to #113, this PR adds support to select sources (in `DataCollection`) ~~and trains (in both `DataCollection` and `KeyData`)~~ via those very rame types, effectively copying a particular property of those to another object. The respective semantics are unchanged, i.e.

- `.select()` raises an exception if sources are selected which are not actually part of the `DataCollection`
- ~~`.select_trains()` returns the intersection of the current object and whatever is used to select trains~~

During the implementation I found a peculiar bug in `DataCollection._expand_selection()`, which prevented an empty iterable (which evaluated to `False` in the check `keys or None` check) to be accepted even though this is advertised as selecting all keys. As a part of this fix, it also accepts `None` now to select all keys (which is used internally in the `DataCollection.selection` property).