### PR TITLE
Scipy is not a dependency

### DIFF
--- a/.github/dependabot/constraints.txt
+++ b/.github/dependabot/constraints.txt
@@ -14,6 +14,5 @@ pyparsing==2.4.7
 python-dateutil==2.8.1
 pytz==2021.1
 pyzmq==22.0.3
-scipy<1.6.1
 six==1.15.0
 xarray==0.16.2

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,6 @@ setup(name="EXtra-data",
           'numpy',
           'pandas',
           'psutil',
-          'scipy',
           'xarray',
       ],
       extras_require={


### PR DESCRIPTION
I think this was left over from karabo_data, when geometry was part of the same package.