### PR TITLE
Warn about deprecated get_series() behaviour for some big detector data

### DIFF
--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -472,6 +472,14 @@ class DataCollection:
                     # Does pulse-oriented data always have an extra dimension?
                     assert data.shape[1] == 1
                     data = data[:, 0]
+
+                    warn(
+                        "Getting a series with pulseId labels is deprecated, "
+                        "as it only works in very specific cases. "
+                        "If you still need this, please contact "
+                        "da-support@xfel.eu to discuss it.",
+                        stacklevel=2
+                    )
                 data = data[: len(index)]
 
                 seq_series.append(pd.Series(data, name=name, index=index))


### PR DESCRIPTION
Once we can remove this special case, then `run.get_series()` can become a simple wrapper around `key.series()`, like some of the other `run.get_*` methods. I suspect no-one is relying on this, but if anyone is, hopefully this warning will give us a chance to either rethink it, or suggest alternatives.