### PR TITLE
JUNGFRAU multi-module data access

### DIFF
--- a/docs/agipd_lpd_data.rst
+++ b/docs/agipd_lpd_data.rst
@@ -1,11 +1,21 @@
-AGIPD, LPD & DSSC data
-======================
+Multi-module detector data
+==========================
 
 .. module:: extra_data.components
 
-These data from AGIPD, LPD and DSSC is spread out in separate files.
-``extra_data`` includes convenient interfaces to access this data,
-pulling together the separate modules into a single array.
+Several X-ray pixel detectors are composed of multiple modules, which are
+stored as separate sources at EuXFEL.
+``extra_data`` includes convenient interfaces to access data from AGIPD, LPD,
+DSSC and JUNGFRAU, pulling together the separate modules into a single array.
+
+.. note::
+
+   These detectors can record a lot of data. The ``.get_array()`` method
+   loads all of the selected data into memory, which may not be practical for
+   entire runs. You might need to think about iterating over trains, selecting
+   batches of trains from the run, or using `Dask arrays
+   <https://docs.dask.org/en/latest/array.html>`_.
+
 
 .. autoclass:: AGIPD1M
 
@@ -17,9 +27,9 @@ pulling together the separate modules into a single array.
 
 .. autoclass:: LPD1M
 
-   .. automethod:: get_dask_array
-
    .. automethod:: get_array
+
+   .. automethod:: get_dask_array
 
    .. automethod:: trains
 
@@ -31,10 +41,18 @@ pulling together the separate modules into a single array.
 
    :doc:`lpd_data`: An example using the class above.
 
+.. autoclass:: JUNGFRAU
+
+   .. automethod:: get_array
+
+   .. automethod:: get_dask_array
+
+   .. automethod:: trains
+
 .. autofunction:: identify_multimod_detectors
 
 If you get data for a train from the main :class:`DataCollection` interface,
-there is also another way to combine detector modules from AGIPD or LPD:
+there is also another way to combine detector modules from AGIPD, DSSC or LPD:
 
 .. currentmodule:: extra_data
 

--- a/extra_data/cli/make_virtual_cxi.py
+++ b/extra_data/cli/make_virtual_cxi.py
@@ -7,14 +7,14 @@ import sys
 from textwrap import dedent
 
 from extra_data import RunDirectory
-from extra_data.components import MultimodFastDetectorBase
+from extra_data.components import XtdfDetectorBase
 from extra_data.exceptions import SourceNameError
 
 log = logging.getLogger(__name__)
 
 
 def _get_detector(data, min_modules):
-    for cls in MultimodFastDetectorBase.__subclasses__():
+    for cls in XtdfDetectorBase.__subclasses__():
         try:
             return cls(data, min_modules=min_modules)
         except SourceNameError:
@@ -24,7 +24,7 @@ def _get_detector(data, min_modules):
 def _detectors():
     """returns a list of names for all detector components available
     """
-    return [d.__name__ for d in MultimodFastDetectorBase.__subclasses__()]
+    return [d.__name__ for d in XtdfDetectorBase.__subclasses__()]
 
 
 def parse_number(number:str):

--- a/extra_data/cli/make_virtual_cxi.py
+++ b/extra_data/cli/make_virtual_cxi.py
@@ -7,14 +7,14 @@ import sys
 from textwrap import dedent
 
 from extra_data import RunDirectory
-from extra_data.components import MPxDetectorBase
+from extra_data.components import MultimodFastDetectorBase
 from extra_data.exceptions import SourceNameError
 
 log = logging.getLogger(__name__)
 
 
 def _get_detector(data, min_modules):
-    for cls in MPxDetectorBase.__subclasses__():
+    for cls in MultimodFastDetectorBase.__subclasses__():
         try:
             return cls(data, min_modules=min_modules)
         except SourceNameError:
@@ -24,7 +24,7 @@ def _get_detector(data, min_modules):
 def _detectors():
     """returns a list of names for all detector components available
     """
-    return [d.__name__ for d in MPxDetectorBase.__subclasses__()]
+    return [d.__name__ for d in MultimodFastDetectorBase.__subclasses__()]
 
 
 def parse_number(number:str):

