### PR TITLE
Virtual overview edits

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,3 @@
 [run]
 omit = */tests/*
-concurrency = "multiprocessing"
+concurrency = multiprocessing

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -1474,7 +1474,7 @@ RunHandler = RunDirectory
 
 def open_run(
         proposal, run, data='raw', include='*', file_filter=locality.lc_any, *,
-        inc_suspect_trains=True
+        inc_suspect_trains=True, _use_voview=True,
 ):
     """Access EuXFEL data on the Maxwell cluster by proposal and run number.
 
@@ -1542,5 +1542,5 @@ def open_run(
 
     return RunDirectory(
         osp.join(prop_dir, data, run), include=include, file_filter=file_filter,
-        inc_suspect_trains=inc_suspect_trains,
+        inc_suspect_trains=inc_suspect_trains, _use_voview=_use_voview
     )


### PR DESCRIPTION
@takluyver I just had a go with generating virtual overview files. it looks like it's working fine for me. I've added some of the changes we discussed last time:
- do no check for mtime
- write overview file to /usr

I'd ideally like to deploy autogeneration of these files before the next user run. Luckily the next Karabo release has an updated numpy version making easier to deploy extra-data in that environment \o/