### PR TITLE
Remove some old h5py workarounds, bump required version

### DIFF
--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -398,12 +398,7 @@ class XtdfDetectorBase(MultimodDetectorBase):
                         positions.step
                     )
                 else:  # ndarray
-                    # h5py fancy indexing needs a list, not an ndarray
-                    data_positions = list(data_slice.start + positions)
-                    if data_positions == []:
-                        # Work around a limitation of h5py
-                        # https://github.com/h5py/h5py/issues/1169
-                        data_positions = slice(0, 0)
+                    data_positions = data_slice.start + positions
 
                 dset = f.file[data_path]
                 if dset.ndim >= 2 and dset.shape[1] == 1:
@@ -765,8 +760,7 @@ class MPxDetectorTrainIterator:
                 positions.step
             )
         else:  # ndarray
-            # h5py fancy indexing needs a list, not an ndarray
-            data_positions = list(first + positions)
+            data_positions = first + positions
 
         return self.data._guess_axes(ds[data_positions], train_pulse_ids, unstack_pulses=True)
 

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(name="EXtra-data",
       },
       install_requires=[
           'fabio',
-          'h5py>=2.7.1',
+          'h5py>=2.10',
           'karabo-bridge >=0.6',
           'matplotlib',
           'numpy',


### PR DESCRIPTION
I spend time improving h5py, I may as well take advantage of the improvements.

These workarounds were for things fixed in h5py 2.10 - see the [what's new in 2.10](https://docs.h5py.org/en/stable/whatsnew/2.10.html) notes.