--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -86,6 +86,7 @@ class MPxDetectorBase:
     """
 
     _source_re = re.compile(r'(?P<detname>.+)/DET/(\d+)CH')
+    _main_data_key = 'image.data'  # This is correct for AGIPD/DSSC/LPD
     n_modules = 16
     # Override in subclass
     module_shape = (0, 0)
@@ -107,7 +108,7 @@ class MPxDetectorBase:
         # pandas' missing-data handling converts the data to floats if there
         # are any gaps - so fill them with 0s and convert back to uint64.
         mod_data_counts = pd.DataFrame({
-            src: data.get_data_counts(src, 'image.data')
+            src: data.get_data_counts(src, self._main_data_key)
             for src in source_to_modno
         }).fillna(0).astype(np.uint64)
 
@@ -886,6 +887,7 @@ class JUNGFRAU(MPxDetectorBase):
     _source_re = re.compile(
         r'(?P<detname>.+_(JNGFR|JF4M))/DET/(MODULE_|JNGFR)(?P<modno>\d+)'
     )
+    _main_data_key = 'data.adc'
     module_shape = (512, 1024)
 
 

--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -59,7 +59,6 @@ class MultimodDetectorBase:
     """
 
     _source_re = re.compile(r'(?P<detname>.+)/DET/(\d+)CH')
-    n_modules = 16
     # Override in subclass
     _main_data_key = ''  # Key to use for checking data counts match
     module_shape = (0, 0)
@@ -264,6 +263,7 @@ class MultimodFastDetectorBase(MultimodDetectorBase):
     different number of frames to be stored for each train, which makes
     access more complicated.
     """
+    n_modules = 16
     _main_data_key = 'image.data'
 
     @staticmethod
@@ -850,7 +850,7 @@ class AGIPD1M(MultimodFastDetectorBase):
     ----------
 
     data: DataCollection
-      A data collection, e.g. from RunDirectory.
+      A data collection, e.g. from :func:`.RunDirectory`.
     modules: set of ints, optional
       Detector module numbers to use. By default, all available modules
       are used.
@@ -871,7 +871,7 @@ class DSSC1M(MultimodFastDetectorBase):
     ----------
 
     data: DataCollection
-      A data collection, e.g. from RunDirectory.
+      A data collection, e.g. from :func:`.RunDirectory`.
     modules: set of ints, optional
       Detector module numbers to use. By default, all available modules
       are used.
@@ -892,7 +892,7 @@ class LPD1M(MultimodFastDetectorBase):
     ----------
 
     data: DataCollection
-      A data collection, e.g. from RunDirectory.
+      A data collection, e.g. from :func:`.RunDirectory`.
     modules: set of ints, optional
       Detector module numbers to use. By default, all available modules
       are used.
@@ -955,7 +955,7 @@ class JUNGFRAU(MultimodDetectorBase):
     ----------
 
     data: DataCollection
-      A data collection, e.g. from RunDirectory.
+      A data collection, e.g. from :func:`.RunDirectory`.
     modules: set of ints, optional
       Detector module numbers to use. By default, all available modules
       are used.
@@ -1045,7 +1045,7 @@ class JUNGFRAU(MultimodDetectorBase):
         ------
 
         train_data: dict
-          A dictionary mapping key names (e.g. ``image.data``) to labelled
+          A dictionary mapping key names (e.g. 'data.adc') to labelled
           arrays.
         """
         for tid, d in super().trains(require_all=require_all):

--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -890,6 +890,34 @@ class JUNGFRAU(MPxDetectorBase):
     _main_data_key = 'data.adc'
     module_shape = (512, 1024)
 
