### PR TITLE
Expose public KeyData.train_id_coordinates() method

### DIFF
--- a/docs/reading_files.rst
+++ b/docs/reading_files.rst
@@ -136,6 +136,8 @@ below, e.g.::
        :doc:`dask_averaging`
          An example using Dask with EuXFEL data
 
+   .. automethod:: train_ids_for_data
+
    .. automethod:: select_trains
    
    .. automethod:: split_trains

--- a/extra_data/keydata.py
+++ b/extra_data/keydata.py
@@ -197,8 +197,20 @@ class KeyData:
 
         return out
 
-    def _trainid_index(self):
-        """A 1D array of train IDs, corresponding to self.shape[0]"""
+    def train_ids_for_data(self):
+        """Make an array of train IDs to use alongside data from ``.ndarray()``.
+
+        :attr:`train_ids` includes each selected train ID once, including trains
+        where data is missing. :meth:`train_ids_for_data` excludes missing
+        trains, and repeats train IDs if the source has multiple entries
+        per train. The result will be the same length as the first dimension
+        of an array from :meth:`ndarray`, and tells you which train each entry
+        belongs to.
+
+        .. seealso::
+
+           :meth:`xarray` returns a labelled array including these train IDs.
+        """
         if not self._data_chunks:
             return np.zeros(0, dtype=np.uint64)
         chunks_trainids = [
@@ -240,7 +252,7 @@ class KeyData:
         dims = ['trainId'] + extra_dims
 
         # Train ID index
-        coords = {'trainId': self._trainid_index()}
+        coords = {'trainId': self.train_ids_for_data()}
 
         if name is None:
             name = f'{self.source}.{self.key}'
@@ -262,7 +274,7 @@ class KeyData:
         if name.endswith('.value') and self.section == 'CONTROL':
             name = name[:-6]
 
-        index = pd.Index(self._trainid_index(), name='trainId')
+        index = pd.Index(self.train_ids_for_data(), name='trainId')
         data = self.ndarray()
         return pd.Series(data, name=name, index=index)
 
@@ -325,7 +337,7 @@ class KeyData:
             dims = ['trainId'] + ['dim_%d' % i for i in range(dask_arr.ndim - 1)]
 
             # Train ID index
-            coords = {'trainId': self._trainid_index()}
+            coords = {'trainId': self.train_ids_for_data()}
 
             import xarray
             return xarray.DataArray(dask_arr, dims=dims, coords=coords)

--- a/extra_data/keydata.py
+++ b/extra_data/keydata.py
@@ -197,11 +197,11 @@ class KeyData:
 
         return out
 
-    def train_ids_for_data(self):
+    def train_id_coordinates(self):
         """Make an array of train IDs to use alongside data from ``.ndarray()``.
 
         :attr:`train_ids` includes each selected train ID once, including trains
-        where data is missing. :meth:`train_ids_for_data` excludes missing
+        where data is missing. :meth:`train_id_coordinates` excludes missing
         trains, and repeats train IDs if the source has multiple entries
         per train. The result will be the same length as the first dimension
         of an array from :meth:`ndarray`, and tells you which train each entry
@@ -252,7 +252,7 @@ class KeyData:
         dims = ['trainId'] + extra_dims
 
         # Train ID index
-        coords = {'trainId': self.train_ids_for_data()}
+        coords = {'trainId': self.train_id_coordinates()}
 
         if name is None:
             name = f'{self.source}.{self.key}'
@@ -274,7 +274,7 @@ class KeyData:
         if name.endswith('.value') and self.section == 'CONTROL':
             name = name[:-6]
 
-        index = pd.Index(self.train_ids_for_data(), name='trainId')
+        index = pd.Index(self.train_id_coordinates(), name='trainId')
         data = self.ndarray()
         return pd.Series(data, name=name, index=index)
 
@@ -337,7 +337,7 @@ class KeyData:
             dims = ['trainId'] + ['dim_%d' % i for i in range(dask_arr.ndim - 1)]
 
             # Train ID index
-            coords = {'trainId': self.train_ids_for_data()}
+            coords = {'trainId': self.train_id_coordinates()}
 
             import xarray
             return xarray.DataArray(dask_arr, dims=dims, coords=coords)


### PR DESCRIPTION
Looking at some code used at FXE, I noticed that there was a pattern of loading data as a NumPy array, along with an array of train IDs to use with the data. You can already get an [xarray DataArray](http://xarray.pydata.org/en/stable/user-guide/data-structures.html#dataarray) which has the train IDs incorporated as labels, but not everyone's going to use Xarray.

```python
jf = run['FXE_XAD_JF1M/DET/JNGFR02:daqOutput', 'data.adc']

# This already works
jf_xarr  = jf.xarray()
jf_data = jf_xarr.values
jf_train_ids = jf.coords['trainId'].values

# New option
jf_data = jf.ndarray()
jf_train_ids = jf.train_ids_for_data()
```