### PR TITLE
Add KeyData.drop_empty_trains() method to drop trains with no data

### DIFF
--- a/docs/reading_files.rst
+++ b/docs/reading_files.rst
@@ -133,6 +133,8 @@ below, e.g.::
 
    .. automethod:: select_trains
 
+   .. automethod:: drop_missing
+
 The run or file object (a :class:`DataCollection`) also has methods to load
 data by sources and keys. :meth:`get_array`, :meth:`get_dask_array` and
 :meth:`get_series` are directly equivalent to the options above, but other

--- a/extra_data/keydata.py
+++ b/extra_data/keydata.py
@@ -111,7 +111,7 @@ class KeyData:
             inc_suspect_trains=self.inc_suspect_trains,
         )
 
-    def drop_missing(self):
+    def drop_empty_trains(self):
         """Select only trains with data as a new :class:`KeyData` object."""
         counts = self.data_counts(labelled=False)
         tids = np.array(self.train_ids)[counts > 0]

--- a/extra_data/tests/test_keydata.py
+++ b/extra_data/tests/test_keydata.py
@@ -130,7 +130,7 @@ def test_select_by(mock_spb_raw_run):
     assert subrun.keys_for_source(am0.source) == {am0.key}
 
 
-def test_drop_missing(mock_sa3_control_data):
+def test_drop_empty_trains(mock_sa3_control_data):
     f = H5File(mock_sa3_control_data)
     beamview = f['SA3_XTD10_IMGFEL/CAM/BEAMVIEW2:daqOutput', 'data.image.dims']
 
@@ -141,7 +141,7 @@ def test_drop_missing(mock_sa3_control_data):
     assert frame_counts.shape == (500,)
     assert frame_counts.min() == 0
 
-    beamview_w_data = beamview.drop_missing()
+    beamview_w_data = beamview.drop_empty_trains()
     assert len(beamview_w_data.train_ids) == 250
     np.testing.assert_array_equal(beamview_w_data.ndarray(), a1)
     frame_counts = beamview_w_data.data_counts(labelled=False)

--- a/extra_data/tests/test_keydata.py
+++ b/extra_data/tests/test_keydata.py
@@ -137,7 +137,13 @@ def test_drop_missing(mock_sa3_control_data):
     assert len(beamview.train_ids) == 500
     a1 = beamview.ndarray()
     assert a1.shape == (250, 2)
+    frame_counts = beamview.data_counts(labelled=False)
+    assert frame_counts.shape == (500,)
+    assert frame_counts.min() == 0
 
     beamview_w_data = beamview.drop_missing()
     assert len(beamview_w_data.train_ids) == 250
     np.testing.assert_array_equal(beamview_w_data.ndarray(), a1)
+    frame_counts = beamview_w_data.data_counts(labelled=False)
+    assert frame_counts.shape == (250,)
+    assert frame_counts.min() == 1

--- a/extra_data/tests/test_keydata.py
+++ b/extra_data/tests/test_keydata.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from extra_data import RunDirectory
+from extra_data import RunDirectory, H5File
 from extra_data.exceptions import TrainIDError
 
 def test_get_keydata(mock_spb_raw_run):
@@ -113,3 +113,16 @@ def test_select_by(mock_spb_raw_run):
     subrun = run.select(am0)
     assert subrun.all_sources == {am0.source}
     assert subrun.keys_for_source(am0.source) == {am0.key}
+
+
+def test_drop_missing(mock_sa3_control_data):
+    f = H5File(mock_sa3_control_data)
+    beamview = f['SA3_XTD10_IMGFEL/CAM/BEAMVIEW2:daqOutput', 'data.image.dims']
+
+    assert len(beamview.train_ids) == 500
+    a1 = beamview.ndarray()
+    assert a1.shape == (250, 2)
+
+    beamview_w_data = beamview.drop_missing()
+    assert len(beamview_w_data.train_ids) == 250
+    np.testing.assert_array_equal(beamview_w_data.ndarray(), a1)


### PR DESCRIPTION
This is roughly equivalent to `.select(..., require_all=True)`, for a single source:

```python
beamview_dims = run['SA3_XTD10_IMGFEL/CAM/BEAMVIEW2:daqOutput', 'data.image.dims'].drop_missing()
```

The naming is roughly imitating pandas (`dropna`, `drop_duplicates`)

I've also added `.data_counts(labelled=False)` to find where there's data without having to load pandas.
