### PR TITLE
Use a metaclass to make FileAccess behave as expected

### DIFF
--- a/extra_data/tests/test_file_access.py
+++ b/extra_data/tests/test_file_access.py
@@ -1,0 +1,44 @@
+import pickle
+
+from ..file_access import FileAccess
+
+
+def test_registry(mock_sa3_control_data):
+    fa = FileAccess(mock_sa3_control_data)
+
+    # Load some data to populate caches
+    fa.get_index('SA3_XTD10_IMGFEL/CAM/BEAMVIEW2:daqOutput', 'data')
+    fa.get_keys('SA3_XTD10_IMGFEL/CAM/BEAMVIEW2:daqOutput')
+
+    assert len(fa._index_cache) == 1
+    assert len(fa._keys_cache) == 1
+
+    # This should get a reference to the existing object, not a duplicate.
+    fa2 = FileAccess(mock_sa3_control_data)
+
+    assert fa2 is fa
+
+    # __init__() should not have been called again
+    assert len(fa._index_cache) == 1
+    assert len(fa._keys_cache) == 1
+
+
+def test_pickle(mock_sa3_control_data):
+    fa = FileAccess(mock_sa3_control_data)
+    b = pickle.dumps(fa)
+
+    # Load some data to populate caches
+    fa.get_index('SA3_XTD10_IMGFEL/CAM/BEAMVIEW2:daqOutput', 'data')
+    fa.get_keys('SA3_XTD10_IMGFEL/CAM/BEAMVIEW2:daqOutput')
+
+    assert len(fa._index_cache) == 1
+    assert len(fa._keys_cache) == 1
+
+    # Unpickling should get a reference to the existing object, not a duplicate.
+    fa2 = pickle.loads(b)
+
+    assert fa2 is fa
+
+    # Unpickling should not update state of existing object
+    assert len(fa._index_cache) == 1
+    assert len(fa._keys_cache) == 1

--- a/extra_data/tests/test_file_access.py
+++ b/extra_data/tests/test_file_access.py
@@ -1,3 +1,4 @@
+import gc
 import pickle
 
 from ..file_access import FileAccess
@@ -42,3 +43,13 @@ def test_pickle(mock_sa3_control_data):
     # Unpickling should not update state of existing object
     assert len(fa._index_cache) == 1
     assert len(fa._keys_cache) == 1
+
+    # Delete the existing instances, then reload from pickle
+    del fa, fa2
+    gc.collect()
+
+    fa3 = pickle.loads(b)
+    assert len(fa3._index_cache) == 0
+    assert len(fa3._keys_cache) == 0
+    assert 'SA3_XTD10_IMGFEL/CAM/BEAMVIEW2:daqOutput' in fa3.instrument_sources
+    assert len(fa3.train_ids) == 500


### PR DESCRIPTION
@philsmt - this came from our discussion yesterday.

This uses a metaclass so that attempting to instantiate `FileAccess()` will look in the registry for an existing instance, and not reinitialise it if it exists. Likewise, unpickling a FileAccess object won't overwrite the state (caches) of an object that already exists.

I had a go at implementing the other option with the `.get()` classmethod as well - branch [`file-access-no-reinit`](https://github.com/European-XFEL/EXtra-data/compare/file-access-no-reinit) - but I think I prefer this one. It's too easy with the `.get()` option to use the normal constructor instead, and get duplicate objects. I could make it an error to call `FileAccess()` directly, but I'm reluctant to do that in case someone is using it outside our code; it's not documented but it's not hard to find.

