### PR TITLE
Allow for usable DataCollection with no trains selected

### DIFF
--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -819,8 +819,7 @@ class DataCollection:
                     train_ids = np.intersect1d(train_ids, source_tids)
 
             # Filtering may have eliminated previously selected files.
-            files = [f for f in files
-                     if f.has_train_ids(train_ids, self.inc_suspect_trains)]
+            files = self._filter_files_for_trains(files, train_ids, selection.keys())
 
             train_ids = list(train_ids)  # Convert back to a list.
 
@@ -900,14 +899,30 @@ class DataCollection:
         """
         new_train_ids = select_train_ids(self.train_ids, train_range)
 
-        files = [f for f in self.files
-                 if f.has_train_ids(new_train_ids, self.inc_suspect_trains)]
+        files = self._filter_files_for_trains(
+            self.files, new_train_ids, self.all_sources
+        )
 
         return DataCollection(
             files, selection=self.selection, train_ids=new_train_ids,
             inc_suspect_trains=self.inc_suspect_trains,
             is_single_run=self.is_single_run,
         )
+
+    def _filter_files_for_trains(self, files, train_ids, sel_sources) -> list:
+        """Filter the files by trains, retaining >= 1 file for each source
+
+        This allows inspection, and access to RUN data, even if no data for that
+        source is selected.
+        """
+        files = {f for f in files
+                 if f.has_train_ids(train_ids, self.inc_suspect_trains)}
+
+        sources_in_files = set().union(f.all_sources for f in files)
+        for src in (sel_sources - sources_in_files):
+            files.add(self._source_index[src][0])
+
+        return sorted(files, key=lambda f: f.filename)
 
     def split_trains(self, parts=None, trains_per_part=None):
         """Split this data into chunks with a fraction of the trains each.

--- a/extra_data/tests/test_reader_mockdata.py
+++ b/extra_data/tests/test_reader_mockdata.py
@@ -826,6 +826,28 @@ def test_get_run_values(mock_fxe_control_data):
     assert isinstance(d['enableShutter.value'], np.uint8)
 
 
+def test_get_run_values_no_trains(mock_jungfrau_run):
+    run = RunDirectory(mock_jungfrau_run)
+    sel = run.select_trains(np.s_[:0])
+    d = sel.get_run_values('SPB_IRDA_JF4M/MDL/POWER')
+    assert isinstance(d['voltage.value'], np.float64)
+
+
+def test_inspect_key_no_trains(mock_jungfrau_run):
+    run = RunDirectory(mock_jungfrau_run)
+    sel = run.select_trains(np.s_[:0])
+
+    # CONTROL
+    jf_pwr_voltage = sel['SPB_IRDA_JF4M/MDL/POWER', 'voltage']
+    assert jf_pwr_voltage.shape == (0,)
+    assert jf_pwr_voltage.dtype == np.dtype(np.float64)
+
+    # INSTRUMENT
+    jf_m1_data = sel['SPB_IRDA_JF4M/DET/JNGFR01:daqOutput', 'data.adc']
+    assert jf_m1_data.shape == (0, 16, 512, 1024)
+    assert jf_m1_data.dtype == np.dtype(np.uint16)
+
+
 def test_run_metadata(mock_spb_raw_run):
     run = RunDirectory(mock_spb_raw_run)
     md = run.run_metadata()
@@ -839,3 +861,9 @@ def test_run_metadata(mock_spb_raw_run):
             'sample', 'sequenceNumber',
         }
         assert isinstance(md['creationDate'], str)
+
+def test_run_metadata_no_trains(mock_scs_run):
+    run = RunDirectory(mock_scs_run)
+    sel = run.select_trains(np.s_[:0])
+    md = sel.run_metadata()
+    assert md['dataFormatVersion'] == '1.0'


### PR DESCRIPTION
As discussed in #235, keep at least one FileAccess object for each selected source, even if there are no trains selected, allowing for access to data in RUN and METADATA, and inspecting the shape & dtype of CONTROL & INSTRUMENT data.