### PR TITLE
Deprecate h5index and *_to_cbf functions

### DIFF
--- a/extra_data/h5index.py
+++ b/extra_data/h5index.py
@@ -1,7 +1,13 @@
 import csv
 import h5py
 import sys
+import warnings
 
+warnings.warn(
+    "extra_data.h5index is deprecated and likely to be removed. "
+    "If you are using it, please contact da-support@xfel.eu.",
+    stacklevel=2,
+)
 
 def hdf5_datasets(grp):
     """Print CSV data of all datasets in an HDF5 file.

--- a/extra_data/utils.py
+++ b/extra_data/utils.py
@@ -10,6 +10,7 @@ program. If not, see <https://opensource.org/licenses/BSD-3-Clause>
 
 from psutil import net_if_addrs
 from socket import AF_INET
+from warnings import warn
 
 import h5py
 import numpy as np
@@ -130,6 +131,12 @@ def hdf5_paths(ds, indent=0, maxlen=100):
 
 def numpy_to_cbf(np_array, index=0, header=None):
     """Given a 3D numpy array, convert it to a CBF data object"""
+    warn(
+        "The numpy_to_cbf and hdf5_to_cbf functions are deprecated and likely "
+        "to be removed. If you are using either of them, please contact "
+        "da-support@xfel.eu .", stacklevel=2,
+    )
+
     import fabio.cbfimage
     img_reduced = np_array[index, ...]
     return fabio.cbfimage.cbfimage(header=header or {}, data=img_reduced)

--- a/extra_data/utils.py
+++ b/extra_data/utils.py
@@ -119,7 +119,12 @@ class QuickView:
 
 
 def hdf5_paths(ds, indent=0, maxlen=100):
-    """Visit and print name of all element in HDF5 file (from S Hauf)"""
+    """Deprecated: Visit and print name of all element in HDF5 file (from S Hauf)"""
+    warn(
+        "hdf5_paths is deprecated and likely to be removed. Try our h5glance "
+        "package for a similar view of HDF5 files. If this is a problem, "
+        "please contact da-support@xfel.eu .", stacklevel=2,
+    )
 
     for k in list(ds.keys())[:maxlen]:
         print(" " * indent + k)
@@ -130,7 +135,7 @@ def hdf5_paths(ds, indent=0, maxlen=100):
 
 
 def numpy_to_cbf(np_array, index=0, header=None):
-    """Given a 3D numpy array, convert it to a CBF data object"""
+    """Deprecated: Given a 3D numpy array, convert it to a CBF data object"""
     warn(
         "The numpy_to_cbf and hdf5_to_cbf functions are deprecated and likely "
         "to be removed. If you are using either of them, please contact "
@@ -143,7 +148,7 @@ def numpy_to_cbf(np_array, index=0, header=None):
 
 
 def hdf5_to_cbf(in_h5file, cbf_filename, index, header=None):
-    """Conversion from HDF5 file to cbf binary image file"""
+    """Deprecated: Conversion from HDF5 file to cbf binary image file"""
     tmpf = h5py.File(in_h5file, 'r')
     paths = list(tmpf["METADATA/dataSourceId"])
     image_path = [p for p in paths if p.endswith(b"image")][0]


### PR DESCRIPTION
* `h5index` was basically a script I used when creating the mock data to check that its structure matched the real data. It worked, but it's very basic & limited and there are no tests for it. I'd rather people didn't notice that it's included in extra_data and then start relying on it.
* The `*_to_cbf` functions are the only part which depends on [FabIO](https://pypi.org/project/fabio/). `numpy_to_cbf` is trivial - you could just use the function from fabio directly. `hdf5_to_cbf` could conceivably be useful, but if you want to convert >1 image it's probably inefficient (reopening the HDF5 file for each one). I'd like to wait for @tmichela to approve deprecating those, since they've been in the code longer than I've been at EuXFEL.