### PR TITLE
Include 'suspect' trains by default

### DIFF
--- a/extra_data/cli/make_virtual_cxi.py
+++ b/extra_data/cli/make_virtual_cxi.py
@@ -65,6 +65,11 @@ def main(argv=None):
              ' "data", "gain" and "mask". (defaults: data: nan (proc, float32)'
              ' or 0 (raw, uint16); gain: 0; mask: 0xffffffff)'
     )
+    ap.add_argument(
+        '--exc-suspect-trains', action='store_true',
+        help="Exclude suspect trains. This tries to avoid some issues with incorrect train IDs in the data, "
+             "but may mean less data is available."
+    )
     args = ap.parse_args(argv)
     out_file = args.output
     fill_values = None
@@ -101,7 +106,7 @@ def main(argv=None):
         sys.exit("ERROR: Don't have write access to {}".format(out_dir))
 
     log.info("Reading run directory %s", run_dir)
-    run = RunDirectory(run_dir)
+    run = RunDirectory(run_dir, inc_suspect_trains=(not args.exc_suspect_trains))
     det = _get_detector(run, args.min_modules)
     if det is None:
         sys.exit(f"No {_detectors()} sources found in {run_dir}")

--- a/extra_data/keydata.py
+++ b/extra_data/keydata.py
@@ -13,7 +13,7 @@ class KeyData:
     """
     def __init__(
             self, source, key, *, train_ids, files, section, dtype, eshape,
-            inc_suspect_trains=False,
+            inc_suspect_trains=True,
     ):
         self.source = source
         self.key = key

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -77,7 +77,7 @@ class DataCollection:
     """
     def __init__(
             self, files, selection=None, train_ids=None, ctx_closes=False, *,
-            inc_suspect_trains=False, is_single_run=False,
+            inc_suspect_trains=True, is_single_run=False,
     ):
         self.files = list(files)
         self.ctx_closes = ctx_closes
@@ -127,7 +127,7 @@ class DataCollection:
 
     @classmethod
     def from_paths(
-            cls, paths, _files_map=None, *, inc_suspect_trains=False,
+            cls, paths, _files_map=None, *, inc_suspect_trains=True,
             is_single_run=False
     ):
         files = []
@@ -169,7 +169,7 @@ class DataCollection:
         )
 
     @classmethod
