### PR TITLE
Avoid scanning keys when making selection

### DIFF
--- a/extra_data/file_access.py
+++ b/extra_data/file_access.py
@@ -315,6 +315,15 @@ class FileAccess:
             counts = np.uint64((ix_group['last'][:ntrains] - firsts + 1) * status)
         return firsts, counts
 
+    def index_group_names(self, source):
+        """Get group names for index data, to use with .get_index()"""
+        if source in self.control_sources:
+            return {''}
+        elif source in self.instrument_sources:
+            return set(self.file[f'/INDEX/{source}'].keys())
+        else:
+            raise SourceNameError(source)
+
     def metadata(self) -> dict:
         """Get the contents of the METADATA group as a dict
 

--- a/extra_data/read_machinery.py
+++ b/extra_data/read_machinery.py
@@ -260,3 +260,6 @@ def find_proposal(propno):
         return d
 
     raise Exception("Couldn't find proposal dir for {!r}".format(propno))
+
+
+glob_wildcards_re = re.compile(r'([*?[])')

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -802,9 +802,9 @@ class DataCollection:
                     # many cases this is 'data', but not always.
                     if keys is None:
                         # All keys are selected.
-                        keys = self.keys_for_source(source)
-
-                    groups = {key.partition('.')[0] for key in keys}
+                        groups = self._source_index[source][0].index_group_names()
+                    else:
+                        groups = {key.partition('.')[0] for key in keys}
                 else:
                     # CONTROL data has no key group.
                     groups = ['']

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -802,7 +802,8 @@ class DataCollection:
                     # many cases this is 'data', but not always.
                     if keys is None:
                         # All keys are selected.
-                        groups = self._source_index[source][0].index_group_names()
+                        f = self._source_index[source][0]
+                        groups = f.index_group_names(source)
                     else:
                         groups = {key.partition('.')[0] for key in keys}
                 else:


### PR DESCRIPTION
A minor performance improvement to avoid scanning all keys in a couple of cases when making a selection:

- When passing a complete key with no wildcards where a glob pattern *could* be used, we can just check for that specific key rather than loading all keys and matching them.
- When the selection keeps all keys from a source (`'*'`) and you use `require_all=True`, so it needs to find indexes

I want to avoid scanning the keys in particular for proc data, because depending on how it's written, some of the keys may be further into the file, which means transferring more chunks to read them. I want to avoid this when writing the corrected data, but it seems worth guarding against it here.

Testing with proc data, I see roughly a 20% speedup selecting single keys and 10% improvement on selecting all keys, though the timings are quite noisy. I hope that it will be more advantageous the slower GPFS is, but I have no good way to test that. I also tested with raw data, which gives far less consistent timings, but these changes seem to be similar or slightly better there too.

<details>
<summary>Timing details</summary>

Code to test:

```python
from extra_data import open_run

run = open_run(2744, 151, data='proc')

# Wildcards
sel = run.select([
    ('FXE_RR_DAQ/ADC/1:network', '*'),
    ('FXE_XAD_JF1M/DET/JNGFR02:daqOutput', '*'),
    ('FXE_AUXT_LIC/DOOCS/PPODL','*'),
    ('FXE_SMS_USR/MOTOR/UM03','*'),
    ('FXE_SMS_USR/MOTOR/UM13','*'),
], require_all=True)

# Single keys
sel = run.select([
    ('FXE_RR_DAQ/ADC/1:network', 'digitizers.channel_1_A.raw.samples'),
    ('FXE_XAD_JF1M/DET/JNGFR02:daqOutput', 'data.adc'),
    ('FXE_AUXT_LIC/DOOCS/PPODL','actualPosition'),
    ('FXE_SMS_USR/MOTOR/UM03','actualPosition'),
    ('FXE_SMS_USR/MOTOR/UM13','actualPosition'),
], require_all=True)
```

I tested with [hyperfine](https://github.com/sharkdp/hyperfine) and with my own [timecmp](https://gitlab.com/takluyver/timecmp) - which is much rougher, but I like it because it alternates between the options rather than doing A several times and then B several times.

hyperfine sample results:

```
$ hyperfine -w 2 'python select_branch_singlekeys.py' 'python select_installed_singlekeys.py'
Benchmark 1: python select_branch_singlekeys.py
  Time (mean ± σ):     552.2 ms ±  72.5 ms    [User: 305.3 ms, System: 359.7 ms]
  Range (min … max):   504.1 ms … 747.5 ms    10 runs
 
Benchmark 2: python select_installed_singlekeys.py
  Time (mean ± σ):     672.2 ms ±  14.1 ms    [User: 424.8 ms, System: 388.5 ms]
  Range (min … max):   647.9 ms … 689.7 ms    10 runs
 
Summary
  'python select_branch_singlekeys.py' ran
    1.22 ± 0.16 times faster than 'python select_installed_singlekeys.py'

$ hyperfine -w 2 'python select_branch_wildcard.py' 'python select_installed_wildcard.py'
Benchmark 1: python select_branch_wildcard.py
  Time (mean ± σ):     532.6 ms ±  17.0 ms    [User: 302.5 ms, System: 374.5 ms]
  Range (min … max):   512.2 ms … 563.3 ms    10 runs
 
Benchmark 2: python select_installed_wildcard.py
  Time (mean ± σ):     606.9 ms ±  18.3 ms    [User: 367.0 ms, System: 381.6 ms]
  Range (min … max):   588.6 ms … 645.3 ms    10 runs
 
Summary
  'python select_branch_wildcard.py' ran
    1.14 ± 0.05 times faster than 'python select_installed_wildcard.py'
```

timecmp sample results:

single keys (A is released version, B is this branch)

```
Wall clock time:
A:  862.807ms ████████████████████████████████████████ 
B:  570.714ms ██████████████████████████▍
A:  650.375ms ██████████████████████████████▏
B:  515.380ms ███████████████████████▉
A:  702.862ms ████████████████████████████████▌
B:  550.661ms █████████████████████████▌

CPU time:
A:  917.481ms ████████████████████████████████████████ 
B:  797.786ms ██████████████████████████████████▊
A:  848.062ms ████████████████████████████████████▉
B:  698.786ms ██████████████████████████████▍
A:  892.779ms ██████████████████████████████████████▉
B:  726.051ms ███████████████████████████████▋
```

Wildcard (A is released version, B is this branch):

```
Wall clock time:
A:  867.868ms ████████████████████████████████████████ 
B:  522.637ms ████████████████████████ 
A:  609.384ms ████████████████████████████ 
B:  532.653ms ████████████████████████▌
A:  627.096ms ████████████████████████████▉
B:  542.592ms █████████████████████████ 

CPU time:
A:  810.263ms ████████████████████████████████████████ 
B:  651.526ms ████████████████████████████████▏
A:  767.957ms █████████████████████████████████████▉
B:  673.428ms █████████████████████████████████▏
A:  756.035ms █████████████████████████████████████▎
B:  683.191ms █████████████████████████████████▋
```
</details>