### PR TITLE
Some fixes for bad train handling

### DIFF
--- a/extra_data/file_access.py
+++ b/extra_data/file_access.py
@@ -163,6 +163,10 @@ class FileAccess:
     def valid_train_ids(self):
         return self.train_ids[self.validity_flag]
 
+    def has_train_ids(self, tids: np.ndarray, inc_suspect=False):
+        f_tids = self.train_ids if inc_suspect else self.valid_train_ids
+        return np.intersect1d(tids, f_tids).size > 0
+
     def close(self):
         """Close* the HDF5 file this refers to.
 

--- a/extra_data/keydata.py
+++ b/extra_data/keydata.py
@@ -100,6 +100,7 @@ class KeyData:
             section=self.section,
             dtype=self.dtype,
             eshape=self.entry_shape,
+            inc_suspect_trains=self.inc_suspect_trains,
         )
 
     def __getitem__(self, item):

--- a/extra_data/keydata.py
+++ b/extra_data/keydata.py
@@ -90,7 +90,7 @@ class KeyData:
         """
         tids = select_train_ids(self.train_ids, trains)
         files = [f for f in self.files
-                 if np.intersect1d(f.train_ids, tids).size > 0]
+                 if f.has_train_ids(tids, self.inc_suspect_trains)]
 
         return KeyData(
             self.source,
@@ -298,8 +298,12 @@ class KeyData:
     def _find_tid(self, tid) -> (Optional[FileAccess], int):
         for fa in self.files:
             matches = (fa.train_ids == tid).nonzero()[0]
-            if matches.size > 0:
+            if self.inc_suspect_trains and matches.size > 0:
                 return fa, matches[0]
+
+            for ix in matches:
+                if fa.validity_flag[ix]:
+                    return fa, ix
 
         return None, 0
 

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -468,15 +468,7 @@ class DataCollection:
 
         seq_series = []
 
-        if source in self.control_sources:
-            data_path = "/CONTROL/{}/{}".format(source, key.replace('.', '/'))
-            for f in self._source_index[source]:
-                data = f.file[data_path][: len(f.train_ids), ...]
-                index = pd.Index(f.train_ids, name='trainId')
-
-                seq_series.append(pd.Series(data, name=name, index=index))
-
-        elif source in self.instrument_sources:
+        if source in self.instrument_sources:
             data_path = "/INSTRUMENT/{}/{}".format(source, key.replace('.', '/'))
             for f in self._source_index[source]:
                 group = key.partition('.')[0]
@@ -506,7 +498,7 @@ class DataCollection:
 
                 seq_series.append(pd.Series(data, name=name, index=index))
         else:
-            raise Exception("Unknown source category")
+            return self._get_key_data(source, key).series()
 
         ser = pd.concat(sorted(seq_series, key=lambda s: s.index[0]))
 
@@ -801,7 +793,7 @@ class DataCollection:
 
             # Filtering may have eliminated previously selected files.
             files = [f for f in files
-                     if np.intersect1d(f.train_ids, train_ids).size > 0]
+                     if f.has_train_ids(train_ids, self.inc_suspect_trains)]
 
             train_ids = list(train_ids)  # Convert back to a list.
 
@@ -880,7 +872,7 @@ class DataCollection:
         new_train_ids = select_train_ids(self.train_ids, train_range)
 
         files = [f for f in self.files
-                 if np.intersect1d(f.train_ids, new_train_ids).size > 0]
+                 if f.has_train_ids(new_train_ids, self.inc_suspect_trains)]
 
         return DataCollection(
             files, selection=self.selection, train_ids=new_train_ids,
@@ -894,10 +886,12 @@ class DataCollection:
         for source, files in self._source_index.items():
             got_tids = np.array([], dtype=np.uint64)
             for file in files:
-                if np.intersect1d(got_tids, file.train_ids).size > 0:
+                if file.has_train_ids(got_tids, self.inc_suspect_trains):
                     sources_with_conflicts.add(source)
                     break
-                got_tids = np.union1d(got_tids, file.train_ids)
+                f_tids = file.train_ids if self.inc_suspect_trains \
+                            else file.valid_train_ids
+                got_tids = np.union1d(got_tids, f_tids)
 
         if sources_with_conflicts:
             raise ValueError("{} sources have conflicting data "
@@ -1074,7 +1068,8 @@ class DataCollection:
         """
         if train_id not in self.train_ids:
             raise ValueError("train {} not found in run.".format(train_id))
-        files = [f for f in self.files if train_id in f.train_ids]
+        files = [f for f in self.files
+                 if f.has_train_ids([train_id], self.inc_suspect_trains)]
         ctrl = set().union(*[f.control_sources for f in files])
         inst = set().union(*[f.instrument_sources for f in files])
 

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -788,10 +788,12 @@ class DataCollection:
                     source_tids = np.empty(0, dtype=np.uint64)
 
                     for f in self._source_index[source]:
+                        valid = True if self.inc_suspect_trains else f.validity_flag
                         # Add the trains with data in each file.
+                        _, counts = f.get_index(source, group)
                         source_tids = np.union1d(
-                            f.train_ids[f.get_index(source, group)[1] > 0],
-                            source_tids)
+                            f.train_ids[valid & (counts > 0)], source_tids
+                        )
 
                     # Remove any trains previously selected, for which this
                     # selected source and key group has no data.

--- a/extra_data/tests/test_bad_trains.py
+++ b/extra_data/tests/test_bad_trains.py
@@ -262,8 +262,15 @@ def test_still_valid_elsewhere(agipd_file_tid_very_high, mock_sa3_control_data):
     assert tids_from_iter == [10200, 10400]
     assert [set(d) for d in data_from_iter] == [set(t1), set(t2)]
 
+    # Check that select with require_all respects the valid train filtering:
+    sel2 = dc.select(agipd_src, require_all=True)
+    assert len(sel2.train_ids) == 249
+
     dc_inc = H5File(agipd_file_tid_very_high, inc_suspect_trains=True)\
                 .union(H5File(mock_sa3_control_data))
     sel_inc = dc_inc.select(sel)
     _, t2_inc = sel_inc.train_from_id(10400, flat_keys=True)
     assert set(t2_inc) == set(t1)
+
+    sel2_inc = dc_inc.select(agipd_src, require_all=True)
+    assert len(sel2_inc.train_ids) == 250

--- a/extra_data/tests/test_bad_trains.py
+++ b/extra_data/tests/test_bad_trains.py
@@ -117,6 +117,9 @@ def test_keydata_interface(agipd_file_tid_very_high):
     assert len(kd.train_ids) == 250
     assert kd.shape == (250 * 64, 512, 128)
 
+    # Check selecting trains preserves inc_suspect_trains flag
+    assert kd[:].shape == (250 * 64, 512, 128)
+
 def test_data_counts(agipd_file_flag0):
     f = H5File(agipd_file_flag0)
     kd = f['SPB_DET_AGIPD1M-1/DET/0CH0:xtdf', 'image.data']


### PR DESCRIPTION
We found a few places where we weren't correctly excluding or including bad trains (according to the `inc_suspect_trains` flag). In particular, `key.select_trains()` and `run.select(..., require_all=True)`. This should fix them.

cc @philsmt 