### PR TITLE
Method to get RUN values

### DIFF
--- a/docs/reading_files.rst
+++ b/docs/reading_files.rst
@@ -128,9 +128,9 @@ below, e.g.::
    .. automethod:: select_trains
 
 The run or file object (a :class:`DataCollection`) also has methods to load
-data by sources and keys. Some of them are directly equivalent to the options
-above, but :meth:`.get_dataframe` and :meth:`.get_virtual_dataset` offer extra
-capabilities.
+data by sources and keys. :meth:`get_array`, :meth:`get_dask_array` and
+:meth:`get_series` are directly equivalent to the options above, but other
+methods offer extra capabilities.
 
 .. class:: DataCollection
    :noindex:
@@ -157,6 +157,10 @@ capabilities.
 
       .. seealso::
         :doc:`parallel_example`
+
+   .. automethod:: get_run_value
+
+      .. versionadded:: 1.5
 
 .. _data-by-train:
 

--- a/docs/reading_files.rst
+++ b/docs/reading_files.rst
@@ -160,7 +160,11 @@ methods offer extra capabilities.
 
    .. automethod:: get_run_value
 
-      .. versionadded:: 1.5
+      .. versionadded:: 1.6
+
+   .. automethod:: get_run_values
+
+      .. versionadded:: 1.6
 
 .. _data-by-train:
 

--- a/extra_data/__init__.py
+++ b/extra_data/__init__.py
@@ -36,6 +36,9 @@ program. If not, see <https://opensource.org/licenses/BSD-3-Clause>
 __version__ = "1.4.1"
 
 
+from .exceptions import (
+    SourceNameError, PropertyNameError, TrainIDError, MultiRunError
+)
 from .keydata import KeyData
 from .reader import *
 from .stacking import *

--- a/extra_data/exceptions.py
+++ b/extra_data/exceptions.py
@@ -27,3 +27,13 @@ class TrainIDError(KeyError):
 
     def __str__(self):
         return "Train ID {!r} not found in this data".format(self.train_id)
+
+
+class MultiRunError(ValueError):
+    def __str__(self):
+        return (
+            "The requested data is only available for a single run. This "
+            "EXtra-data DataCollection may have data from multiple runs, e.g. "
+            "because you have used .union() to combine data. Please retrieve "
+            "this information before combining."
+        )

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -1087,6 +1087,8 @@ class DataCollection:
                         else:
                             entry_info = ""
                         dt = ds.dtype
+                        if h5py.check_string_dtype(dt):
+                            dt = 'string'
                         print(f"      - {k}\t[{dt}{entry_info}]")
 
         print()

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -1072,7 +1072,22 @@ class DataCollection:
             print('  -', s)
             if any(p.match(s) for p in details_sources_re):
                 # Detail for control sources: list keys
-                keys_detail(s, sorted(self.keys_for_source(s)), prefix='    - ')
+                ctrl_keys = self.keys_for_source(s)
+                keys_detail(s, sorted(ctrl_keys), prefix='    - ')
+
+                run_keys = self._source_index[s][0].get_run_keys(s)
+                run_only_keys = run_keys - ctrl_keys
+                if run_only_keys:
+                    print('    + extra RUN keys (1 entry per run):')
+                    for k in run_only_keys:
+                        ds = self._source_index[s][0].file[f"/RUN/{s}/{k.replace('.', '/')}"]
+                        entry_shape = ds.shape[1:]
+                        if entry_shape:
+                            entry_info = f", entry shape {entry_shape}"
+                        else:
+                            entry_info = ""
+                        dt = ds.dtype
+                        print(f"'      - '{k}\t[{dt}{entry_info}]")
 
         print()
 

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -1087,7 +1087,7 @@ class DataCollection:
                         else:
                             entry_info = ""
                         dt = ds.dtype
-                        print(f"'      - '{k}\t[{dt}{entry_info}]")
+                        print(f"      - {k}\t[{dt}{entry_info}]")
 
         print()
 

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -1067,18 +1067,19 @@ class DataCollection:
 
 
         print()
-        print(len(self.control_sources), 'control sources: (1 entry per train)')
+        print(len(self.control_sources), 'control sources:')
         for s in sorted(self.control_sources):
             print('  -', s)
             if any(p.match(s) for p in details_sources_re):
                 # Detail for control sources: list keys
                 ctrl_keys = self.keys_for_source(s)
-                keys_detail(s, sorted(ctrl_keys), prefix='    - ')
+                print('    - Control keys (1 entry per train):')
+                keys_detail(s, sorted(ctrl_keys), prefix='      - ')
 
                 run_keys = self._source_index[s][0].get_run_keys(s)
                 run_only_keys = run_keys - ctrl_keys
                 if run_only_keys:
