### PR TITLE
Try a <= constraint on scipy version in tests

### DIFF
--- a/.github/dependabot/constraints.txt
+++ b/.github/dependabot/constraints.txt
@@ -14,6 +14,6 @@ pyparsing==2.4.7
 python-dateutil==2.8.1
 pytz==2020.5
 pyzmq==21.0.1
-scipy==1.5.4
+scipy<=1.5.4
 six==1.15.0
 xarray==0.16.2


### PR DESCRIPTION
The automatic PR to test with the latest scipy (#119) fails because it pins that specific version, and that's not compatible with Python 3.6. I still want EXtra-data to support 3.6 for a while, because that's what the main Anaconda installation on Maxwell has, and I suspect many people use EXtra-data in that.

So this is an attempt to see if dependabot will still work with a `<=` dependency, as a cheap way of allowing the tests to fall back to older versions as needed by the Python version. If it works, I'll do the same for all dependencies.

cc @RobertRosca 