### PR TITLE
Don't default to libver latest when writing virtual CXI files

### DIFF
--- a/extra_data/write_cxi.py
+++ b/extra_data/write_cxi.py
@@ -202,7 +202,11 @@ class VirtualCXIWriter:
 
         log.info("Writing to %s", filename)
 
-        with h5py.File(filename, 'w', libver='v110') as f:
+        # Virtual datasets require HDF5 >= 1.10. Specifying this up front should
+        # mean it fails before touching the file if run on an older version.
+        # We also specify this as the maximum version, to ensure we're creating
+        # files that can be read by HDF5 1.10.
+        with h5py.File(filename, 'w', libver=('v110', 'v110')) as f:
             f.create_dataset('cxi_version', data=[150])
             d = f.create_dataset('entry_1/experiment_identifier',
                                  shape=experiment_ids.shape,

--- a/extra_data/write_cxi.py
+++ b/extra_data/write_cxi.py
@@ -202,7 +202,7 @@ class VirtualCXIWriter:
 
         log.info("Writing to %s", filename)
 
-        with h5py.File(filename, 'w', libver='latest') as f:
+        with h5py.File(filename, 'w', libver='v110') as f:
             f.create_dataset('cxi_version', data=[150])
             d = f.create_dataset('entry_1/experiment_identifier',
                                  shape=experiment_ids.shape,


### PR DESCRIPTION
This allows h5py with HDF5 1.12 to write files which can be read by HDF5 1.10.

A single argument to `libver` sets the default version it will try to use; it may still use newer parts of the file format if we do something that requires a new feature. We could specify a tuple `libver=('v110', 'v110')`, in which case attempting to use features incompatible with 1.10 would raise an error while writing the file.

- h5py docs: https://docs.h5py.org/en/stable/high/file.html#version-bounding
- HDF5 docs: https://portal.hdfgroup.org/display/HDF5/H5P_SET_LIBVER_BOUNDS

cc @dallanto 