### PR TITLE
Add architecture doc

### DIFF
--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -1,0 +1,57 @@
+Architecture
+============
+
+.. note::
+
+   This page describes technical details about EXtra-data. You shouldn't need
+   this information to use it.
+
+Objects
+-------
+
+The :class:`DataCollection` class is the central piece of EXtra-data. It
+represents a collection of XFEL data sources and their keys, for a set of train
+IDs. It refers to data in one or more files (a run directory is often the
+starting point). A subset of its sources/keys or train IDs may be selected to
+make a new, more restricted :class:`DataCollection`.
+
+:class:`KeyData` represents data for a single source & key, selected from a
+``DataCollection`` like ``run[source, key]``. This data may still be spread
+across several files. The data can be loaded into a NumPy array, among other
+types.
+
+:class:`FileAccess` manages access to a single EuXFEL format HDF5 file,
+including caching index information. There should only be one ``FileAccess``
+object per file on disk, even if multiple ``DataCollection`` and ``KeyData``
+objects refer to it.
+
+Modules
+-------
+
+- ``exceptions`` defines some custom error classes.
+- ``file_access`` contains :class:`FileAccess` (described above), along with
+  machinery to keep the number of open files under a limit.
+- ``locality`` can check whether files are available on disk or on tape,
+  and is specific to EuXFEL & DESY infrastructure.
+- ``read_machinery`` is a collection of pieces that support ``reader``.
+- ``reader`` contains :class:`DataCollection` (described above), and functions
+  to open a run or a file.
+- ``run_files_map`` manages caching metadata about the files of a run in a
+  JSON file, to speed up opening the run.
+- ``validation`` checks if files & runs have the expected format, for the
+  :ref:`cmd-validate` command.
+- ``keydata`` contains :class:`KeyData` (described above).
+- ``components`` provides interfaces that bring together data from several
+  similar sources, i.e. multi-module detectors where each module is a separate
+  source.
+- ``stacking`` has functions for stacking multiple arrays into one, another
+  option for working with multi-module detector data.
+- ``writer`` writes data in EuXFEL format files, for
+  :meth:`~.DataCollection.write` and :meth:`~.DataCollection.write_virtual`.
+- ``write_cxi`` makes CXI format HDF5 files using virtual datasets to
+  expose multi-module detector data. Used by :meth:`~.LPD1M.write_virtual_cxi`
+  and the :ref:`cmd-make-virtual-cxi` command.
+- ``export`` sends data from files over ZMQ in the Karabo Bridge format.
+- ``lsxfel`` is the :ref:`cmd-lsxfel` command.
+- ``utils`` is miscellaneous pieces that don't fit anywhere else.
+- ``h5index`` lists datasets in an HDF5 file. Deprecated.

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -28,30 +28,32 @@ objects refer to it.
 Modules
 -------
 
-- ``exceptions`` defines some custom error classes.
-- ``file_access`` contains :class:`.FileAccess` (described above), along with
-  machinery to keep the number of open files under a limit.
-- ``locality`` can check whether files are available on disk or on tape
-  in a `dCache <https://www.dcache.org/>`_ filesystem.
-- ``read_machinery`` is a collection of pieces that support ``reader``.
-- ``reader`` contains :class:`.DataCollection` (described above), and functions
-  to open a run or a file.
-- ``run_files_map`` manages caching metadata about the files of a run in a
-  JSON file, to speed up opening the run.
-- ``validation`` checks if files & runs have the expected format, for the
-  :ref:`cmd-validate` command.
-- ``keydata`` contains :class:`.KeyData` (described above).
+- ``cli`` contains command-line interfaces (so far only
+  :ref:`cmd-make-virtual-cxi`).
 - ``components`` provides interfaces that bring together data from several
   similar sources, i.e. multi-module detectors where each module is a separate
   source.
+- ``exceptions`` defines some custom error classes.
+- ``export`` sends data from files over ZMQ in the Karabo Bridge format.
+- ``file_access`` contains :class:`.FileAccess` (described above), along with
+  machinery to keep the number of open files under a limit.
+- ``h5index`` lists datasets in an HDF5 file. Deprecated.
+- ``keydata`` contains :class:`.KeyData` (described above).
+- ``locality`` can check whether files are available on disk or on tape
+  in a `dCache <https://www.dcache.org/>`_ filesystem.
+- ``lsxfel`` is the :ref:`cmd-lsxfel` command.
+- ``reader`` contains :class:`.DataCollection` (described above), and functions
+  to open a run or a file.
+- ``read_machinery`` is a collection of pieces that support ``reader``.
+- ``run_files_map`` manages caching metadata about the files of a run in a
+  JSON file, to speed up opening the run.
 - ``stacking`` has functions for stacking multiple arrays into one, another
   option for working with multi-module detector data.
