### PR TITLE
Add repr for DataCollection objects

### DIFF
--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -981,6 +981,10 @@ class DataCollection:
 
         return None, None
 
+    def __repr__(self):
+        return f"<extra_data.DataCollection for {len(self.all_sources)} " \
+               f"sources and {len(self.train_ids)} trains>"
+
     def info(self, details_for_sources=()):
         """Show information about the selected data.
         """


### PR DESCRIPTION
We have repr methods for KeyData & SourceData already, so this seems like an obvious addition. :slightly_smiling_face: 