### PR TITLE
Split DataCollection & KeyData into chunks by train

### DIFF
--- a/docs/reading_files.rst
+++ b/docs/reading_files.rst
@@ -17,8 +17,6 @@ run number to look up the standard data paths on the Maxwell cluster.
 
 .. autofunction:: open_run
 
-   .. versionadded:: 0.5
-
 You can also open a single file. The methods described below all work for either
 a run or a single file.
 
@@ -162,8 +160,6 @@ methods offer extra capabilities.
           Examples using xarray & pandas with EuXFEL data
 
    .. automethod:: get_virtual_dataset
-
-      .. versionadded:: 0.5
 
       .. seealso::
         :doc:`parallel_example`

--- a/docs/reading_files.rst
+++ b/docs/reading_files.rst
@@ -133,6 +133,10 @@ below, e.g.::
 
    .. automethod:: select_trains
 
+   .. automethod:: split_trains
+
+      .. versionadded:: 1.7
+
 The run or file object (a :class:`DataCollection`) also has methods to load
 data by sources and keys. :meth:`get_array`, :meth:`get_dask_array` and
 :meth:`get_series` are directly equivalent to the options above, but other
@@ -230,6 +234,10 @@ data, so you use them like this::
    .. automethod:: deselect
 
    .. automethod:: select_trains
+
+   .. automethod:: split_trains
+
+      .. versionadded:: 1.7
 
    .. automethod:: union
 

--- a/extra_data/keydata.py
+++ b/extra_data/keydata.py
@@ -116,6 +116,8 @@ class KeyData:
         This returns an iterator yielding new :class:`KeyData` objects.
         The parts will have similar sizes, e.g. splitting 11 trains
         with ``trains_per_part=8`` will produce 5 & 6 trains, not 8 & 3.
+        Selected trains count even if they are missing data, so different
+        keys from the same run can be split into matching chunks.
 
         Parameters
         ----------

--- a/extra_data/keydata.py
+++ b/extra_data/keydata.py
@@ -113,7 +113,8 @@ class KeyData:
 
         Either *parts* or *trains_per_part* must be specified.
 
-        The returned parts will have similar sizes, e.g. splitting 11 trains
+        This returns an iterator yielding new :class:`KeyData` objects.
+        The parts will have similar sizes, e.g. splitting 11 trains
         with ``trains_per_part=8`` will produce 5 & 6 trains, not 8 & 3.
 
         Parameters
@@ -124,8 +125,8 @@ class KeyData:
             specified, this is a minimum, and it may make more parts.
             It may also make fewer if there are fewer trains in the data.
         trains_per_part: int
-            A maximum number of trains in each part. Typically the parts will
-            have fewer trains than this.
+            A maximum number of trains in each part. Parts will often have
+            fewer trains than this.
         """
         for s in split_trains(len(self.train_ids), parts, trains_per_part):
             yield self.select_trains(s)

--- a/extra_data/keydata.py
+++ b/extra_data/keydata.py
@@ -4,7 +4,9 @@ import numpy as np
 
 from .exceptions import TrainIDError
 from .file_access import FileAccess
-from .read_machinery import contiguous_regions, DataChunk, select_train_ids
+from .read_machinery import (
+    contiguous_regions, DataChunk, select_train_ids, split_trains,
+)
 
 class KeyData:
     """Data for one key in one source
@@ -105,6 +107,28 @@ class KeyData:
 
     def __getitem__(self, item):
         return self.select_trains(item)
