### PR TITLE
Display structured data types in lsxfel

### DIFF
--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -956,7 +956,7 @@ class DataCollection:
                 else:
                     entry_info = ""
                 dt = self.get_dtype(s, k)
-                print(f"{prefix}{k}\t[{dt.name}{entry_info}]")
+                print(f"{prefix}{k}\t[{dt}{entry_info}]")
 
         non_detector_inst_srcs = self.instrument_sources - self.detector_sources
         print(len(non_detector_inst_srcs), 'instrument sources (excluding detectors):')


### PR DESCRIPTION
`lsxfel` currently displays `np.dtype.name` when running with `--detail`, which returns `voidN` with byte size `N` for structure data types. This PR changes this to use `np.dtype.__str__` instead, which in turn displays the struct's members.

### Before:
```
1 instrument sources (excluding detectors):
  - SQS_REMI_DLD6/DET/TOP:output
    - rec:
      data for 34113 trains (100.00%), up to 70 entries per train
      - rec.hits        [void224, entry shape (50,)]
      - rec.signals     [void448, entry shape (50,)]
```

### After:
```
1 instrument sources (excluding detectors):
  - SQS_REMI_DLD6/DET/TOP:output
    - rec:
      data for 5000 trains (100.00%), up to 70 entries per train
      - rec.hits        [[('x', '<f8'), ('y', '<f8'), ('t', '<f8'), ('method', '<i4')], entry shape (50,)]
      - rec.signals     [[('u1', '<f8'), ('u2', '<f8'), ('v1', '<f8'), ('v2', '<f8'), ('w1', '<f8'), ('w2', '<f8'), ('mcp', '<f8')], entry shape (50,)]
```

I've tested it against several run files lying around and all primitive types are printed as before, also:
```python
for type_ in [int, float, np.float64, np.uint8]:
    assert str(np.dtype(type_)) == np.dtype(type_).name
```
There is a difference for strings/bytes, namely:
```python
str(np.dtype('S10')) == '|S10'
np.dtype('S10') == 'bytes80'
```
Frankly I'd prefer the first one...