+    def get_array(self, key, *, fill_value=None, roi=()):
+        """Get a labelled array of detector data
+
+        Parameters
+        ----------
+
+        key: str
+          The data to get, e.g. 'data.adc' for pixel values.
+        fill_value: int or float, optional
+            Value to use for missing values. If None (default) the fill value
+            is 0 for integers and np.nan for floats.
+        roi: tuple
+          Specify e.g. ``np.s_[:, 10:60, 100:200]`` to select data within each
+          module & each train when reading data. The first dimension is pulses,
+          then there are two pixel dimensions. The same selection is applied
+          to data from each module, so selecting pixels may only make sense if
+          you're using a single module.
+        """
+        arr = super().get_array(key, fill_value=fill_value, roi=roi)
+        arr = arr.rename({'trainId': 'train'})
+        if arr.ndim == 5:
+            arr = arr.rename({
+                'dim_0': 'pulse', 'dim_1': 'slow_scan', 'dim_2': 'fast_scan'
+            })
+        elif arr.ndim == 3:
+            arr = arr.rename({'dim_0': 'pulse'})
+        return arr
+
 
 def identify_multimod_detectors(
         data, detector_name=None, *, single=False, clses=None

--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -918,6 +918,14 @@ class JUNGFRAU(MPxDetectorBase):
             arr = arr.rename({'dim_0': 'pulse'})
         return arr
 
+    def write_virtual_cxi(self, filename, fillvalues=None):
+        raise NotImplementedError("Virtual CXI files not implemented for JUNGFRAU")
+
+    def write_frames(self, filename, trains, pulses):
+        raise NotImplementedError(
+            "Writing selected frames not implemented for JUNGFRAU"
+        )
+
 
 def identify_multimod_detectors(
         data, detector_name=None, *, single=False, clses=None

--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -864,6 +864,27 @@ class LPD1M(MPxDetectorBase):
         )
 
 
+class JUNGFRAU(MPxDetectorBase):
+    """An interface to JUNGFRAU data.
+
+    Parameters
+    ----------
+
+    data: DataCollection
+      A data collection, e.g. from RunDirectory.
+    modules: set of ints, optional
+      Detector module numbers to use. By default, all available modules
+      are used.
+    detector_name: str, optional
+      Name of a detector, e.g. 'SPB_IRDA_JNGFR'. This is only needed
+      if the dataset includes more than one JUNGFRAU detector.
+    min_modules: int
+      Include trains where at least n modules have data. Default is 1.
+    """
+    _source_re = re.compile(r'(?P<detname>(.+)_JNGFR(.*))/DET/MODULE_(\d+)')
+    module_shape = (1024, 512)
+
+
 def identify_multimod_detectors(
         data, detector_name=None, *, single=False, clses=None
 ):

--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -880,12 +880,12 @@ class JUNGFRAU(MPxDetectorBase):
     min_modules: int
       Include trains where at least n modules have data. Default is 1.
     """
-    # We appear to have a couple of different formats for source names:
+    # We appear to have a few different formats for source names:
     # SPB_IRDA_JNGFR/DET/MODULE_1:daqOutput  (e.g. in p 2566, r 61)
     # SPB_IRDA_JF4M/DET/JNGFR03:daqOutput    (e.g. in p 2732, r 12)
-    # This should catch both. We may need to generalise it more in the future.
+    # FXE_XAD_JF1M/DET/RECEIVER-1
     _source_re = re.compile(
-        r'(?P<detname>.+_(JNGFR|JF4M))/DET/(MODULE_|JNGFR)(?P<modno>\d+)'
+        r'(?P<detname>.+_(JNGFR|JF[14]M))/DET/(MODULE_|RECEIVER-|JNGFR)(?P<modno>\d+)'
     )
     _main_data_key = 'data.adc'
     module_shape = (512, 1024)

--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -255,7 +255,7 @@ class MultimodDetectorBase:
         return MPxDetectorTrainIterator(self, require_all=require_all)
 
 
-class MultimodFastDetectorBase(MultimodDetectorBase):
+class XtdfDetectorBase(MultimodDetectorBase):
     """Common machinery for a group of detectors with similar data format
 
     AGIPD, DSSC & LPD all store pulse-resolved data in an "image" group,
@@ -843,7 +843,7 @@ class MPxDetectorTrainIterator:
             yield tid, self._assemble_data(tid)
 
 
-class AGIPD1M(MultimodFastDetectorBase):
+class AGIPD1M(XtdfDetectorBase):
     """An interface to AGIPD-1M data.
 
     Parameters
@@ -864,7 +864,7 @@ class AGIPD1M(MultimodFastDetectorBase):
     module_shape = (512, 128)
 
 
-class DSSC1M(MultimodFastDetectorBase):
+class DSSC1M(XtdfDetectorBase):
     """An interface to DSSC-1M data.
 
     Parameters
@@ -885,7 +885,7 @@ class DSSC1M(MultimodFastDetectorBase):
     module_shape = (128, 512)
 
 
-class LPD1M(MultimodFastDetectorBase):
+class LPD1M(XtdfDetectorBase):
     """An interface to LPD-1M data.
 
     Parameters

--- a/extra_data/export.py
+++ b/extra_data/export.py
@@ -17,7 +17,7 @@ from warnings import warn
 from karabo_bridge import ServerInThread
 from karabo_bridge.server import Sender
 
-from .components import MPxDetectorBase
+from .components import MultimodFastDetectorBase
 from .exceptions import SourceNameError
 from .reader import RunDirectory, H5File
 from .stacking import stack_detector_data
@@ -54,7 +54,7 @@ def _iter_trains(data, merge_detector=False):
     """
     det, source_name = None, ''
     if merge_detector:
-        for detector in MPxDetectorBase.__subclasses__():
+        for detector in MultimodFastDetectorBase.__subclasses__():
             try:
                 det = detector(data)
                 source_name = f'{det.detector_name}/DET/APPEND'

--- a/extra_data/export.py
+++ b/extra_data/export.py
@@ -17,7 +17,7 @@ from warnings import warn
 from karabo_bridge import ServerInThread
 from karabo_bridge.server import Sender
 
-from .components import MultimodFastDetectorBase
+from .components import XtdfDetectorBase
 from .exceptions import SourceNameError
 from .reader import RunDirectory, H5File
 from .stacking import stack_detector_data
@@ -54,7 +54,7 @@ def _iter_trains(data, merge_detector=False):
     """
     det, source_name = None, ''
     if merge_detector:
-        for detector in MultimodFastDetectorBase.__subclasses__():
+        for detector in XtdfDetectorBase.__subclasses__():
             try:
                 det = detector(data)
                 source_name = f'{det.detector_name}/DET/APPEND'

--- a/extra_data/tests/conftest.py
+++ b/extra_data/tests/conftest.py
@@ -94,6 +94,13 @@ def mock_spb_raw_run(format_version):
 
 
 @pytest.fixture(scope='session')
+def mock_jungfrau_run():
+    with TemporaryDirectory() as td:
+        make_examples.make_jungfrau_run(td)
+        yield td
+
+
+@pytest.fixture(scope='session')
 def empty_h5_file():
     with TemporaryDirectory() as td:
         path = osp.join(td, 'empty.h5')

--- a/extra_data/tests/make_examples.py
+++ b/extra_data/tests/make_examples.py
@@ -12,6 +12,9 @@ from .mockdata.detectors import AGIPDModule, LPDModule
 from .mockdata.gauge import Gauge
 from .mockdata.gec_camera import GECCamera
 from .mockdata.imgfel import IMGFELCamera, IMGFELMotor
+from .mockdata.jungfrau import (
+    JUNGFRAUModule, JUNGFRAUControl, JUNGFRAUMonitor, JUNGFRAUPower,
+)
 from .mockdata.motor import Motor
 from .mockdata.mpod import MPOD
 from .mockdata.tsens import TemperatureSensor
@@ -293,6 +296,20 @@ def make_reduced_spb_run(dir_path, raw=True, rng=None, format_version='0.5'):
                  BaslerCam('SPB_IRU_CAM/CAM/SIDEMIC', sensor_size=(1024, 768))
                ], ntrains=32, firsttrain=10032, chunksize=32,
                format_version=format_version)
+
+def make_jungfrau_run(dir_path):
+    # Naming based on /gpfs/exfel/exp/SPB/202022/p002732/raw/r0012
+    for modno in range(1, 9):
+        path = osp.join(dir_path, f'RAW-R0012-JNGFR{modno:02}-S00000.h5')
+        write_file(path, [
+            JUNGFRAUModule(f'SPB_IRDA_JF4M/DET/JNGFR{modno:02}')
+        ], ntrains=100, chunksize=1, format_version='1.0')
+
+    write_file(osp.join(dir_path, f'RAW-R0012-JNGFRCTRL00-S00000.h5'), [
+        JUNGFRAUControl('SPB_IRDA_JF4M/DET/CONTROL'),
+        JUNGFRAUMonitor('SPB_IRDA_JF4M/MDL/MONITOR'),
+        JUNGFRAUPower('SPB_IRDA_JF4M/MDL/POWER'),
+    ], ntrains=100, chunksize=1, format_version='1.0')
 
 if __name__ == '__main__':
     make_agipd_example_file('agipd_example.h5')

--- a/extra_data/tests/mockdata/jungfrau.py
+++ b/extra_data/tests/mockdata/jungfrau.py
@@ -1,0 +1,72 @@
+from .base import DeviceBase
+
+class JUNGFRAUModule(DeviceBase):
+    output_channels = ('daqOutput/data',)
+
+    instrument_keys = [
+        ('adc', 'u2', (16, 512, 1024)),
+        ('frameNumber', 'u8', (16,)),
+        ('gain', 'u1', (16, 512, 1024)),
+        ('memoryCell', 'u1', (16,)),
+        ('timestamp', 'f8', (16,)),
+    ]
+
+class JUNGFRAUControl(DeviceBase):
+    control_keys = [
+        ('acquisitionTime', 'f4', ()),
+        ('angDir', 'i2', (1000,)),
+        ('binSize', 'f4', (1000,)),
+        ('bitDepth', 'i4', ()),
+        ('dataStorage.enable', 'u1', ()),
+        ('dataStorage.fileIndex', 'i4', ()),
+        ('delayAfterTrigger', 'f4', (1000,)),
+        ('detectorHostPort', 'u2', (1000,)),
+        ('detectorHostStopPort', 'u2', (1000,)),
+        ('exposurePeriod', 'f4', ()),
+        ('exposureTime', 'f4', ()),
+        ('exposureTimeout', 'u4', ()),
+        ('exposureTimer', 'u2', ()),
+        ('globalOff', 'f4', (1000,)),
+        ('heartbeatInterval', 'i4', ()),
+        ('lock', 'i2', (1000,)),
+        ('master', 'i2', ()),
+        ('maximumDetectorSize', 'i4', (1000,)),
+        ('moveFlag', 'i2', (1000,)),
+        ('numberOfCycles', 'i8', ()),
+        ('numberOfFrames', 'i8', ()),
+        ('numberOfGates', 'i8', ()),
+        ('online', 'i2', (1000,)),
+        ('performanceStatistics.enable', 'u1', ()),
+        ('performanceStatistics.maxEventLoopLatency', 'u4', ()),
+        ('performanceStatistics.maxProcessingLatency', 'u4', ()),
+        ('performanceStatistics.messagingProblems', 'u1', ()),
+        ('performanceStatistics.numMessages', 'u4', ()),
+        ('performanceStatistics.processingLatency', 'f4', ()),
+        ('pollingInterval', 'u4', ()),
+        ('progress', 'i4', ()),
+        ('rOnline', 'i2', ()),
+        ('rxTcpPort', 'u2', (1000,)),
+        ('rxUdpPort', 'u2', (1000,)),
+        ('rxUdpSocketSize', 'u4', ()),
+        ('storageCellStart', 'i2', ()),
+        ('storageCells', 'i2', ()),
+        ('threaded', 'i2', ()),
+        ('triggerPeriod', 'f4', ()),
+        ('vHighVoltage', 'u4', (1000,)),
+        ('vHighVoltageMax', 'u4', ()),
+    ]
+
+class JUNGFRAUMonitor(DeviceBase):
+    control_keys = sum(([
+        (f'module{n}.adcTemperature', 'f8', ()),
+        (f'module{n}.fpgaTemperature', 'f8', ()),
+    ] for n in range(1, 9)), [])
+
+class JUNGFRAUPower(DeviceBase):
+    control_keys = [
+        ('current', 'f8', ()),
+        ('pollingInterval', 'f8', ()),
+        ('port', 'u2', ()),
+        ('temperature', 'f8', ()),
+        ('voltage', 'f8', ()),
+    ]

--- a/extra_data/tests/test_components.py
+++ b/extra_data/tests/test_components.py
@@ -277,6 +277,16 @@ def test_iterate_lpd_parallel_gain(mock_lpd_parallelgain_run):
            ('module', 'train', 'gain', 'pulse', 'slow_scan', 'fast_scan')
 
 
+def test_iterate_jungfrau(mock_jungfrau_run):
+    run = RunDirectory(mock_jungfrau_run)
+    jf = JUNGFRAU(run)
+
+    tid, d = next(iter(jf.trains()))
+    assert tid == 10000
+    assert d['data.adc'].shape == (8, 16, 512, 1024)
+    assert d['data.adc'].dims == ('module', 'pulse', 'slow_scan', 'fast_scan')
+
+
 def test_write_virtual_cxi(mock_spb_proc_run, tmpdir):
     run = RunDirectory(mock_spb_proc_run)
     det = AGIPD1M(run)

--- a/extra_data/tests/test_components.py
+++ b/extra_data/tests/test_components.py
@@ -160,7 +160,6 @@ def test_get_array_jungfrau(mock_jungfrau_run):
     arr = jf.get_array('data.adc')
     assert arr.shape == (8, 2, 16, 512, 1024)
     assert arr.dims == ('module', 'train', 'pulse', 'slow_scan', 'fast_scan')
-    print(arr.dims)
     np.testing.assert_array_equal(arr.coords['train'], [10000, 10001])
 
 
@@ -206,6 +205,17 @@ def test_get_dask_array_lpd_parallelgain(mock_lpd_parallelgain_run):
     assert arr.shape == (16, 2 * 3 * 100, 1, 256, 256)
     assert arr.dims[:2] == ('module', 'train_pulse')
     np.testing.assert_array_equal(arr.coords['pulseId'], np.tile(np.arange(100), 6))
+
+
+def test_get_dask_array_jungfrau(mock_jungfrau_run):
+    run = RunDirectory(mock_jungfrau_run)
+    jf = JUNGFRAU(run)
+    assert jf.detector_name == 'SPB_IRDA_JF4M'
+
+    arr = jf.get_dask_array('data.adc')
+    assert arr.shape == (8, 100, 16, 512, 1024)
+    assert arr.dims == ('module', 'train', 'pulse', 'slow_scan', 'fast_scan')
+    np.testing.assert_array_equal(arr.coords['train'], np.arange(10000, 10100))
 
 
 def test_iterate(mock_fxe_raw_run):

--- a/extra_data/tests/test_components.py
+++ b/extra_data/tests/test_components.py
@@ -159,8 +159,9 @@ def test_get_array_jungfrau(mock_jungfrau_run):
 
     arr = jf.get_array('data.adc')
     assert arr.shape == (8, 2, 16, 512, 1024)
+    assert arr.dims == ('module', 'train', 'pulse', 'slow_scan', 'fast_scan')
     print(arr.dims)
-    np.testing.assert_array_equal(arr.coords['trainId'], [10000, 10001])
+    np.testing.assert_array_equal(arr.coords['train'], [10000, 10001])
 
 
 def test_get_dask_array(mock_fxe_raw_run):

--- a/extra_data/tests/test_components.py
+++ b/extra_data/tests/test_components.py
@@ -6,7 +6,9 @@ import pytest
 from testpath import assert_isfile
 
 from extra_data.reader import RunDirectory, H5File, by_id, by_index
-from extra_data.components import AGIPD1M, LPD1M, identify_multimod_detectors
+from extra_data.components import (
+    AGIPD1M, LPD1M, JUNGFRAU, identify_multimod_detectors,
+)
 
 
 def test_get_array(mock_fxe_raw_run):
@@ -148,6 +150,17 @@ def test_get_array_lpd_parallelgain(mock_lpd_parallelgain_run):
     assert arr.dims == ('module', 'train', 'gain', 'pulse', 'slow_scan', 'fast_scan')
     np.testing.assert_array_equal(arr.coords['gain'], np.arange(3))
     np.testing.assert_array_equal(arr.coords['pulse'], np.arange(100))
+
+
+def test_get_array_jungfrau(mock_jungfrau_run):
+    run = RunDirectory(mock_jungfrau_run)
+    jf = JUNGFRAU(run.select_trains(by_index[:2]))
+    assert jf.detector_name == 'SPB_IRDA_JF4M'
+
+    arr = jf.get_array('data.adc')
+    assert arr.shape == (8, 2, 16, 512, 1024)
+    print(arr.dims)
+    np.testing.assert_array_equal(arr.coords['trainId'], [10000, 10001])
 
 
 def test_get_dask_array(mock_fxe_raw_run):


### PR DESCRIPTION
This enables things like this:

```python
jf = JUNGFRAU(run.select_trains(np.s_[:10]))
jf.get_array('data.adc')
```

Virtual CXI files and writing selected frames aren't included. I'm not sure if writing selected frames can ever really be done with the current data format, as it doesn't really allow storing a different number of frames from train to train.

I'd like to refactor this at some point, because currently the base class provides the extra functionality for selecting pulses on AGIPD/DSSC/LPD, which the JUNGFRAU data doesn't need. However, that complexity only kicks in for keys starting with `image.`, which JUNGFRAU doesn't have, so it's not a big practical problem.

cc @dallanto 