### PR TITLE
Only merge in open_run(..., data='all') if raw is not a subset of proc

### DIFF
--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -1493,9 +1493,15 @@ def open_run(
         raw_extra = raw_dc.deselect(
             [(src, '*') for src in raw_dc.all_sources & proc_dc.all_sources])
 
-        # Merge extra raw sources into proc sources and re-enable is_single_run.
-        dc = proc_dc.union(raw_extra)
-        dc.is_single_run = True
+        if raw_extra.files:
+            # If raw is not a subset of proc, merge the "extra" raw
+            # sources into proc sources and re-enable is_single_run.
+            dc = proc_dc.union(raw_extra)
+            dc.is_single_run = True
+        else:
+            # If raw is a subset of proc, just use proc.
+            dc = proc_dc
+
         return dc
 
     if isinstance(proposal, str):


### PR DESCRIPTION
`open_run(..., data='all')` throws an exception since https://github.com/European-XFEL/EXtra-data/pull/208 if `raw` is completely a subset of `proc`, because it will try to access the metadata of `raw` \ `proc` while merging this into `proc`. If this set is empty however, the call to `DataCollection.run_metadata()` fails due to access to `files[0]`.

While this begs a larger question of whether such `DataCollection` objects such exist in the first place, @takluyver and me agreed to discuss this separately in https://github.com/European-XFEL/EXtra-data/issues/235. It is clearly not necessary and thus a bug in `open_run` do try this in the first place if the `DataCollection` is empty anyway.