### PR TITLE
A robust way to retrieve reduced key values 

### DIFF
--- a/docs/reading_files.rst
+++ b/docs/reading_files.rst
@@ -146,6 +146,11 @@ below, e.g.::
    
       .. versionadded:: 1.7
 
+   .. automethod:: as_single_value
+   
+      .. versionadded:: 1.9
+
+
 The run or file object (a :class:`DataCollection`) also has methods to load
 data by sources and keys. :meth:`get_array`, :meth:`get_dask_array` and
 :meth:`get_series` are directly equivalent to the options above, but other

--- a/extra_data/exceptions.py
+++ b/extra_data/exceptions.py
@@ -37,3 +37,16 @@ class MultiRunError(ValueError):
             "because you have used .union() to combine data. Please retrieve "
             "this information before combining."
         )
+
+
+class NoDataError(ValueError):
+    def __init__(self, source, key=None):
+        self.source = source
+        self.key = key
+
+    def __str__(self):
+        if self.key is not None:
+            return 'This data is empty for key {!r} of source {!r}'.format(
+                self.key, self.source)
+        else:
+            return 'This data is empty for source {!r}'.format(self.source)

--- a/extra_data/keydata.py
+++ b/extra_data/keydata.py
@@ -169,7 +169,7 @@ class KeyData:
             idxs = np.argsort(train_ids)
             return counts[idxs]
 
-    def single_value(self, rtol=1e-5, atol=0.0, reduce_by='median'):
+    def as_single_value(self, rtol=1e-5, atol=0.0, reduce_by='median'):
         """Retrieve a single reduced value if within tolerances.
 
         The relative and absolute tolerances *rtol* and *atol* work the

--- a/extra_data/keydata.py
+++ b/extra_data/keydata.py
@@ -169,6 +169,42 @@ class KeyData:
             idxs = np.argsort(train_ids)
             return counts[idxs]
 
+    def single_value(self, rtol=1e-5, atol=0.0, reduce_by='median'):
+        """Retrieve a single reduced value if within tolerances.
+
+        The relative and absolute tolerances *rtol* and *atol* work the
+        same way as in ``numpy.allclose``. The default relative tolerance
+        is 1e-5 with no absolute tolerance. The data for this key is compared
+        against a reduced value obtained by the method described in *reduce_by*.
+
+        This may be a callable taking the key data, the string value of a
+        global symbol in the numpy packge such as 'median' or 'first' to use
+        the first value encountered. By default, 'median' is used.
+
+        If within tolerances, the reduced value is returned.
+        """
+
+        data = self.ndarray()
+
+        if callable(reduce_by):
+            value = reduce_by(data)
+        elif isinstance(reduce_by, str) and hasattr(np, reduce_by):
+            value = getattr(np, reduce_by)(data, axis=0)
+        elif reduce_by == 'first':
+            value = data[0]
+        else:
+            raise ValueError('invalid reduction method (may be callable, '
+                             'global numpy symbol or "first")')
+
+        if not np.allclose(data, value, rtol=rtol, atol=atol):
+            adev = np.max(np.abs(data - value))
+            rdev = np.max(np.abs(adev / value))
+
+            raise ValueError(f'data values are not within tolerance '
+                             f'(absolute: {adev:.3g}, relative: {rdev:.3g})')
+
+        return value
+
     # Getting data as different kinds of array: -------------------------------
 
     def ndarray(self, roi=()):

--- a/extra_data/keydata.py
+++ b/extra_data/keydata.py
@@ -2,7 +2,7 @@ from typing import List, Optional, Tuple
 
 import numpy as np
 
-from .exceptions import TrainIDError
+from .exceptions import TrainIDError, NoDataError
 from .file_access import FileAccess
 from .read_machinery import (
     contiguous_regions, DataChunk, select_train_ids, split_trains, roi_shape
@@ -185,6 +185,9 @@ class KeyData:
         """
 
         data = self.ndarray()
+
+        if len(data) == 0:
+            raise NoDataError(self.source, self.key)
 
         if callable(reduce_by):
             value = reduce_by(data)

--- a/extra_data/tests/test_keydata.py
+++ b/extra_data/tests/test_keydata.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 from extra_data import RunDirectory, H5File
-from extra_data.exceptions import TrainIDError
+from extra_data.exceptions import TrainIDError, NoDataError
 
 def test_get_keydata(mock_spb_raw_run):
     run = RunDirectory(mock_spb_raw_run)
@@ -172,7 +172,13 @@ def test_drop_empty_trains(mock_sa3_control_data):
 
 def test_single_value(mock_sa3_control_data, monkeypatch):
     f = H5File(mock_sa3_control_data)
+
+    imager = f['SA3_XTD10_IMGFEL/CAM/BEAMVIEW:daqOutput', 'data.image.pixels']
     flux = f['SA3_XTD10_XGM/XGM/DOOCS', 'pulseEnergy.photonFlux']
