### PR TITLE
Fix get_array() when introducing gaps in multi-module detector data

### DIFF
--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -556,12 +556,12 @@ class XtdfDetectorBase(MultimodDetectorBase):
         ):
             inc_pulses_chunk = sel_frames[tgt_slice]
             if inc_pulses_chunk.sum() == 0:  # No data from this chunk selected
-                return
+                continue
             elif inc_pulses_chunk.all():  # All pulses in chunk
                 chunk.dataset.read_direct(
                     mod_out[tgt_slice], source_sel=(chunk_slice,) + roi
                 )
-                return
+                continue
 
             # Read a subset of pulses from the chunk:
 

--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -578,7 +578,7 @@ class XtdfDetectorBase(MultimodDetectorBase):
             # zeros() uses calloc, so the OS can do virtual memory tricks.
             # Don't change this to zeros_like() !
             tmp = np.zeros(chunk.dataset.shape, chunk.dataset.dtype)
-            pulse_sel = np.nonzero(inc_pulses_chunk)[0] + chunk.first
+            pulse_sel = np.nonzero(inc_pulses_chunk)[0] + chunk_slice.start
             sel_region = (pulse_sel,) + roi
             chunk.dataset.read_direct(
                 tmp, source_sel=sel_region, dest_sel=sel_region,

--- a/extra_data/tests/conftest.py
+++ b/extra_data/tests/conftest.py
@@ -70,6 +70,13 @@ def mock_lpd_parallelgain_run():
 
 
 @pytest.fixture(scope='session')
+def mock_lpd_mini_gap_run():
+    with TemporaryDirectory() as td:
+        make_examples.make_lpd_run_mini_missed_train(td)
+        yield td
+
+
+@pytest.fixture(scope='session')
 def mock_spb_proc_run(format_version):
     with TemporaryDirectory() as td:
         make_examples.make_spb_run(td, raw=False, format_version=format_version)

--- a/extra_data/tests/make_examples.py
+++ b/extra_data/tests/make_examples.py
@@ -244,6 +244,24 @@ def make_lpd_parallelgain_run(dir_path, raw=True, format_version='0.5'):
                       frames_per_train=300)
         ], ntrains=100, chunksize=32, format_version=format_version)
 
+def make_lpd_run_mini_missed_train(dir_path):
+    write_file(osp.join(dir_path, 'RAW-R0450-LPD00-S00000.h5'), [
+        LPDModule('FXE_DET_LPD1M-1/DET/0CH0', frames_per_train=10),
+    ], ntrains=5, chunksize=5, format_version='1.0')
+    mod1_f = osp.join(dir_path, 'RAW-R0450-LPD01-S00000.h5')
+    write_file(mod1_f, [
+        LPDModule('FXE_DET_LPD1M-1/DET/1CH0', frames_per_train=10),
+    ], ntrains=4, chunksize=5, format_version='1.0')
+
+    # Modify the file for module 1, as if it missed train 10002
+    # & fill some data to check in the test.
+    with h5py.File(mod1_f, 'r+') as f:
+        f['INDEX/trainId'][:4] = [10000, 10001, 10003, 10004]
+        mod1_dset = f['INSTRUMENT/FXE_DET_LPD1M-1/DET/1CH0:xtdf/image/data']
+        print(mod1_dset.shape)
+        mod1_dset[8::10, 0, 0, 0] = np.arange(1, 5)
+
+
 def make_spb_run(dir_path, raw=True, sensor_size=(1024, 768), format_version='0.5'):
     prefix = 'RAW' if raw else 'CORR'
     for modno in range(16):

--- a/extra_data/tests/make_examples.py
+++ b/extra_data/tests/make_examples.py
@@ -258,7 +258,6 @@ def make_lpd_run_mini_missed_train(dir_path):
     with h5py.File(mod1_f, 'r+') as f:
         f['INDEX/trainId'][:4] = [10000, 10001, 10003, 10004]
         mod1_dset = f['INSTRUMENT/FXE_DET_LPD1M-1/DET/1CH0:xtdf/image/data']
-        print(mod1_dset.shape)
         mod1_dset[8::10, 0, 0, 0] = np.arange(1, 5)
 
 

--- a/extra_data/tests/test_components.py
+++ b/extra_data/tests/test_components.py
@@ -134,6 +134,22 @@ def test_get_array_pulse_indexes_reduced_data(mock_reduced_spb_proc_run):
     assert np.isin(arr.coords['pulse'], [1, 7, 15, 23]).all()
 
 
+def test_get_array_gap(mock_lpd_mini_gap_run):
+    run = RunDirectory(mock_lpd_mini_gap_run)
+    det = LPD1M(run, modules=[0, 1])
+
+    # All pulses
+    arr = det.get_array('image.data')
+    assert arr.shape == (2, 5, 10, 256, 256)
+    np.testing.assert_array_equal(arr[1, :, 8, 0, 0], [1, 2, 0, 3, 4])
+
+    # Selected pulses
+    arr = det.get_array('image.data', pulses=[8])
+    assert arr.shape == (2, 5, 1, 256, 256)
+    np.testing.assert_array_equal(arr[1, :, 0, 0, 0], [1, 2, 0, 3, 4])
+
+
+
 def test_get_array_roi(mock_fxe_raw_run):
     run = RunDirectory(mock_fxe_raw_run)
     det = LPD1M(run.select_trains(by_index[:3]))


### PR DESCRIPTION
@daviddoji alerted me to a bug when reading LPD data, where the same data would appear in the array twice.

This turned out to be when we introduce a gap in the data for one module, where that module missed a train which other modules recorded. I.e. a contiguous chunk of data in the file has to be split into 2 or more pieces in the output array. After each split, it was going back to the start of the source chunk, instead of continuing from after the split point. This only affects the new code path for reading with a pulse selection.

Edit: I found another bug when introducing gaps and *not* using pulse selection. Another win for tests.


~~I'm not exactly sure how to have a good test for this.~~