### PR TITLE
Make dependencies for karabo_bridge streaming optional

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Install dependencies
       run: |
         python3 -m pip install --upgrade pip
-        python3 -m pip install .[test] --constraint .github/dependabot/constraints.txt
+        python3 -m pip install .[bridge,test] --constraint .github/dependabot/constraints.txt
 
     - name: Test with pytest
       run: |

--- a/docs/streaming.rst
+++ b/docs/streaming.rst
@@ -12,11 +12,22 @@ To stream the data from a file or run unmodified, use the command::
 
 The number (4545) must be an unused TCP port above 1024. It will bind to
 this and stream the data to any connected clients.
-
 Command-line options are explained on the
 :ref:`command reference <cmd-serve-files>` page.
 
-We provide Karabo bridge clients as Python and C++ libraries.
+.. note::
+
+   If you install EXtra-data yourself, streaming data requires some optional
+   dependencies. To ensure you have these, run::
+
+      pip install extra_data[bridge]
+
+   These dependencies are installed in the EuXFEL Anaconda installation on the
+   Maxwell cluster.
+
+We provide Karabo bridge clients as `Python
+<https://github.com/European-XFEL/karabo-bridge-py>`__ and `C++ libraries
+<https://github.com/European-XFEL/karabo-bridge-cpp>`__.
 
 If you want to do some processing on the data before streaming it, you can
 use this Python interface to send it out:

--- a/extra_data/cli/serve_files.py
+++ b/extra_data/cli/serve_files.py
@@ -1,0 +1,61 @@
+from argparse import ArgumentParser
+import sys
+
+IMPORT_FAILED_MSG = """\
+{}
+
+karabo-bridge-serve-files requires additional dependencies:
+    pip install karabo-bridge psutil
+"""
+
+def main(argv=None):
+    ap = ArgumentParser(prog="karabo-bridge-serve-files")
+    ap.add_argument("path", help="Path of a file or run directory to serve")
+    ap.add_argument("port", help="TCP port or ZMQ endpoint to send data on")
+    ap.add_argument(
+        "--source", help="Stream only matching sources ('*' is a wildcard)",
+        default='*',
+    )
+    ap.add_argument(
+        "--key", help="Stream only matching keys ('*' is a wildcard)",
+        default='*',
+    )
+    ap.add_argument(
+        "--append-detector-modules", help="combine multiple module sources"
+        " into one (will only work for AGIPD data currently).",
+        action='store_true'
+    )
+    ap.add_argument(
+        "--dummy-timestamps", help="create dummy timestamps if the meta-data"
+        " lacks proper timestamps",
+        action='store_true'
+    )
+    ap.add_argument(
+        "--use-infiniband", help="Use infiniband interface if available "
+                                 "(if a TCP port is specified)",
+        action='store_true'
+    )
+    ap.add_argument(
+        "-z", "--socket-type", help="ZeroMQ socket type",
+        choices=['PUB', 'PUSH', 'REP'], default='REP'
+    )
+    args = ap.parse_args(argv)
+
+    try:
+        from ..export import serve_files
+    except ImportError as e:
+        sys.exit(IMPORT_FAILED_MSG.format(e))
+
+    try:
+        serve_files(
+            args.path, args.port, source_glob=args.source, key_glob=args.key,
+            append_detector_modules=args.append_detector_modules,
+            dummy_timestamps=args.dummy_timestamps,
+            use_infiniband=args.use_infiniband, sock=args.socket_type
+        )
+    except KeyboardInterrupt:
+        pass
+    print('\nStopped.')
+
+if __name__ == '__main__':
+    main()

--- a/extra_data/export.py
+++ b/extra_data/export.py
@@ -10,7 +10,6 @@ You should have received a copy of the 3-Clause BSD License along with this
 program. If not, see <https://opensource.org/licenses/BSD-3-Clause>
 """
 
-from argparse import ArgumentParser
 import os.path as osp
 from socket import AF_INET
 from warnings import warn
@@ -36,7 +35,7 @@ def find_infiniband_ip():
     """
     addrs = net_if_addrs()
     for addr in addrs.get('ib0', ()):
-        if addr.family is AF_INET:
+        if addr.family == AF_INET:
             return addr.address
     return '*'
 

--- a/extra_data/export.py
+++ b/extra_data/export.py
@@ -12,19 +12,33 @@ program. If not, see <https://opensource.org/licenses/BSD-3-Clause>
 
 from argparse import ArgumentParser
 import os.path as osp
+from socket import AF_INET
 from warnings import warn
 
 from karabo_bridge import ServerInThread
 from karabo_bridge.server import Sender
+from psutil import net_if_addrs
 
 from .components import XtdfDetectorBase
 from .exceptions import SourceNameError
 from .reader import RunDirectory, H5File
 from .stacking import stack_detector_data
-from .utils import find_infiniband_ip
 
 
 __all__ = ['ZMQStreamer', 'serve_files']
+
+
+def find_infiniband_ip():
+    """Find the first infiniband IP address
+
+    :returns: str
+        IP of the first infiniband interface if it exists else '*'
+    """
+    addrs = net_if_addrs()
+    for addr in addrs.get('ib0', ()):
+        if addr.family is AF_INET:
+            return addr.address
+    return '*'
 
 
 class ZMQStreamer(ServerInThread):