-    def from_path(cls, path, *, inc_suspect_trains=False):
+    def from_path(cls, path, *, inc_suspect_trains=True):
         files = [FileAccess(path)]
         return cls(
             files, ctx_closes=True, inc_suspect_trains=inc_suspect_trains,
@@ -1379,7 +1379,7 @@ class TrainIterator:
             yield tid, self._assemble_data(tid)
 
 
-def H5File(path, *, inc_suspect_trains=False):
+def H5File(path, *, inc_suspect_trains=True):
     """Open a single HDF5 file generated at European XFEL.
 
     ::
@@ -1393,16 +1393,16 @@ def H5File(path, *, inc_suspect_trains=False):
     path: str
         Path to the HDF5 file
     inc_suspect_trains: bool
-        If False (default), suspect train IDs within a file are skipped.
+        If False, suspect train IDs within a file are skipped.
         In newer files, trains where INDEX/flag are 0 are suspect. For older
         files which don't have this flag, out-of-sequence train IDs are suspect.
-        If True, it tries to include these trains.
+        If True (default), it tries to include these trains.
     """
     return DataCollection.from_path(path, inc_suspect_trains=inc_suspect_trains)
 
 
 def RunDirectory(
-        path, include='*', file_filter=locality.lc_any, *, inc_suspect_trains=False
+        path, include='*', file_filter=locality.lc_any, *, inc_suspect_trains=True
 ):
     """Open data files from a 'run' at European XFEL.
 
@@ -1425,10 +1425,10 @@ def RunDirectory(
         Function to subset the list of filenames to open.
         Meant to be used with functions in the extra_data.locality module.
     inc_suspect_trains: bool
-        If False (default), suspect train IDs within a file are skipped.
+        If False, suspect train IDs within a file are skipped.
         In newer files, trains where INDEX/flag are 0 are suspect. For older
         files which don't have this flag, out-of-sequence train IDs are suspect.
-        If True, it tries to include these trains.
+        If True (default), it tries to include these trains.
     """
     files = [f for f in os.listdir(path) if f.endswith('.h5')]
     files = [osp.join(path, f) for f in fnmatch.filter(files, include)]
@@ -1455,7 +1455,7 @@ RunHandler = RunDirectory
 
 def open_run(
         proposal, run, data='raw', include='*', file_filter=locality.lc_any, *,
-        inc_suspect_trains=False
+        inc_suspect_trains=True
 ):
     """Access EuXFEL data on the Maxwell cluster by proposal and run number.
 
@@ -1481,10 +1481,10 @@ def open_run(
         Function to subset the list of filenames to open.
         Meant to be used with functions in the extra_data.locality module.
     inc_suspect_trains: bool
-        If False (default), suspect train IDs within a file are skipped.
+        If False, suspect train IDs within a file are skipped.
         In newer files, trains where INDEX/flag are 0 are suspect. For older
         files which don't have this flag, out-of-sequence train IDs are suspect.
-        If True, it tries to include these trains.
+        If True (default), it tries to include these trains.
     """
     if isinstance(proposal, str):
         if ('/' not in proposal) and not proposal.startswith('p'):

--- a/extra_data/tests/test_bad_trains.py
+++ b/extra_data/tests/test_bad_trains.py
@@ -70,7 +70,7 @@ def test_validity_flag(agipd_file_flag0):
     assert not fa.validity_flag[30]
 
 def test_exc_trainid(agipd_file_tid_very_high, agipd_file_tid_high, agipd_file_tid_low, agipd_file_flag0):
-    f = H5File(agipd_file_tid_very_high)
+    f = H5File(agipd_file_tid_very_high, inc_suspect_trains=False)
     assert len(f.train_ids) == 249
     assert 10400 not in f.train_ids
 
@@ -78,7 +78,7 @@ def test_exc_trainid(agipd_file_tid_very_high, agipd_file_tid_high, agipd_file_t
     assert len(f.train_ids) == 250
     assert 10400 in f.train_ids
 
-    f = H5File(agipd_file_tid_high)
+    f = H5File(agipd_file_tid_high, inc_suspect_trains=False)
     assert len(f.train_ids) == 485
     assert 10100 in f.train_ids
 
@@ -86,7 +86,7 @@ def test_exc_trainid(agipd_file_tid_very_high, agipd_file_tid_high, agipd_file_t
     assert len(f.train_ids) == 485  # this list is always deduped & sorted
     assert 10100 in f.train_ids
 
-    f = H5File(agipd_file_tid_low)
+    f = H5File(agipd_file_tid_low, inc_suspect_trains=False)
     assert len(f.train_ids) == 249
     assert 9000 not in f.train_ids
 
@@ -94,7 +94,7 @@ def test_exc_trainid(agipd_file_tid_very_high, agipd_file_tid_high, agipd_file_t
     assert len(f.train_ids) == 250
     assert 9000 in f.train_ids
 
-    f = H5File(agipd_file_flag0)
+    f = H5File(agipd_file_flag0, inc_suspect_trains=False)
     assert len(f.train_ids) == 485
     assert 10030 not in f.train_ids
 
@@ -107,7 +107,7 @@ def test_exc_trainid(agipd_file_tid_very_high, agipd_file_tid_high, agipd_file_t
 # each behaviour on just one of the sample files.
 
 def test_keydata_interface(agipd_file_tid_very_high):
-    f = H5File(agipd_file_tid_very_high)
+    f = H5File(agipd_file_tid_very_high, inc_suspect_trains=False)
     kd = f['SPB_DET_AGIPD1M-1/DET/7CH0:xtdf', 'image.data']
     assert len(kd.train_ids) == 249
     assert kd.shape == (249 * 64, 512, 128)
@@ -121,7 +121,7 @@ def test_keydata_interface(agipd_file_tid_very_high):
     assert kd[:].shape == (250 * 64, 512, 128)
 
 def test_data_counts(agipd_file_flag0):
-    f = H5File(agipd_file_flag0)
+    f = H5File(agipd_file_flag0, inc_suspect_trains=False)
     kd = f['SPB_DET_AGIPD1M-1/DET/0CH0:xtdf', 'image.data']
     assert 10030 not in kd.data_counts().index
 
@@ -130,7 +130,7 @@ def test_data_counts(agipd_file_flag0):
     assert 10030 in kd.data_counts().index
 
 def test_array(agipd_file_tid_low):
-    f = H5File(agipd_file_tid_low)
+    f = H5File(agipd_file_tid_low, inc_suspect_trains=False)
     arr = f['SPB_DET_AGIPD1M-1/DET/7CH0:xtdf', 'image.pulseId'].xarray()
     assert arr.shape == (249 * 64, 1)
 
@@ -139,7 +139,7 @@ def test_array(agipd_file_tid_low):
     assert arr.shape == (250 * 64, 1)
 
 def test_array_dup(agipd_file_tid_high):
-    f = H5File(agipd_file_tid_high)
+    f = H5File(agipd_file_tid_high, inc_suspect_trains=False)
     arr = f['SPB_DET_AGIPD1M-1/DET/0CH0:xtdf', 'image.pulseId'].xarray()
     assert arr.shape == (485 * 64, 1)
     assert list(arr.coords['trainId'].values[(9*64):(11*64):64]) == [10009, 10011]
@@ -150,7 +150,7 @@ def test_array_dup(agipd_file_tid_high):
     assert list(arr.coords['trainId'].values[(9 * 64):(11 * 64):64]) == [10009, 10100]
 
 def test_dask_array(agipd_file_flag0):
-    f = H5File(agipd_file_flag0)
+    f = H5File(agipd_file_flag0, inc_suspect_trains=False)
     arr = f['SPB_DET_AGIPD1M-1/DET/0CH0:xtdf', 'image.pulseId'].dask_array()
     assert arr.shape == (485 * 64, 1)
 
@@ -159,7 +159,7 @@ def test_dask_array(agipd_file_flag0):
     assert arr.shape == (486 * 64, 1)
 
 def test_iterate_keydata(agipd_file_tid_very_high):
-    f = H5File(agipd_file_tid_very_high)
+    f = H5File(agipd_file_tid_very_high, inc_suspect_trains=False)
     kd = f['SPB_DET_AGIPD1M-1/DET/7CH0:xtdf', 'image.pulseId']
     tids = [t for (t, _) in kd.trains()]
     assert len(tids) == 249
@@ -172,7 +172,7 @@ def test_iterate_keydata(agipd_file_tid_very_high):
     assert 10400 in tids
 
 def test_iterate_keydata_dup(agipd_file_tid_high):
-    f = H5File(agipd_file_tid_high)
+    f = H5File(agipd_file_tid_high, inc_suspect_trains=False)
     kd = f['SPB_DET_AGIPD1M-1/DET/0CH0:xtdf', 'image.pulseId']
     tids = [t for (t, _) in kd.trains()]
     assert len(tids) == 485
@@ -180,13 +180,13 @@ def test_iterate_keydata_dup(agipd_file_tid_high):
     assert tids[9:11] == [10009, 10011]
 
 def test_iterate_datacollection(agipd_file_tid_low):
-    f = H5File(agipd_file_tid_low)
+    f = H5File(agipd_file_tid_low, inc_suspect_trains=False)
     tids = [t for (t, _) in f.trains()]
     assert len(tids) == 249
     assert 9000 not in tids
 
 def test_get_train_keydata(agipd_file_tid_low):
-    f = H5File(agipd_file_tid_low)
+    f = H5File(agipd_file_tid_low, inc_suspect_trains=False)
     kd = f['SPB_DET_AGIPD1M-1/DET/7CH0:xtdf', 'image.pulseId']
     with pytest.raises(TrainIDError):
         kd.train_from_id(9000)
@@ -196,14 +196,14 @@ def test_get_train_keydata(agipd_file_tid_low):
     assert kd.train_from_id(9000)[0] == 9000
 
 def test_components_array(agipd_file_flag0):
-    f = H5File(agipd_file_flag0)
+    f = H5File(agipd_file_flag0, inc_suspect_trains=False)
     agipd = AGIPD1M(f, modules=[0])
     arr = agipd.get_array('image.data', pulses=np.s_[:1])
     assert arr.shape == (1, 485, 1, 2, 512, 128)
     assert arr.dims == ('module', 'train', 'pulse', 'data_gain', 'slow_scan', 'fast_scan')
 
 def test_components_array_dup(agipd_file_tid_high):
-    f = H5File(agipd_file_tid_high)
+    f = H5File(agipd_file_tid_high, inc_suspect_trains=False)
     agipd = AGIPD1M(f, modules=[0])
     arr = agipd.get_array('image.data', pulses=np.s_[:1])
     assert arr.shape == (1, 485, 1, 2, 512, 128)
@@ -211,7 +211,7 @@ def test_components_array_dup(agipd_file_tid_high):
     assert list(arr.coords['train'].values[9:11]) == [10009, 10011]
 
 def test_write_virtual_cxi_dup(agipd_file_tid_high, tmp_path, caplog):
-    f = H5File(agipd_file_tid_high)
+    f = H5File(agipd_file_tid_high, inc_suspect_trains=False)
     agipd = AGIPD1M(f, modules=[0])
     cxi_path = tmp_path / 'exc_suspect.cxi'
     agipd.write_virtual_cxi(str(cxi_path))
@@ -220,14 +220,14 @@ def test_write_virtual_cxi_dup(agipd_file_tid_high, tmp_path, caplog):
         assert f['entry_1/data_1/data'].shape == (485 * 64, 16, 2, 512, 128)
 
 def test_write_virtual(agipd_file_tid_low, agipd_file_tid_high, tmp_path):
-    f = H5File(agipd_file_tid_low)
+    f = H5File(agipd_file_tid_low, inc_suspect_trains=False)
     f.write_virtual(tmp_path / 'low.h5')
     with h5py.File(tmp_path / 'low.h5', 'r') as vf:
         assert 9000 not in vf['INDEX/trainId'][:]
         ds = vf['INSTRUMENT/SPB_DET_AGIPD1M-1/DET/7CH0:xtdf/image/pulseId']
         assert ds.shape == (249 * 64, 1)
 
-    f = H5File(agipd_file_tid_high)
+    f = H5File(agipd_file_tid_high, inc_suspect_trains=False)
     f.write_virtual(tmp_path / 'high.h5')
     with h5py.File(tmp_path / 'high.h5', 'r') as vf:
         ds = vf['INSTRUMENT/SPB_DET_AGIPD1M-1/DET/0CH0:xtdf/image/trainId']
@@ -235,7 +235,9 @@ def test_write_virtual(agipd_file_tid_low, agipd_file_tid_high, tmp_path):
         assert list(ds[(9*64):(11*64):64]) == [10009, 10011]
 
 def test_still_valid_elsewhere(agipd_file_tid_very_high, mock_sa3_control_data):
-    dc = H5File(agipd_file_tid_very_high).union(H5File(mock_sa3_control_data))
+    dc = H5File(
+        agipd_file_tid_very_high, inc_suspect_trains=False
+    ).union(H5File(mock_sa3_control_data))
     assert dc.train_ids == list(range(10000, 10500))
 
     agipd_src = 'SPB_DET_AGIPD1M-1/DET/7CH0:xtdf'


### PR DESCRIPTION
As we've discussed internally, it seems that 'suspect' train IDs are more common than we had thought, and we've heard from a couple of scientists who were confused why data was suddenly missing. We had hoped it was just occasional problem trains from AGIPD, but other things are affected too.

This preserves all the machinery to exclude the suspect trains, but changes the default to include them again.

Q: should there be a different default for `extra-data-make-virtual-cxi`? Should we add a command-line option to control it?