-                    print('    + extra RUN keys (1 entry per run):')
+                    print('    - Additional run keys (1 entry per run):')
                     for k in sorted(run_only_keys):
                         ds = self._source_index[s][0].file[f"/RUN/{s}/{k.replace('.', '/')}"]
                         entry_shape = ds.shape[1:]

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -1079,7 +1079,7 @@ class DataCollection:
                 run_only_keys = run_keys - ctrl_keys
                 if run_only_keys:
                     print('    + extra RUN keys (1 entry per run):')
-                    for k in run_only_keys:
+                    for k in sorted(run_only_keys):
                         ds = self._source_index[s][0].file[f"/RUN/{s}/{k.replace('.', '/')}"]
                         entry_shape = ds.shape[1:]
                         if entry_shape:

--- a/extra_data/tests/test_reader_mockdata.py
+++ b/extra_data/tests/test_reader_mockdata.py
@@ -728,3 +728,13 @@ def test_get_run_value_union(mock_fxe_control_data, mock_sa3_control_data):
     data = f.union(f2)
     with pytest.raises(MultiRunError):
         data.get_run_value('FXE_XAD_GEC/CAM/CAMERA', 'firmwareVersion')
+
+    with pytest.raises(MultiRunError):
+        data.get_run_values('FXE_XAD_GEC/CAM/CAMERA')
+
+def test_get_run_values(mock_fxe_control_data):
+    f = H5File(mock_fxe_control_data)
+    src = 'FXE_XAD_GEC/CAM/CAMERA'
+    d = f.get_run_values(src, )
+    assert isinstance(d['firmwareVersion.value'], np.int32)
+    assert isinstance(d['enableShutter.value'], np.uint8)

--- a/extra_data/tests/test_reader_mockdata.py
+++ b/extra_data/tests/test_reader_mockdata.py
@@ -705,3 +705,17 @@ def test_get_data_counts(mock_spb_raw_run):
     count = run.get_data_counts('SPB_XTD9_XGM/DOOCS/MAIN', 'beamPosition.ixPos.value')
     assert count.index.tolist() == run.train_ids
     assert (count.values == 1).all()
+
+
+def test_get_run_value(mock_fxe_control_data):
+    f = H5File(mock_fxe_control_data)
+    src = 'FXE_XAD_GEC/CAM/CAMERA'
+    val = f.get_run_value(src, 'firmwareVersion')
+    assert isinstance(val, np.int32)
+    assert f.get_run_value(src, 'firmwareVersion.value') == val
+
+    with pytest.raises(SourceNameError):
+        f.get_run_value(src + '_NONEXIST', 'firmwareVersion')
+
+    with pytest.raises(PropertyNameError):
+        f.get_run_value(src, 'non.existant')

--- a/extra_data/tests/test_reader_mockdata.py
+++ b/extra_data/tests/test_reader_mockdata.py
@@ -14,6 +14,7 @@ from xarray import DataArray
 from extra_data import (
     H5File, RunDirectory, by_index, by_id,
     SourceNameError, PropertyNameError, DataCollection, open_run,
+    MultiRunError
 )
 
 def test_iterate_trains(mock_agipd_data):
@@ -719,3 +720,11 @@ def test_get_run_value(mock_fxe_control_data):
 
     with pytest.raises(PropertyNameError):
         f.get_run_value(src, 'non.existant')
+
+
+def test_get_run_value_union(mock_fxe_control_data, mock_sa3_control_data):
+    f = H5File(mock_fxe_control_data)
+    f2 = H5File(mock_sa3_control_data)
+    data = f.union(f2)
+    with pytest.raises(MultiRunError):
+        data.get_run_value('FXE_XAD_GEC/CAM/CAMERA', 'firmwareVersion')


### PR DESCRIPTION
Closes #26

To keep things fast & simple, this just selects an arbitrary file for the relevant source to get the RUN data from. Within a run, the value should be the same in all files.

If you combine runs with `.union()`, you'll get the value from an arbitrary one of the runs. If that was likely to come up often, I'd want to load the value from each run and error if they're inconsistent. But I think merging runs is relatively unusual, and checking for it has a cost in either performance or complexity, so for now I'm ignoring it.

```
In [2]: run = open_run(2702, 173)                                               

In [3]: run.get_run_value('HED_OPT_PAM/CAM/SAMPLE_CAM_4', 'triggerMode')        
Out[3]: 'ExtTrigMult'

In [4]: run.get_run_value('HED_OPT_PAM/CAM/SAMPLE_CAM_4', 'triggerMode.value')  
Out[4]: 'ExtTrigMult'
```