### PR TITLE
keep run_metadata if its a union of a single run

### DIFF
--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -593,17 +593,27 @@ class DataCollection:
         files = set(self.files)
         train_ids = set(self.train_ids)
 
+        dc_run_num = self.run_metadata()["runNumber"] if self.is_single_run else None  # noqa
+
         for other in others:
             files.update(other.files)
             train_ids.update(other.train_ids)
+            # Set self.is_single_run to False
+            # in case of Unioning multiple run DataCollections.
 
+            if not (
+                other.is_single_run and
+                other.run_metadata()["runNumber"] == dc_run_num
+            ):
+                self.is_single_run = False
         train_ids = sorted(train_ids)
-        selection = union_selections([self.selection] +
-                                     [o.selection for o in others])
+        selection = union_selections(
+            [self.selection] + [o.selection for o in others])
 
         return DataCollection(
             files, selection=selection, train_ids=train_ids,
             inc_suspect_trains=self.inc_suspect_trains,
+            is_single_run = self.is_single_run,
         )
 
     def _expand_selection(self, selection):

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -593,7 +593,11 @@ class DataCollection:
         files = set(self.files)
         train_ids = set(self.train_ids)
 
-        dc_run_num = self.run_metadata()["runNumber"] if self.is_single_run else None  # noqa
+        run_num = self.run_metadata()[
+            "runNumber"] if self.is_single_run else None
+
+        proposal_num = self.run_metadata()[
+            "proposalNumber"] if self.is_single_run else None
 
         for other in others:
             files.update(other.files)
@@ -603,9 +607,11 @@ class DataCollection:
 
             if not (
                 other.is_single_run and
-                other.run_metadata()["runNumber"] == dc_run_num
+                other.run_metadata()["runNumber"] == run_num and
+                other.run_metadata()["proposalNumber"] == proposal_num
             ):
                 self.is_single_run = False
+
         train_ids = sorted(train_ids)
         selection = union_selections(
             [self.selection] + [o.selection for o in others])

--- a/extra_data/tests/mockdata/base.py
+++ b/extra_data/tests/mockdata/base.py
@@ -156,7 +156,10 @@ def write_metadata(h5file, data_sources, chunksize=16, format_version='0.5'):
         h5file['METADATA/karaboFramework'] = [b'2.7.0']
         h5file.create_dataset('METADATA/proposalNumber', dtype=np.uint32,
                               data=[700000])
-        h5file.create_dataset('METADATA/runNumber', dtype=np.uint32, data=[1])
+        h5file.create_dataset(
+            'METADATA/runNumber', dtype=np.uint32,
+            data=[int(re.findall(r".*-R([0-9]+)-.*", h5file.filename)[0])],
+        )
         h5file['METADATA/runType'] = [b'Test DAQ']
         h5file['METADATA/sample'] = [b'No Sample']
         # get sequence number

--- a/extra_data/tests/test_reader_mockdata.py
+++ b/extra_data/tests/test_reader_mockdata.py
@@ -787,15 +787,31 @@ def test_get_run_value(mock_fxe_control_data):
         f.get_run_value(src, 'non.existant')
 
 
-def test_get_run_value_union(mock_fxe_control_data, mock_sa3_control_data):
+def test_get_run_value_union_multirun(mock_fxe_control_data, mock_lpd_data):
     f = H5File(mock_fxe_control_data)
-    f2 = H5File(mock_sa3_control_data)
+    f2 = H5File(mock_lpd_data)
     data = f.union(f2)
     with pytest.raises(MultiRunError):
         data.get_run_value('FXE_XAD_GEC/CAM/CAMERA', 'firmwareVersion')
 
     with pytest.raises(MultiRunError):
         data.get_run_values('FXE_XAD_GEC/CAM/CAMERA')
+
+
+def test_get_run_value_union(mock_fxe_control_data, mock_sa3_control_data):
+    f = H5File(mock_fxe_control_data)
+    f2 = H5File(mock_sa3_control_data)
+    data = f.union(f2)
+    if data.files[0].format_version != '0.5':
+        assert data.get_run_value(
+            'FXE_XAD_GEC/CAM/CAMERA', 'firmwareVersion') == 0
+
+        assert (
+            data.run_metadata()["runNumber"] ==
+            f.run_metadata()["runNumber"] ==
+            f2.run_metadata()["runNumber"]
+        )
+
 
 def test_get_run_values(mock_fxe_control_data):
     f = H5File(mock_fxe_control_data)


### PR DESCRIPTION
This PR is related to https://git.xfel.eu/gitlab/detectors/pycalibration/merge_requests/535


Creating a union out of Different `H5File`  `DataCollections` of the same run, acts as if it is not a single run anymore.

As I wanted to create a Union of certain files without loading all run files and then selecting specific sources. I created these changes to keep run_metadata of a union as long as it is of the same run.


@takluyver 