### PR TITLE
Fix select's dict API and broadening of keys by re-selecting

### DIFF
--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -623,6 +623,14 @@ class DataCollection:
                     raise SourceNameError(source)
 
                 if keys:
+                    # keys may be None, which is allowed as an
+                    # undocumented behaviour to support passing a
+                    # DataCollection as the selector.
+
+                    for key in keys:
+                        if not self._has_source_key(source, key):
+                            raise PropertyNameError(key, source)
+
                     res[source].update(keys)
                 else:
                     res[source] = None

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -631,7 +631,15 @@ class DataCollection:
                         if not self._has_source_key(source, key):
                             raise PropertyNameError(key, source)
 
-                    res[source].update(keys)
+                    if self.selection[source] is not None:
+                        # If the current DataCollection also selected
+                        # specific keys, make sure the new keys are a
+                        # subset of it.
+                        res[source].update(keys & self.selection[source])
+                    else:
+                        res[source].update(keys)
+                elif self.selection[source] is not None:
+                    res[source] = self.selection[source]
                 else:
                     res[source] = None
 
@@ -667,7 +675,10 @@ class DataCollection:
                 continue
 
             if key_glob == '*':
-                matched[source] = None
+                if self.selection[source] is None:
+                    matched[source] = None
+                else:
+                    matched[source] = self.selection[source]
             else:
                 r = ctrl_key_re if source in self.control_sources else key_re
                 keys = set(filter(r.match, self.keys_for_source(source)))

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -617,31 +617,53 @@ class DataCollection:
         res = defaultdict(set)
         if isinstance(selection, dict):
             # {source: {key1, key2}}
-            # {source: {}} -> all keys for this source
-            for source, keys in selection.items():  #
+            # {source: {}} or {source: None} -> all keys for this source
+            for source, in_keys in selection.items():
                 if source not in self.all_sources:
                     raise SourceNameError(source)
 
-                if keys:
-                    # keys may be None, which is allowed as an
-                    # undocumented behaviour to support passing a
-                    # DataCollection as the selector.
+                # Keys of the current DataCollection.
+                cur_keys = self.selection[source]
 
-                    for key in keys:
+                # Keys input as the new selection.
+                if in_keys:
+                    # If a specific set of keys is selected, make sure
+                    # they are all valid.
+                    for key in in_keys:
                         if not self._has_source_key(source, key):
                             raise PropertyNameError(key, source)
-
-                    if self.selection[source] is not None:
-                        # If the current DataCollection also selected
-                        # specific keys, make sure the new keys are a
-                        # subset of it.
-                        res[source].update(keys & self.selection[source])
-                    else:
-                        res[source].update(keys)
-                elif self.selection[source] is not None:
-                    res[source] = self.selection[source]
                 else:
+                    # Catches both an empty set and None.
+                    # While the public API describes an empty set to
+                    # refer to all keys, the internal API actually uses
+                    # None for this case. This method is supposed to
+                    # accept both cases in order to natively support
+                    # passing a DataCollection as the selector. To keep
+                    # the conditions below clearer, any non-True value
+                    # is converted to None.
+                    in_keys = None
+
+                if cur_keys is None and in_keys is None:
+                    # Both the new and current keys select all.
                     res[source] = None
+
+                elif cur_keys is not None and in_keys is not None:
+                    # Both the new and current keys are specific, take
+                    # the intersection of both. This should never be
+                    # able to result in an empty set, but to prevent the
+                    # code further below from breaking, assert it.
+                    res[source] = cur_keys & in_keys
+                    assert res[source]
+
+                elif cur_keys is None and in_keys is not None:
+                    # Current keys are unspecific but new ones are, just
+                    # use the new keys.
+                    res[source] = in_keys
+
+                elif cur_keys is not None and in_keys is None:
+                    # The current keys are specific but new ones are
+                    # not, use the current keys.
+                    res[source] = cur_keys
 
         elif isinstance(selection, Iterable):
             # selection = [('src_glob', 'key_glob'), ...]
@@ -675,6 +697,10 @@ class DataCollection:
                 continue
 
             if key_glob == '*':
+                # When the selection refers to all keys, make sure this
+                # is restricted to the current selection of keys for
+                # this source.
+
                 if self.selection[source] is None:
                     matched[source] = None
                 else:

