### PR TITLE
Fix listing of RUN keys in lsxfel and run.info()

### DIFF
--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -1065,7 +1065,9 @@ class DataCollection:
                 if run_only_keys:
                     print('    - Additional run keys (1 entry per run):')
                     for k in sorted(run_only_keys):
-                        ds = self._source_index[s][0].file[f"/RUN/{s}/{k.replace('.', '/')}"]
+                        ds = self._source_index[s][0].file[
+                            f"/RUN/{s}/{k.replace('.', '/')}/value"
+                        ]
                         entry_shape = ds.shape[1:]
                         if entry_shape:
                             entry_info = f", entry shape {entry_shape}"

--- a/extra_data/tests/test_reader_mockdata.py
+++ b/extra_data/tests/test_reader_mockdata.py
@@ -71,6 +71,11 @@ def test_train_info(mock_lpd_data, capsys):
         assert "FXE_DET_LPD1M-1/DET/0CH0:xtdf" in out
 
 
+def test_info(mock_spb_raw_run):
+    run = RunDirectory(mock_spb_raw_run)
+    run.info(details_for_sources='*/DOOCS/*')  # Smoketest
+
+
 def test_iterate_trains_fxe(mock_fxe_control_data):
     with H5File(mock_fxe_control_data) as f:
         for train_id, data in islice(f.trains(), 10):


### PR DESCRIPTION
While investigating something else, I noticed that #206 broke listing the RUN keys with things like `lsxfel --detail '*/XGM/*'`. This fixes it again.