### PR TITLE
Fix detector get_array with ROI

### DIFF
--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -409,9 +409,11 @@ class XtdfDetectorBase(MultimodDetectorBase):
                 if dset.ndim >= 2 and dset.shape[1] == 1:
                     # Ensure ROI applies to pixel dimensions, not the extra
                     # dim in raw data (except AGIPD, where it is data/gain)
-                    roi = np.index_exp[:] + roi
+                    sel_args = (data_positions, np.s_[:]) + roi
+                else:
+                    sel_args = (data_positions,) + roi
 
-                data = f.file[data_path][(data_positions,) + roi]
+                data = f.file[data_path][sel_args]
 
                 arr = self._guess_axes(data, index, unstack_pulses)
 

--- a/extra_data/tests/conftest.py
+++ b/extra_data/tests/conftest.py
@@ -101,6 +101,13 @@ def mock_jungfrau_run():
 
 
 @pytest.fixture(scope='session')
+def mock_scs_run():
+    with TemporaryDirectory() as td:
+        make_examples.make_scs_run(td)
+        yield td
+
+
+@pytest.fixture(scope='session')
 def empty_h5_file():
     with TemporaryDirectory() as td:
         path = osp.join(td, 'empty.h5')

--- a/extra_data/tests/make_examples.py
+++ b/extra_data/tests/make_examples.py
@@ -8,7 +8,7 @@ from .mockdata.adc import ADC
 from .mockdata.base import write_base_index
 from .mockdata.basler_camera import BaslerCamera as BaslerCam
 from .mockdata.dctrl import DCtrl
-from .mockdata.detectors import AGIPDModule, LPDModule
+from .mockdata.detectors import AGIPDModule, DSSCModule, LPDModule
 from .mockdata.gauge import Gauge
 from .mockdata.gec_camera import GECCamera
 from .mockdata.imgfel import IMGFELCamera, IMGFELMotor
@@ -310,6 +310,15 @@ def make_jungfrau_run(dir_path):
         JUNGFRAUMonitor('SPB_IRDA_JF4M/MDL/MONITOR'),
         JUNGFRAUPower('SPB_IRDA_JF4M/MDL/POWER'),
     ], ntrains=100, chunksize=1, format_version='1.0')
+
+def make_scs_run(dir_path):
+    # Multiple sequence files for detector modules
+    for modno in range(16):
+        mod = DSSCModule(f'SCS_DET_DSSC1M-1/DET/{modno}CH0', frames_per_train=64)
+        for seq in range(2):
+            path = osp.join(dir_path, f'RAW-R0163-DSSC{modno:0>2}-S{seq:0>5}.h5')
+            write_file(path, [mod], ntrains=64, firsttrain=(10000 + seq * 64),
+                       chunksize=32, format_version='1.0')
 
 if __name__ == '__main__':
     make_agipd_example_file('agipd_example.h5')

--- a/extra_data/tests/mockdata/detectors.py
+++ b/extra_data/tests/mockdata/detectors.py
@@ -161,3 +161,7 @@ class AGIPDModule(DetectorModule):
 class LPDModule(DetectorModule):
     image_dims = (1, 256, 256)
     detector_data_size = 416
+
+class DSSCModule(DetectorModule):
+    image_dims = (1, 128, 512)
+    detector_data_size = 416

--- a/extra_data/tests/test_components.py
+++ b/extra_data/tests/test_components.py
@@ -7,7 +7,7 @@ from testpath import assert_isfile
 
 from extra_data.reader import RunDirectory, H5File, by_id, by_index
 from extra_data.components import (
-    AGIPD1M, LPD1M, JUNGFRAU, identify_multimod_detectors,
+    AGIPD1M, DSSC1M, LPD1M, JUNGFRAU, identify_multimod_detectors,
 )
 
 
@@ -142,6 +142,14 @@ def test_get_array_roi(mock_fxe_raw_run):
     arr = det.get_array('image.data', roi=np.s_[10:60, 100:200])
     assert arr.shape == (16, 3, 128, 50, 100)
     assert arr.dims == ('module', 'train', 'pulse', 'slow_scan', 'fast_scan')
+
+
+def test_get_array_roi_dssc(mock_scs_run):
+    run = RunDirectory(mock_scs_run)
+    det = DSSC1M(run, modules=[3])
+
+    arr = det.get_array('image.data', roi=np.s_[20:25, 40:52])
+    assert arr.shape == (1, 128, 64, 5, 12)
 
 
 def test_get_array_lpd_parallelgain(mock_lpd_parallelgain_run):


### PR DESCRIPTION
Raw xtdf detector (AGIPD/DSSC/LPD) data has an extra dimension which is only used for AGIPD. `det.get_array()` checks for this and shifts the specified ROI so it applies the pixel dimensions, not the meaningless length=1 dimension.

However, we were doing this shift inside a loop, so each data chunk (typically a sequence file) would add another dimension to the ROI, and before long we'd be trying to select a 4D array on 5 dimensions, causing an error. This fixes that.

We missed this because the tests for this bit of code only used a single sequence file. I've added a test with 2 sequence files per DSSC module, which failed before this change.