### PR TITLE
Add parameters to let stack_detector_data work for JUNGFRAU

### DIFF
--- a/extra_data/stacking.py
+++ b/extra_data/stacking.py
@@ -55,7 +55,7 @@ def stack_data(train, data, axis=-3, xcept=()):
 
 def stack_detector_data(
         train, data, axis=-3, modules=16, fillvalue=None, real_array=True, *,
-        pattern=r'/DET/(\d+)CH', startsat1=False,
+        pattern=r'/DET/(\d+)CH', starts_at=0,
 ):
     """Stack data from detector modules in a train.
 
@@ -79,10 +79,12 @@ def stack_detector_data(
         using detector geometry, and allows better performance.
     pattern: str
         Regex to find the module number in source names. Should contain a group
-        which can be converted to an integer.
-    startsat1: bool
-        If False (by default), module numbers start at 0, and module 0 will be
-        inserted if it is missing. If True, module numbers start at 1.
+        which can be converted to an integer. E.g. ``r'/DET/JNGFR(\\d+)'`` for
+        one JUNGFRAU naming convention.
+    starts_at: int
+        By default, uses module numbers starting at 0 (e.g. 0-15 inclusive).
+        If the numbering is e.g. 1-16 instead, pass starts_at=1. This is not
+        automatic because the first or last module may be missing from the data.
 
     Returns
     -------
@@ -99,7 +101,7 @@ def stack_detector_data(
         det_mod_match = re.search(pattern, src)
         if not det_mod_match:
             raise ValueError(f"Source {src!r} doesn't match pattern {pattern!r}")
-        modno = int(det_mod_match.group(1)) - int(startsat1)
+        modno = int(det_mod_match.group(1)) - starts_at
 
         try:
             array = train[src][data]

--- a/extra_data/tests/test_stacking.py
+++ b/extra_data/tests/test_stacking.py
@@ -137,6 +137,17 @@ def test_stack_detector_data_extra_mods(mock_fxe_raw_run):
         comb = stack_detector_data(data, 'image.data')
     assert "16" in str(excinfo.value)
 
+
+def test_stack_detector_data_jungfrau(mock_jungfrau_run):
+    run = RunDirectory(mock_jungfrau_run)
+    _, data = run.select('*JF4M/DET/*', 'data.adc').train_from_index(0)
+
+    comb = stack_detector_data(
+        data, 'data.adc', modules=8, pattern=r'/DET/JNGFR(\d+)', startsat1=True
+    )
+    assert comb.shape == (16, 8, 512, 1024)
+
+
 def test_stackview_squeeze():
     # Squeeze not dropping stacking dim
     data = {0: np.zeros((1, 4)), 1: np.zeros((1, 4))}

--- a/extra_data/tests/test_stacking.py
+++ b/extra_data/tests/test_stacking.py
@@ -143,7 +143,7 @@ def test_stack_detector_data_jungfrau(mock_jungfrau_run):
     _, data = run.select('*JF4M/DET/*', 'data.adc').train_from_index(0)
 
     comb = stack_detector_data(
-        data, 'data.adc', modules=8, pattern=r'/DET/JNGFR(\d+)', startsat1=True
+        data, 'data.adc', modules=8, pattern=r'/DET/JNGFR(\d+)', starts_at=1
     )
     assert comb.shape == (16, 8, 512, 1024)
 


### PR DESCRIPTION
From the test, these are the parameters you need:

```python
_, data = run.select('*JF4M/DET/*', 'data.adc').train_from_index(0)

comb = stack_detector_data(
    data, 'data.adc', modules=8, pattern=r'/DET/JNGFR(\d+)', startsat1=True
)
```

The JUNGFRAU data access class from PR #139 is maybe a bit more convenient, because it doesn't need so many non-default parameters.

cc @dallanto 