### PR TITLE
Fix KeyData.data_counts() with no data

### DIFF
--- a/extra_data/tests/test_keydata.py
+++ b/extra_data/tests/test_keydata.py
@@ -121,6 +121,19 @@ def test_data_counts(mock_reduced_spb_proc_run):
     assert count.values.sum() == mod.shape[0]
 
 
+def test_data_counts_empty(mock_fxe_raw_run):
+    run = RunDirectory(mock_fxe_raw_run)
+    cam_nodata = run['FXE_XAD_GEC/CAM/CAMERA_NODATA:daqOutput', 'data.image.pixels']
+
+    count_ser = cam_nodata.data_counts(labelled=True)
+    assert len(count_ser) == 480
+    assert count_ser.sum() == 0
+
+    count_arr = cam_nodata.data_counts(labelled=False)
+    assert len(count_arr) == 480
+    assert count_arr.sum() == 0
+
+
 def test_select_by(mock_spb_raw_run):
     run = RunDirectory(mock_spb_raw_run)
     am0 = run['SPB_DET_AGIPD1M-1/DET/0CH0:xtdf', 'image.data']

--- a/extra_data/tests/test_keydata.py
+++ b/extra_data/tests/test_keydata.py
@@ -68,6 +68,10 @@ def test_nodata(mock_fxe_raw_run):
     assert arr.shape == (0, 255, 1024)
     assert arr.dtype == np.dtype('u2')
 
+    dask_arr = cam_pix.dask_array(labelled=True)
+    assert dask_arr.shape == (0, 255, 1024)
+    assert dask_arr.dtype == np.dtype('u2')
+
     assert list(cam_pix.trains()) == []
     tid, data = cam_pix.train_from_id(10010)
     assert tid == 10010
@@ -133,6 +137,11 @@ def test_data_counts_empty(mock_fxe_raw_run):
     assert len(count_arr) == 480
     assert count_arr.sum() == 0
 
+    count_none_ser = cam_nodata.drop_empty_trains().data_counts(labelled=True)
+    assert len(count_none_ser) == 0
+
+    count_none_arr = cam_nodata.drop_empty_trains().data_counts(labelled=False)
+    assert len(count_none_arr) == 0
 
 def test_select_by(mock_spb_raw_run):
     run = RunDirectory(mock_spb_raw_run)


### PR DESCRIPTION
Closes #221 

There are two related cases. If there are trains selected with no data, `.data_counts()` should give one zero entry per train selected. If there are no trains selected, it should return an array/series with length 0.