### PR TITLE
Fix float train IDs when require_all is used during select

### DIFF
--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -759,7 +759,8 @@ class DataCollection:
                     groups = ['']
 
                 for group in groups:
-                    source_tids = []
+                    # Empty list would be converted to np.float64 array.
+                    source_tids = np.empty(0, dtype=np.uint64)
 
                     for f in self._source_index[source]:
                         # Add the trains with data in each file.
@@ -774,6 +775,8 @@ class DataCollection:
             # Filtering may have eliminated previously selected files.
             files = [f for f in files
                      if np.intersect1d(f.train_ids, train_ids).size > 0]
+
+            train_ids = list(train_ids)  # Convert back to a list.
 
         else:
             train_ids = self.train_ids

--- a/extra_data/tests/test_reader_mockdata.py
+++ b/extra_data/tests/test_reader_mockdata.py
@@ -530,6 +530,11 @@ def test_select_require_all(mock_sa3_control_data, select_str):
     subrun = run.select(select_str, require_all=True)
     np.testing.assert_array_equal(subrun.train_ids, run.train_ids[1::2])
 
+    # The train IDs are held by ndarrays during this operation, make
+    # sure it's a list of np.uint64 again.
+    assert isinstance(subrun.train_ids, list)
+    assert all([isinstance(x, np.uint64) for x in subrun.train_ids])
+
 
 def test_deselect(mock_fxe_raw_run):
     run = RunDirectory(mock_fxe_raw_run)


### PR DESCRIPTION
By chance, I stumbled upon a bug I introduced with #113. Turns out, the implicit conversion of a list passed to `np.union1d` yields an array with type `np.float64`, causing all train IDs to become float. This PR fixes this by starting with an empty `uint64` array instead.

Also, I added a conversion back into list, as `DataCollection.train_ids` is typically one.