--- a/extra_data/tests/test_reader_mockdata.py
+++ b/extra_data/tests/test_reader_mockdata.py
@@ -494,6 +494,23 @@ def test_select(mock_fxe_raw_run):
     assert sel_by_dict.keys_for_source('FXE_DET_LPD1M-1/DET/0CH0:xtdf') == \
         sel.keys_for_source('FXE_DET_LPD1M-1/DET/0CH0:xtdf')
 
+    # Re-select using * selection, should yield the same keys.
+    assert sel.keys_for_source('FXE_DET_LPD1M-1/DET/0CH0:xtdf') == \
+        sel.select('FXE_DET_LPD1M-1/DET/0CH0:xtdf', '*') \
+           .keys_for_source('FXE_DET_LPD1M-1/DET/0CH0:xtdf')
+    assert sel.keys_for_source('FXE_DET_LPD1M-1/DET/0CH0:xtdf') == \
+        sel.select({'FXE_DET_LPD1M-1/DET/0CH0:xtdf': {}}) \
+           .keys_for_source('FXE_DET_LPD1M-1/DET/0CH0:xtdf')
+
+    # Re-select a different but originally valid key, should fail.
+    with pytest.raises(ValueError):
+        # ValueError due to globbing.
+        sel.select('FXE_DET_LPD1M-1/DET/0CH0:xtdf', 'image.trainId')
+
+    with pytest.raises(PropertyNameError):
+        # PropertyNameError via explicit key.
+        sel.select({'FXE_DET_LPD1M-1/DET/0CH0:xtdf': {'image.trainId'}})
+
     # Select by another DataCollection.
     sel_by_dc = run.select(sel)
     assert sel_by_dc.control_sources == sel.control_sources

--- a/extra_data/tests/test_reader_mockdata.py
+++ b/extra_data/tests/test_reader_mockdata.py
@@ -476,17 +476,29 @@ def test_select(mock_fxe_raw_run):
 
     assert 'SPB_XTD9_XGM/DOOCS/MAIN' in run.control_sources
 
+    # Basic selection machinery, glob API
     sel = run.select('*/DET/*', 'image.pulseId')
     assert 'SPB_XTD9_XGM/DOOCS/MAIN' not in sel.control_sources
     assert 'FXE_DET_LPD1M-1/DET/0CH0:xtdf' in sel.instrument_sources
     _, data = sel.train_from_id(10000)
     for source, source_data in data.items():
-        print(source)
         assert set(source_data.keys()) == {'image.pulseId', 'metadata'}
 
-    sel2 = run.select(sel)
-    assert 'SPB_XTD9_XGM/DOOCS/MAIN' not in sel2.control_sources
-    assert 'FXE_DET_LPD1M-1/DET/0CH0:xtdf' in sel2.instrument_sources
+    # Basic selection machinery, dict-based API
+    sel_by_dict = run.select({
+        'SA1_XTD2_XGM/DOOCS/MAIN': None,
+        'FXE_DET_LPD1M-1/DET/0CH0:xtdf': {'image.pulseId'}
+    })
+    assert sel_by_dict.control_sources == {'SA1_XTD2_XGM/DOOCS/MAIN'}
+    assert sel_by_dict.instrument_sources == {'FXE_DET_LPD1M-1/DET/0CH0:xtdf'}
+    assert sel_by_dict.keys_for_source('FXE_DET_LPD1M-1/DET/0CH0:xtdf') == \
+        sel.keys_for_source('FXE_DET_LPD1M-1/DET/0CH0:xtdf')
+
+    # Select by another DataCollection.
+    sel_by_dc = run.select(sel)
+    assert sel_by_dc.control_sources == sel.control_sources
+    assert sel_by_dc.instrument_sources == sel.instrument_sources
+    assert sel_by_dc.train_ids == sel.train_ids
 
 
 @pytest.mark.parametrize('select_str',


### PR DESCRIPTION
Fixes #95 by restricting any subsequent key selections to the already selected keys, in particular occuring when re-selecting `*`.

While addressing this issue, I've realized missing checks in the `dict` API of `DataCollection.select`, which I fixed before in addition to adding some tests for it.