### PR TITLE
Create smaller files when testing writing selected frames

### DIFF
--- a/extra_data/tests/test_components.py
+++ b/extra_data/tests/test_components.py
@@ -381,9 +381,9 @@ def test_write_selected_frames(mock_spb_raw_run, tmp_path):
     run = RunDirectory(mock_spb_raw_run)
     det = AGIPD1M(run)
 
-    trains = np.repeat(np.arange(10000, 10010), 3)
-    pulses = np.tile([0, 1, 5], 10)
-    test_file = str(tmp_path / 'sel_frames.h5')
+    trains = np.repeat(np.arange(10000, 10006), 2)
+    pulses = np.tile([0, 5], 6)
+    test_file = tmp_path / 'sel_frames.h5'
     det.write_frames(test_file, trains, pulses)
     assert_isfile(test_file)
 
@@ -396,14 +396,18 @@ def test_write_selected_frames(mock_spb_raw_run, tmp_path):
             f'SPB_DET_AGIPD1M-1/DET/{i}CH0:xtdf' for i in range(16)
         }
 
+    # pytest leaves temp files for inspection, but these files are big enough
+    # to be inconvenient, so delete them if the assertions have passed.
+    test_file.unlink()
+
 
 def test_write_selected_frames_proc(mock_spb_proc_run, tmp_path):
     run = RunDirectory(mock_spb_proc_run)
     det = AGIPD1M(run)
 
-    trains = np.repeat(np.arange(10000, 10010), 3)
-    pulses = np.tile([0, 1, 5], 10)
-    test_file = str(tmp_path / 'sel_frames.h5')
+    trains = np.repeat(np.arange(10000, 10006), 2)
+    pulses = np.tile([0, 7], 6)
+    test_file = tmp_path / 'sel_frames.h5'
     det.write_frames(test_file, trains, pulses)
     assert_isfile(test_file)
 
@@ -416,6 +420,9 @@ def test_write_selected_frames_proc(mock_spb_proc_run, tmp_path):
             f'SPB_DET_AGIPD1M-1/DET/{i}CH0:xtdf' for i in range(16)
         }
 
+    # pytest leaves temp files for inspection, but these files are big enough
+    # to be inconvenient, so delete them if the assertions have passed.
+    test_file.unlink()
 
 def test_identify_multimod_detectors(mock_fxe_raw_run):
     run = RunDirectory(mock_fxe_raw_run)


### PR DESCRIPTION
And delete them when the test passes. This reduces the disk space required to run tests, and dramatically reduces the size of the temp files hanging around after running the tests.