### PR TITLE
Validate indexes for CONTROL data

### DIFF
--- a/extra_data/validation.py
+++ b/extra_data/validation.py
@@ -101,6 +101,7 @@ class FileValidator:
                         ),
                         dataset=ds_path,
                     )
+                    break  # Recording every key separately can make a *lot* of errors
 
             self._check_index(f'/INDEX/{src}')
 

--- a/extra_data/validation.py
+++ b/extra_data/validation.py
@@ -103,7 +103,7 @@ class FileValidator:
                     )
                     break  # Recording every key separately can make a *lot* of errors
 
-            self._check_index(f'/INDEX/{src}')
+            self._check_index(f'INDEX/{src}')
 
         for src in self.file.instrument_sources:
             src_groups = set()
@@ -123,7 +123,7 @@ class FileValidator:
                     )
 
             for src, group in src_groups:
-                self._check_index(f'/INDEX/{src}/{group}')
+                self._check_index(f'INDEX/{src}/{group}')
 
     def _check_index(self, path):
         record = partial(self.record, dataset=path)


### PR DESCRIPTION
Previously, we were only checking the indexes for INSTRUMENT data, not CONTROL. I think we may have assumed that CONTROL was unlikely to go wrong. On #187, we found a run where there is a problem - CONTROL data missing, INDEX still records it as though it was there - which `extra-data-validate` did not pick up.

This extends the same checks we do on INSTRUMENT data to CONTROL, with one difference. We only record the "Index referring to data outside dataset" problem once per source & per file, rather than for every key. When I recorded it for every key, I got a list of some 27000 problems with the run. Once per source should be plenty to point out the problem, and then you can use `h5glance` to find more detail if necessary.


```
Checking run directory: /gpfs/exfel/exp/SPB/201901/p002316/raw/r0174
Progress: 207/207 [##################################################]
84 problems in 7 files (last: RAW-R0174-DA02-S00002.h5)
Validation failed! 84 problems:

Index referring to data (11) outside dataset (0)
  dataset: CONTROL/SPB_IRU_AGIPD1M1/CTRL/MC1/module2/dBoardTemperature2/timestamp
  file: /gpfs/exfel/exp/SPB/201901/p002316/raw/r0174/RAW-R0174-DA02-S00006.h5

Index referring to data (11) outside dataset (0)
  dataset: CONTROL/SPB_IRU_AGIPD1M/TSENS/Q2_T_BLOCK/force/timestamp
  file: /gpfs/exfel/exp/SPB/201901/p002316/raw/r0174/RAW-R0174-DA02-S00006.h5

...
```