### PR TITLE
Slurm is not all-caps

### DIFF
--- a/docs/dask_averaging.ipynb
+++ b/docs/dask_averaging.ipynb
@@ -75,7 +75,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Submit 2 SLURM jobs, for 32 Dask workers\n",
+    "# Submit 2 Slurm jobs, for 32 Dask workers\n",
     "cluster.scale(32)"
    ]
   },

--- a/docs/parallel_example.ipynb
+++ b/docs/parallel_example.ipynb
@@ -246,9 +246,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Using SLURM\n",
+    "## Using Slurm\n",
     "\n",
-    "What if we need more power? The example above is limited to one machine, but we can use SLURM to spread the work over multiple machines on the [Maxwell cluster](https://confluence.desy.de/display/IS/Maxwell).\n",
+    "What if we need more power? The example above is limited to one machine, but we can use Slurm to spread the work over multiple machines on the [Maxwell cluster](https://confluence.desy.de/display/IS/Maxwell).\n",
     "\n",
     "This is massive overkill for this example calculation - we'll only use one CPU core for a fraction of a second on each machine. But we could do something similar for a much bigger problem."
    ]


### PR DESCRIPTION
I always want to type SLURM, but it's Slurm. [Wikipedia says](https://en.wikipedia.org/wiki/Slurm_Workload_Manager) it used to be an acronym (Simple Linux Utility for Resource Management), but now it's just a name, and [the docs](https://slurm.schedmd.com/) spell it Slurm.