+
+    def split_trains(self, parts=None, trains_per_part=None):
+        """Split this data into chunks with a fraction of the trains each.
+
+        Either *parts* or *trains_per_part* must be specified.
+
+        The returned parts will have similar sizes, e.g. splitting 11 trains
+        with ``trains_per_part=8`` will produce 5 & 6 trains, not 8 & 3.
+
+        Parameters
+        ----------
+
+        parts: int
+            How many parts to split the data into. If trains_per_part is also
+            specified, this is a minimum, and it may make more parts.
+            It may also make fewer if there are fewer trains in the data.
+        trains_per_part: int
+            A maximum number of trains in each part. Typically the parts will
+            have fewer trains than this.
+        """
+        for s in split_trains(len(self.train_ids), parts, trains_per_part):
+            yield self.select_trains(s)
 
     def data_counts(self):
         """Get a count of data entries in each train.

--- a/extra_data/read_machinery.py
+++ b/extra_data/read_machinery.py
@@ -128,10 +128,12 @@ def select_train_ids(train_ids, sel):
 
 def split_trains(n_trains, parts=None, trains_per_part=None) -> [slice]:
     if trains_per_part is not None:
+        assert trains_per_part >= 1
         n_parts = math.ceil(n_trains / trains_per_part)
         if parts is not None:
             n_parts = max(n_parts, min(parts, n_trains))
     elif parts is not None:
+        assert parts >= 1
         n_parts = min(parts, n_trains)
     else:
         raise ValueError("Either parts or trains_per_part must be specified")

--- a/extra_data/read_machinery.py
+++ b/extra_data/read_machinery.py
@@ -5,6 +5,7 @@ The public API is in extra_data.reader; this is internal code.
 from collections import defaultdict
 from glob import iglob
 import logging
+import math
 import numpy as np
 import os.path as osp
 import re
@@ -124,6 +125,21 @@ def select_train_ids(train_ids, sel):
     else:
         raise TypeError(type(sel))
 
+
+def split_trains(n_trains, parts=None, trains_per_part=None) -> [slice]:
+    if trains_per_part is not None:
+        n_parts = math.ceil(n_trains / trains_per_part)
+        if parts is not None:
+            n_parts = max(n_parts, min(parts, n_trains))
+    elif parts is not None:
+        n_parts = min(parts, n_trains)
+    else:
+        raise ValueError("Either parts or trains_per_part must be specified")
+
+    return [
+        slice(i * n_trains // n_parts, (i + 1) * n_trains // n_parts)
+        for i in range(n_parts)
+    ]
 
 class DataChunk:
     """Reference to a contiguous chunk of data for one or more trains."""

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -40,6 +40,7 @@ from .read_machinery import (
     by_id,
     by_index,
     select_train_ids,
+    split_trains,
     union_selections,
     find_proposal,
 )
@@ -959,6 +960,28 @@ class DataCollection:
             inc_suspect_trains=self.inc_suspect_trains,
             is_single_run=self.is_single_run,
         )
+
+    def split_trains(self, parts=None, trains_per_part=None):
+        """Split this data into chunks with a fraction of the trains each.
+
+        Either *parts* or *trains_per_part* must be specified.
+
+        The returned parts will have similar sizes, e.g. splitting 11 trains
+        with ``trains_per_part=8`` will produce 5 & 6 trains, not 8 & 3.
+
+        Parameters
+        ----------
+
+        parts: int
+            How many parts to split the data into. If trains_per_part is also
+            specified, this is a minimum, and it may make more parts.
+            It may also make fewer if there are fewer trains in the data.
+        trains_per_part: int
+            A maximum number of trains in each part. Typically the parts will
+            have fewer trains than this.
+        """
+        for s in split_trains(len(self.train_ids), parts, trains_per_part):
+            yield self.select_trains(s)
 
     def _check_source_conflicts(self):
         """Check for data with the same source and train ID in different files.

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -966,7 +966,8 @@ class DataCollection:
 
         Either *parts* or *trains_per_part* must be specified.
 
-        The returned parts will have similar sizes, e.g. splitting 11 trains
+        This returns an iterator yielding new :class:`DataCollection` objects.
+        The parts will have similar sizes, e.g. splitting 11 trains
         with ``trains_per_part=8`` will produce 5 & 6 trains, not 8 & 3.
 
         Parameters
@@ -977,8 +978,8 @@ class DataCollection:
             specified, this is a minimum, and it may make more parts.
             It may also make fewer if there are fewer trains in the data.
         trains_per_part: int
-            A maximum number of trains in each part. Typically the parts will
-            have fewer trains than this.
+            A maximum number of trains in each part. Parts will often have
+            fewer trains than this.
         """
         for s in split_trains(len(self.train_ids), parts, trains_per_part):
             yield self.select_trains(s)

--- a/extra_data/tests/test_keydata.py
+++ b/extra_data/tests/test_keydata.py
@@ -41,6 +41,21 @@ def test_select_trains(mock_spb_raw_run):
     assert sel3.shape == (1,)
 
 
+def test_split_trains(mock_spb_raw_run):
+    run = RunDirectory(mock_spb_raw_run)
+    xgm_beam_x = run['SPB_XTD9_XGM/DOOCS/MAIN', 'beamPosition.ixPos.value']
+    assert xgm_beam_x.shape == (64,)
+
+    chunks = list(xgm_beam_x.split_trains(3))
+    assert len(chunks) == 3
+    assert {c.shape for c in chunks} == {(21,), (22,)}
+    assert chunks[0].ndarray().shape == chunks[0].shape
+
+    chunks = list(xgm_beam_x.split_trains(3, trains_per_part=20))
+    assert len(chunks) == 4
+    assert {c.shape for c in chunks} == {(16,)}
+
+
 def test_nodata(mock_fxe_raw_run):
     run = RunDirectory(mock_fxe_raw_run)
     cam_pix = run['FXE_XAD_GEC/CAM/CAMERA_NODATA:daqOutput', 'data.image.pixels']

--- a/extra_data/tests/test_reader_mockdata.py
+++ b/extra_data/tests/test_reader_mockdata.py
@@ -590,6 +590,19 @@ def test_select_trains(mock_fxe_raw_run):
         run.select_trains(by_index[[480]])
 
 
+def test_split_trains(mock_fxe_raw_run):
+    run = RunDirectory(mock_fxe_raw_run)
+    assert len(run.train_ids) == 480
+
+    chunks = list(run.split_trains(3))
+    assert len(chunks) == 3
+    assert {len(c.train_ids) for c in chunks} == {160}
+
+    chunks = list(run.split_trains(4, trains_per_part=100))
+    assert len(chunks) == 5
+    assert {len(c.train_ids) for c in chunks} == {96}
+
+
 def test_train_timestamps(mock_scs_run):
     run = RunDirectory(mock_scs_run)
 


### PR DESCRIPTION
Currently, we make it easy to get all of the data for a given source & key in one go, or to work train by train. But you may want an intermediate position, where you work on chunks of, say, 10 trains at a time. This can be more efficient than reading individual trains, but use less memory than loading data from a whole run. It can also be useful for parallel processing.

Currently, calling code has to decide where to cut the data and use `.select_trains()` to get subsets. This adds a `.split_trains()` method which does that for you, given a number of parts to make and/or a maximum number of trains per part. If both parameters are given, it makes *at least* X parts so that there are *at most* Y trains per part.

