### PR TITLE
Skip empty datasets

### DIFF
--- a/extra_data/keydata.py
+++ b/extra_data/keydata.py
@@ -29,7 +29,7 @@ class KeyData:
         """Find contiguous chunks of data for this key, in any order."""
         for file in self.files:
             if file.file[self.hdf5_data_path].size == 0:
-                # this file does not contain data for this key we skip the files here
+                # this file does not contain data for this key. We skip the files here
                 # for cases where index claims there's data for this key, but the
                 # dataset is empty.
                 continue

--- a/extra_data/keydata.py
+++ b/extra_data/keydata.py
@@ -28,6 +28,12 @@ class KeyData:
     def _find_chunks(self):
         """Find contiguous chunks of data for this key, in any order."""
         for file in self.files:
+            if file.file[self.hdf5_data_path].size == 0:
+                # this file does not contain data for this key we skip the files here
+                # for cases where index claims there's data for this key, but the
+                # dataset is empty.
+                continue
+
             firsts, counts = file.get_index(self.source, self._key_group)
 
             # Of trains in this file, which are in selection
@@ -168,6 +174,8 @@ class KeyData:
             np.repeat(chunk.train_ids, chunk.counts.astype(np.intp))
             for chunk in self._data_chunks
         ]
+        if not chunks_trainids:
+            return chunks_trainids
         return np.concatenate(chunks_trainids)
 
     def xarray(self, extra_dims=None, roi=(), name=None):

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -486,6 +486,8 @@ class DataCollection:
         if source in self.instrument_sources:
             data_path = "/INSTRUMENT/{}/{}".format(source, key.replace('.', '/'))
             for f in self._source_index[source]:
+                if f.file[data_path].size == 0:
+                    continue
                 group = key.partition('.')[0]
                 firsts, counts = f.get_index(source, group)
                 trainids = self._expand_trainids(counts, f.train_ids)
@@ -515,7 +517,10 @@ class DataCollection:
         else:
             return self._get_key_data(source, key).series()
 
-        ser = pd.concat(sorted(seq_series, key=lambda s: s.index[0]))
+        if not seq_series:
+            ser = pd.Series([])
+        else:
+            ser = pd.concat(sorted(seq_series, key=lambda s: s.index[0]))
 
         # Select out only the train IDs of interest
         if isinstance(ser.index, pd.MultiIndex):

--- a/extra_data/tests/conftest.py
+++ b/extra_data/tests/conftest.py
@@ -134,7 +134,13 @@ def mock_empty_dataset_file(format_version):
             shape = f['INSTRUMENT/SA1_XTD2_XGM/DOOCS/MAIN:output/data/intensityTD'].shape
             f['INSTRUMENT/SA1_XTD2_XGM/DOOCS/MAIN:output/data/intensityTD'].resize((0, *shape[1:]))
 
+            shape = f['INSTRUMENT/SA1_XTD2_XGM/DOOCS/MAIN:output/data/trainId'].shape
+            f['INSTRUMENT/SA1_XTD2_XGM/DOOCS/MAIN:output/data/trainId'].resize((0, *shape[1:]))
+
             shape = f['CONTROL/SA1_XTD2_XGM/DOOCS/MAIN/pulseEnergy/photonFlux/value'].shape
             f['CONTROL/SA1_XTD2_XGM/DOOCS/MAIN/pulseEnergy/photonFlux/value'].resize((0, *shape[1:]))
+
+            shape = f['CONTROL/SA1_XTD2_XGM/DOOCS/MAIN/beamPosition/ixPos/value'].shape
+            f['CONTROL/SA1_XTD2_XGM/DOOCS/MAIN/beamPosition/ixPos/value'].resize((0, *shape[1:]))
 
         yield path

--- a/extra_data/tests/conftest.py
+++ b/extra_data/tests/conftest.py
@@ -122,3 +122,19 @@ def mock_empty_file():
         path = osp.join(td, 'RAW-R0450-DA01-S00002.h5')
         make_examples.make_sa3_da_file(path, ntrains=0)
         yield path
+
+
+@pytest.fixture(scope='function')
+def mock_empty_dataset_file(format_version):
+    with TemporaryDirectory() as td:
+        path = osp.join(td, 'RAW-R0999-DA10-S00001.h5')
+        make_examples.make_fxe_da_file(path, format_version=format_version)
+
+        with h5py.File(path, 'a') as f:
+            shape = f['INSTRUMENT/SA1_XTD2_XGM/DOOCS/MAIN:output/data/intensityTD'].shape
+            f['INSTRUMENT/SA1_XTD2_XGM/DOOCS/MAIN:output/data/intensityTD'].resize((0, *shape[1:]))
+
+            shape = f['CONTROL/SA1_XTD2_XGM/DOOCS/MAIN/pulseEnergy/photonFlux/value'].shape
+            f['CONTROL/SA1_XTD2_XGM/DOOCS/MAIN/pulseEnergy/photonFlux/value'].resize((0, *shape[1:]))
+
+        yield path

--- a/extra_data/tests/test_reader_mockdata.py
+++ b/extra_data/tests/test_reader_mockdata.py
@@ -818,10 +818,17 @@ def test_empty_dataset(mock_empty_dataset_file):
     _, data = sel.train_from_index(0)
     assert list(data[device].keys()) == ['metadata']
 
-    # assert len(list(sel.trains(require_all=True))) == 0
     for _, data in sel.trains(require_all=True):
         assert key not in data[device]
         break
 
     _, data = sel.train_from_index(0)
     assert key not in data[device]
+
+    s = run.get_series(device, 'data.trainId')
+    assert isinstance(s, pd.Series)
+    assert len(s) == 0
+
+    df = run.get_dataframe(fields=[("*_XGM/*", "*.i[xy]Pos*")])
+    assert len(df.columns) == 4
+    assert "SA1_XTD2_XGM/DOOCS/MAIN/beamPosition.ixPos" in df.columns

--- a/extra_data/tests/test_reader_mockdata.py
+++ b/extra_data/tests/test_reader_mockdata.py
@@ -804,3 +804,24 @@ def test_run_metadata(mock_spb_raw_run):
             'sample', 'sequenceNumber',
         }
         assert isinstance(md['creationDate'], str)
+
+
+def test_empty_dataset(mock_empty_dataset_file):
+
+    run = H5File(mock_empty_dataset_file)
+    device, key = 'SA1_XTD2_XGM/DOOCS/MAIN:output', 'data.intensityTD'
+
+    assert run.get_array(device, key).size == 0
+    assert run.get_dask_array(device, key).size == 0
+
+    sel = run.select(device, key)
+    _, data = sel.train_from_index(0)
+    assert list(data[device].keys()) == ['metadata']
+
+    # assert len(list(sel.trains(require_all=True))) == 0
+    for _, data in sel.trains(require_all=True):
+        assert key not in data[device]
+        break
+
+    _, data = sel.train_from_index(0)
+    assert key not in data[device]


### PR DESCRIPTION
Fixes #189 

I simplified the case where we skip a dataset when it is completely empty in a file, as it it the only scenario I've seen so far where we had index filled but no data.