@@ -148,47 +162,3 @@ def serve_files(path, port, source_glob='*', key_glob='*',
     # wait until ZMQ has finished transferring them before the socket is closed.
     sender.server_socket.close(linger=-1)
 
-
-def main(argv=None):
-    ap = ArgumentParser(prog="karabo-bridge-serve-files")
-    ap.add_argument("path", help="Path of a file or run directory to serve")
-    ap.add_argument("port", help="TCP port or ZMQ endpoint to send data on")
-    ap.add_argument(
-        "--source", help="Stream only matching sources ('*' is a wildcard)",
-        default='*',
-    )
-    ap.add_argument(
-        "--key", help="Stream only matching keys ('*' is a wildcard)",
-        default='*',
-    )
-    ap.add_argument(
-        "--append-detector-modules", help="combine multiple module sources"
-        " into one (will only work for AGIPD data currently).",
-        action='store_true'
-    )
-    ap.add_argument(
-        "--dummy-timestamps", help="create dummy timestamps if the meta-data"
-        " lacks proper timestamps",
-        action='store_true'
-    )
-    ap.add_argument(
-        "--use-infiniband", help="Use infiniband interface if available "
-                                 "(if a TCP port is specified)",
-        action='store_true'
-    )
-    ap.add_argument(
-        "-z", "--socket-type", help="ZeroMQ socket type",
-        choices=['PUB', 'PUSH', 'REP'], default='REP'
-    )
-    args = ap.parse_args(argv)
-
-    try:
-        serve_files(
-            args.path, args.port, source_glob=args.source, key_glob=args.key,
-            append_detector_modules=args.append_detector_modules,
-            dummy_timestamps=args.dummy_timestamps,
-            use_infiniband=args.use_infiniband, sock=args.socket_type
-        )
-    except KeyboardInterrupt:
-        pass
-    print('\nStopped.')

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -22,7 +22,6 @@ import numpy as np
 from operator import index
 import os
 import os.path as osp
-import psutil
 import re
 import signal
 import sys
@@ -48,6 +47,7 @@ from .read_machinery import (
 from .run_files_map import RunFilesMap
 from . import locality
 from .file_access import FileAccess
+from .utils import available_cpu_cores
 
 __all__ = [
     'H5File',
@@ -151,9 +151,7 @@ class DataCollection:
                 # prevent child processes from receiving KeyboardInterrupt
                 signal.signal(signal.SIGINT, signal.SIG_IGN)
 
-            # cpu_affinity give a list of cpu cores we can use, can be all or a
-            # subset of the cores the machine has.
-            nproc = min(len(psutil.Process().cpu_affinity()), len(uncached))
+            nproc = min(available_cpu_cores(), len(uncached))
             with Pool(processes=nproc, initializer=initializer) as pool:
                 for fname, fa in pool.imap_unordered(cls._open_file, uncached):
                     if isinstance(fa, FileAccess):

--- a/extra_data/utils.py
+++ b/extra_data/utils.py
@@ -9,7 +9,6 @@ program. If not, see <https://opensource.org/licenses/BSD-3-Clause>
 """
 
 import os
-from socket import AF_INET
 from warnings import warn
 
 import h5py
@@ -156,20 +155,6 @@ def hdf5_to_cbf(in_h5file, cbf_filename, index, header=None):
     cbf_out = numpy_to_cbf(images, index=index)
     cbf_out.write(cbf_filename)
     print("Convert {} index {} to {}".format(in_h5file, index, cbf_filename))
-
-
-def find_infiniband_ip():
-    """Find the first infiniband IP address
-
-    :returns: str
-        IP of the first infiniband interface if it exists else '*'
-    """
-    from psutil import net_if_addrs
-    addrs = net_if_addrs()
-    for addr in addrs.get('ib0', ()):
-        if addr.family is AF_INET:
-            return addr.address
-    return '*'
 
 
 def available_cpu_cores():

--- a/extra_data/utils.py
+++ b/extra_data/utils.py
@@ -8,7 +8,7 @@ You should have received a copy of the 3-Clause BSD License along with this
 program. If not, see <https://opensource.org/licenses/BSD-3-Clause>
 """
 
-from psutil import net_if_addrs
+import os
 from socket import AF_INET
 from warnings import warn
 
@@ -164,8 +164,20 @@ def find_infiniband_ip():
     :returns: str
         IP of the first infiniband interface if it exists else '*'
     """
+    from psutil import net_if_addrs
     addrs = net_if_addrs()
     for addr in addrs.get('ib0', ()):
         if addr.family is AF_INET:
             return addr.address
     return '*'
+
+
+def available_cpu_cores():
+    # This process may be restricted to a subset of the cores on the machine;
+    # sched_getaffinity() tells us which on some Unix flavours (inc Linux)
+    if hasattr(os, 'sched_getaffinity'):
+        return len(os.sched_getaffinity(0))
+    else:
+        # Fallback, inc on Windows
+        ncpu = os.cpu_count() or 2
+        return min(ncpu, 8)

--- a/setup.py
+++ b/setup.py
@@ -47,14 +47,16 @@ setup(name="EXtra-data",
       install_requires=[
           'fabio',
           'h5py>=2.10',
-          'karabo-bridge >=0.6',
           'matplotlib',
           'numpy',
           'pandas',
-          'psutil',
           'xarray',
       ],
       extras_require={
+          'bridge': [
+              'karabo-bridge >=0.6',
+              'psutil',
+          ],
           'docs': [
               'sphinx',
               'nbsphinx',

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(name="EXtra-data",
       entry_points={
           "console_scripts": [
               "lsxfel = extra_data.lsxfel:main",
-              "karabo-bridge-serve-files = extra_data.export:main",
+              "karabo-bridge-serve-files = extra_data.cli.serve_files:main",
               "extra-data-validate = extra_data.validation:main",
               "extra-data-make-virtual-cxi = extra_data.cli.make_virtual_cxi:main",
               "extra-data-locality = extra_data.locality:main",


### PR DESCRIPTION
Including making psutil optional. Part of #210.

- [x] What to call the extra? `bridge`? `stream`? `streaming`?
- [x] Document extra