+- ``utils`` is miscellaneous pieces that don't fit anywhere else.
+- ``validation`` checks if files & runs have the expected format, for the
+  :ref:`cmd-validate` command.
 - ``writer`` writes data in EuXFEL format files, for
   :meth:`~.DataCollection.write` and :meth:`~.DataCollection.write_virtual`.
 - ``write_cxi`` makes CXI format HDF5 files using virtual datasets to
   expose multi-module detector data. Used by :meth:`~.LPD1M.write_virtual_cxi`
   and the :ref:`cmd-make-virtual-cxi` command.
-- ``export`` sends data from files over ZMQ in the Karabo Bridge format.
-- ``lsxfel`` is the :ref:`cmd-lsxfel` command.
-- ``utils`` is miscellaneous pieces that don't fit anywhere else.
-- ``h5index`` lists datasets in an HDF5 file. Deprecated.

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -31,8 +31,8 @@ Modules
 - ``exceptions`` defines some custom error classes.
 - ``file_access`` contains :class:`.FileAccess` (described above), along with
   machinery to keep the number of open files under a limit.
-- ``locality`` can check whether files are available on disk or on tape,
-  and is specific to EuXFEL & DESY infrastructure.
+- ``locality`` can check whether files are available on disk or on tape
+  in a `dCache <https://www.dcache.org/>`_ filesystem.
 - ``read_machinery`` is a collection of pieces that support ``reader``.
 - ``reader`` contains :class:`.DataCollection` (described above), and functions
   to open a run or a file.

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -9,18 +9,18 @@ Architecture
 Objects
 -------
 
-The :class:`DataCollection` class is the central piece of EXtra-data. It
+The :class:`.DataCollection` class is the central piece of EXtra-data. It
 represents a collection of XFEL data sources and their keys, for a set of train
 IDs. It refers to data in one or more files (a run directory is often the
 starting point). A subset of its sources/keys or train IDs may be selected to
-make a new, more restricted :class:`DataCollection`.
+make a new, more restricted :class:`.DataCollection`.
 
-:class:`KeyData` represents data for a single source & key, selected from a
+:class:`.KeyData` represents data for a single source & key, selected from a
 ``DataCollection`` like ``run[source, key]``. This data may still be spread
 across several files. The data can be loaded into a NumPy array, among other
 types.
 
-:class:`FileAccess` manages access to a single EuXFEL format HDF5 file,
+:class:`.FileAccess` manages access to a single EuXFEL format HDF5 file,
 including caching index information. There should only be one ``FileAccess``
 object per file on disk, even if multiple ``DataCollection`` and ``KeyData``
 objects refer to it.
@@ -29,18 +29,18 @@ Modules
 -------
 
 - ``exceptions`` defines some custom error classes.
-- ``file_access`` contains :class:`FileAccess` (described above), along with
+- ``file_access`` contains :class:`.FileAccess` (described above), along with
   machinery to keep the number of open files under a limit.
 - ``locality`` can check whether files are available on disk or on tape,
   and is specific to EuXFEL & DESY infrastructure.
 - ``read_machinery`` is a collection of pieces that support ``reader``.
-- ``reader`` contains :class:`DataCollection` (described above), and functions
+- ``reader`` contains :class:`.DataCollection` (described above), and functions
   to open a run or a file.
 - ``run_files_map`` manages caching metadata about the files of a run in a
   JSON file, to speed up opening the run.
 - ``validation`` checks if files & runs have the expected format, for the
   :ref:`cmd-validate` command.
-- ``keydata`` contains :class:`KeyData` (described above).
+- ``keydata`` contains :class:`.KeyData` (described above).
 - ``components`` provides interfaces that bring together data from several
   similar sources, i.e. multi-module detectors where each module is a separate
   source.

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -30,6 +30,7 @@ file:
 
    This option can make ``lsxfel`` considerably slower.
 
+.. _cmd-validate:
 
 ``extra-data-validate``
 ------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -94,6 +94,7 @@ Documentation contents
    :maxdepth: 1
 
    changelog
+   architecture
 
 .. seealso::
 


### PR DESCRIPTION
Based on the reasoning of [this blog post](https://matklad.github.io//2021/02/06/ARCHITECTURE.md.html). I've chosen
to do this as part of the docs rather than a standalone markdown file, though that's up for discussion if someone thinks a separate file is better.