### PR TITLE
Skip chunks from files with no trains

### DIFF
--- a/extra_data/keydata.py
+++ b/extra_data/keydata.py
@@ -30,6 +30,9 @@ class KeyData:
     def _find_chunks(self):
         """Find contiguous chunks of data for this key, in any order."""
         for file in self.files:
+            if len(file.train_ids) == 0:
+                continue
+
             firsts, counts = file.get_index(self.source, self._key_group)
 
             # Of trains in this file, which are in selection


### PR DESCRIPTION
I don't think this happens any more with new data, but while looking at old data I came across a file which was valid HDF5 but had no trains (`INDEX/trainId` length 0). This was failing from `KeyData._find_chunks()`, specifically on this line:

https://github.com/European-XFEL/EXtra-data/blob/ad47920f487ecc98e7a2844b6da6f2caec6e1b9e/extra_data/read_machinery.py#L184

This simply skips over those files in `_find_chunks`. We could exclude them entirely, but the easy way to do that would also skip caching details about them in the 'run map', so the empty files would have to be re-inspected each time the run was opened.