### PR TITLE
Select pulses per gain stage for LPD in parallel gain mode

### DIFF
--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -372,24 +372,31 @@ class XtdfDetectorBase(MultimodDetectorBase):
 
                 inner_ids = get_inner_ids(f, data_slice, inner_index)
 
-                if isinstance(pulses, by_id):
-                    if inner_index == 'pulseId':
-                        pulse_id = inner_ids
-                    else:
-                        pulse_id = get_inner_ids(f, data_slice, 'pulseId')
-                    positions = self._select_pulse_ids(pulses, pulse_id)
-                else:  # by_index
-                    positions = self._select_pulse_indices(
-                        pulses, chunk_firsts - data_slice.start, chunk_counts
-                    )
-
                 trainids = np.repeat(
                     np.arange(first_tid, last_tid + 1, dtype=np.uint64),
                     chunk_counts.astype(np.intp),
                 )
                 index = self._make_image_index(
                     trainids, inner_ids, inner_index[:-2]
-                )[positions]
+                )
+
+                if isinstance(pulses, by_id):
+                    # Get the pulse ID values out of the MultiIndex rather than
+                    # using inner_ids, because LPD1M in parallel_gain mode
+                    # makes the MultiIndex differently, repeating pulse IDs.
+                    if inner_index == 'pulseId':
+                        pulse_id = index.get_level_values('pulse')
+                    else:
+                        pulse_id = self._make_image_index(
+                            trainids, get_inner_ids(f, data_slice, 'pulseId'),
+                        ).get_level_values('pulse')
+                    positions = self._select_pulse_ids(pulses, pulse_id)
+                else:  # by_index
+                    positions = self._select_pulse_indices(
+                        pulses, chunk_firsts - data_slice.start, chunk_counts
+                    )
+
+                index = index[positions]
 
                 if isinstance(positions, slice):
                     data_positions = slice(

--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -950,7 +950,7 @@ class LPD1M(XtdfDetectorBase):
             n_per_gain_stage = int(frames // 3)
             train_desired = desired[desired < n_per_gain_stage]
             for stage in range(3):
-                start = ix + (stage * n_per_gain_stage)
+                start = ix + np.uint64(stage * n_per_gain_stage)
                 positions.append(start + train_desired)
 
         return np.concatenate(positions)

--- a/extra_data/tests/test_components.py
+++ b/extra_data/tests/test_components.py
@@ -164,6 +164,22 @@ def test_get_array_lpd_parallelgain(mock_lpd_parallelgain_run):
     np.testing.assert_array_equal(arr.coords['pulse'], np.arange(100))
 
 
+def test_get_array_lpd_parallelgain_select_pulses(mock_lpd_parallelgain_run):
+    run = RunDirectory(mock_lpd_parallelgain_run)
+    det = LPD1M(run.select_trains(by_index[:2]), parallel_gain=True)
+    assert det.detector_name == 'FXE_DET_LPD1M-1'
+
+    arr = det.get_array('image.data', pulses=np.s_[:5])
+    assert arr.shape == (16, 2, 3, 5, 256, 256)
+    assert arr.dims == ('module', 'train', 'gain', 'pulse', 'slow_scan', 'fast_scan')
+    np.testing.assert_array_equal(arr.coords['gain'], np.arange(3))
+    np.testing.assert_array_equal(arr.coords['pulse'], np.arange(5))
+
+    arr = det.get_array('image.data', pulses=by_id[:5])
+    assert arr.shape == (16, 2, 3, 5, 256, 256)
+    np.testing.assert_array_equal(arr.coords['pulse'], np.arange(5))
+
+
 def test_get_array_jungfrau(mock_jungfrau_run):
     run = RunDirectory(mock_jungfrau_run)
     jf = JUNGFRAU(run.select_trains(by_index[:2]))


### PR DESCRIPTION
cc @daviddoji - ~~I haven't actually tested this yet,~~ but if you've got time to try it and see if it works for your use case, that would be good. Selecting `pulses=np.s_[:1]` should give you the first pulse from each gain stage.

Todo:

- [x] Do the same for selection using pulse ID
- [x] Add tests