+
+    with pytest.raises(NoDataError):
+        imager.as_single_value()  # FEL imager with no data.
+        flux[:0].as_single_value()  # No data through selection.
 
     # Monkeypatch some actual data into the KeyData object
     data = np.arange(flux.shape[0])

--- a/extra_data/tests/test_keydata.py
+++ b/extra_data/tests/test_keydata.py
@@ -176,18 +176,25 @@ def test_single_value(mock_sa3_control_data, monkeypatch):
     imager = f['SA3_XTD10_IMGFEL/CAM/BEAMVIEW:daqOutput', 'data.image.pixels']
     flux = f['SA3_XTD10_XGM/XGM/DOOCS', 'pulseEnergy.photonFlux']
 
+    # Try without data for a source and key.
     with pytest.raises(NoDataError):
         imager.as_single_value()  # FEL imager with no data.
+
+    with pytest.raises(NoDataError):
         flux[:0].as_single_value()  # No data through selection.
 
     # Monkeypatch some actual data into the KeyData object
     data = np.arange(flux.shape[0])
     monkeypatch.setattr(flux, 'ndarray', lambda: data)
 
+    # Try some tolerances that have to fail.
     with pytest.raises(ValueError):
-        # Try some tolerances that have to fail.
         flux.as_single_value()
+
+    with pytest.raises(ValueError):
         flux.as_single_value(atol=1)
+
+    with pytest.raises(ValueError):
         flux.as_single_value(rtol=0.1)
 
     # Try with large enough tolerances.

--- a/extra_data/tests/test_keydata.py
+++ b/extra_data/tests/test_keydata.py
@@ -180,19 +180,19 @@ def test_single_value(mock_sa3_control_data, monkeypatch):
 
     with pytest.raises(ValueError):
         # Try some tolerances that have to fail.
-        flux.single_value()
-        flux.single_value(atol=1)
-        flux.single_value(rtol=0.1)
+        flux.as_single_value()
+        flux.as_single_value(atol=1)
+        flux.as_single_value(rtol=0.1)
 
     # Try with large enough tolerances.
-    assert flux.single_value(atol=len(data)/2) == np.median(data)
-    assert flux.single_value(rtol=0.5, atol=len(data)/4) == np.median(data)
-    assert flux.single_value(rtol=1) == np.median(data)
+    assert flux.as_single_value(atol=len(data)/2) == np.median(data)
+    assert flux.as_single_value(rtol=0.5, atol=len(data)/4) == np.median(data)
+    assert flux.as_single_value(rtol=1) == np.median(data)
 
     # Other reduction options
-    assert flux.single_value(rtol=1, reduce_by='mean') == np.mean(data)
-    assert flux.single_value(rtol=1, reduce_by=np.mean) == np.mean(data)
-    assert flux.single_value(atol=len(data)-1, reduce_by='first') == 0
+    assert flux.as_single_value(rtol=1, reduce_by='mean') == np.mean(data)
+    assert flux.as_single_value(rtol=1, reduce_by=np.mean) == np.mean(data)
+    assert flux.as_single_value(atol=len(data)-1, reduce_by='first') == 0
 
     # Try vector data.
     intensity = f['SA3_XTD10_XGM/XGM/DOOCS:output', 'data.intensityTD']
@@ -200,6 +200,6 @@ def test_single_value(mock_sa3_control_data, monkeypatch):
     monkeypatch.setattr(intensity, 'ndarray', lambda: data)
 
     with pytest.raises(ValueError):
-        intensity.single_value()
+        intensity.as_single_value()
 
-    np.testing.assert_equal(intensity.single_value(rtol=1), np.median(data))
+    np.testing.assert_equal(intensity.as_single_value(rtol=1), np.median(data))


### PR DESCRIPTION
Quite often, `CONTROL` data is assumed constant for a given run or other unit of analysis, e.g. for the detector conditions when applying corrections. A common pattern here is to omit proper checks that this is actually the case. This PR adds the method `KeyData.single_value` which performs such checks automatically in a configurable way and a corresponding entry point in `DataCollection.get_single_value`.

The implementation is centered around [`np.allclose`](https://numpy.org/doc/stable/reference/generated/numpy.allclose.html) which defines a relative and absolute tolerance combined into a single check. The reduction method to obtain the value to check the data against can be configured, but the median is used by default. It may be passed either as `Callable`, the string of a global symbol in `numpy` such as `median` or `mean` or the special case `first`.

Technically both the `str` version and `first` are redundant with just passing a `Callable`, e.g. `np.mean` instead of `'mean'` and `lambda x: x[0]` instead of `first`, but it seemed convenient to provide. I don't have strong feelings about this.

If the reduced value is within the specified tolerances, it is returned. If not, a `ValueError` is raised. I was not sure whether it makes sense to add a derived exception class here to distinguish it from other `ValueError`s.