### PR TITLE
Extend open_run to return a single run DataCollection of both raw and proc

### DIFF
--- a/extra_data/tests/test_reader_mockdata.py
+++ b/extra_data/tests/test_reader_mockdata.py
@@ -694,12 +694,31 @@ def test_open_run(mock_spb_raw_run, mock_spb_proc_run, tmpdir):
         assert {f.filename for f in run.files} == paths
 
         # Proc folder
-        run = open_run(proposal=2012, run=238, data='proc')
+        proc_run = open_run(proposal=2012, run=238, data='proc')
 
-        proc_paths = {f.filename for f in run.files}
+        proc_paths = {f.filename for f in proc_run.files}
         assert proc_paths
         for path in proc_paths:
             assert '/raw/' not in path
+
+        # All folders
+        all_run = open_run(proposal=2012, run=238, data='all')
+
+        # Raw contains all sources.
+        assert run.all_sources == all_run.all_sources
+
+        # Proc is a true subset.
+        assert proc_run.all_sources < all_run.all_sources
+
+        for source, files in all_run._source_index.items():
+            for file in files:
+                if '/DET/' in source:
+                    # AGIPD data is in proc.
+                    assert '/raw/' not in file.filename
+                else:
+                    # Non-AGIPD data is in raw.
+                    # (CAM, XGM)
+                    assert '/proc/' not in file.filename
 
         # Run that doesn't exist
         with pytest.raises(Exception):


### PR DESCRIPTION
The "single-run" logic introduced in #164 makes it somewhat awkward to obtain a `DataCollection` of both `raw` and `proc` for a single run.  Just using `open_run(..., data='raw').union(open_run(..., data='proc'))` with the same parameters no longer has the `is_single_run` flag. In an effort to no longer mindlessly copy over all raw data (and/or having the pre-calibrated data available, too!), this will be common use case.

While it can be set manually, this is confusing and unnecessarily verbose. This PR extends `open_run` with an option for `data` to create this union automatically and re-enable the `is_single_run` flag.

As an WIP, I've added the string `'all'` and the `Ellipsis`, but I don't have any strong opinions of this. Given this flag is only useful on our infrastructure and there won't be any new folder suddenly beyond the current ones, a string like `'all'` is probably safe?