### PR TITLE
Track files by source

### DIFF
--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -840,7 +840,7 @@ class FramesFileWriter(FileWriter):
         frame_tids_piecewise = []
 
         src_files = sorted(
-            self.data._source_index[source],
+            self.data[source].files,
             key=lambda fa: fa.train_ids[0]
         )
 

--- a/extra_data/read_machinery.py
+++ b/extra_data/read_machinery.py
@@ -2,7 +2,6 @@
 
 The public API is in extra_data.reader; this is internal code.
 """
-from collections import defaultdict
 from glob import iglob
 import logging
 import math

--- a/extra_data/read_machinery.py
+++ b/extra_data/read_machinery.py
@@ -204,25 +204,6 @@ def contiguous_regions(condition):
     return idx
 
 
-def union_selections(selections):
-    """Merge together different selections
-
-    A selection is a dict of {source: set(keys)}, or {source: None}
-    to include all keys for a given source.
-    """
-    selection_multi = defaultdict(list)
-
-    for seln in selections:
-        for source, keys in seln.items():
-            selection_multi[source].append(keys)
-
-    # Merge selected keys; None -> all keys selected
-    return {
-        source: None if (None in keygroups) else set().union(*keygroups)
-        for (source, keygroups) in selection_multi.items()
-    }
-
-
 def roi_shape(orig_shape: tuple, roi: tuple) -> tuple:
     """Find array shape after slicing ROI"""
     dummy = np.zeros((0,) + orig_shape)  # Extra 0 dim -> minimal memory use

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -635,7 +635,9 @@ class DataCollection:
                 if source not in self.all_sources:
                     raise SourceNameError(source)
 
-                if in_keys is not None and not isinstance(in_keys, set):
+                # Empty dict was accidentally allowed and tested; keep it
+                # working just in case.
+                if in_keys is not None and not isinstance(in_keys, (set, dict)):
                     raise TypeError(
                         f"keys in selection dict should be a set or None (got "
                         f"{in_keys!r})"

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -637,7 +637,10 @@ class DataCollection:
 
                 # Empty dict was accidentally allowed and tested; keep it
                 # working just in case.
-                if in_keys is not None and not isinstance(in_keys, (set, dict)):
+                if in_keys == {}:
+                    in_keys = set()
+
+                if in_keys is not None and not isinstance(in_keys, set):
                     raise TypeError(
                         f"keys in selection dict should be a set or None (got "
                         f"{in_keys!r})"

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -211,6 +211,15 @@ class DataCollection:
         return {src: srcdata.sel_keys for src, srcdata in self._sources_data.items()}
 
     @property
+    def _source_index(self):
+        warn(
+            "DataCollection._source_index will be removed. "
+            "Contact da-support@xfel.eu if you need to discuss alternatives.",
+            stacklevel=2
+        )
+        return {src: srcdata.files for src, srcdata in self._sources_data.items()}
+
+    @property
     def all_sources(self):
         return self.control_sources | self.instrument_sources
 

--- a/extra_data/sourcedata.py
+++ b/extra_data/sourcedata.py
@@ -133,6 +133,14 @@ class SourceData:
         return matched
 
     def select_keys(self, keys) -> 'SourceData':
+        """Select a subset of the keys in this source
+
+        *keys* is either a single key name, a set of names, or a glob pattern
+        (e.g. ``beamPosition.*``) matching a subset of keys. PropertyNameError
+        is matched if a specified key does not exist.
+
+        Returns a new :class:`SourceData` object.
+        """
         if isinstance(keys, str):
             keys = self._glob_keys(keys)
         elif keys:
@@ -176,6 +184,8 @@ class SourceData:
         return res
 
     def select_trains(self, trains) -> 'SourceData':
+        """Select a subset of trains in this data as a new :class:`SourceData` object.
+        """
         return self._only_tids(select_train_ids(self.train_ids, trains))
 
     def _only_tids(self, tids) -> 'SourceData':
@@ -190,6 +200,12 @@ class SourceData:
         return res
 
     def union(self, *others) -> 'SourceData':
+        """Combine two or more ``SourceData`` objects
+
+        These must be for the same source, e.g. from separate runs.
+        """
+        if len({sd.source for sd in (self,) + others}) > 1:
+            raise ValueError("Cannot use SourceData.union() with different sources")
         keygroups = [sd.sel_keys for sd in (self,) + others]
         files = set(self.files)
         train_ids = set(self.train_ids)

--- a/extra_data/tests/test_reader_mockdata.py
+++ b/extra_data/tests/test_reader_mockdata.py
@@ -511,7 +511,7 @@ def test_select(mock_fxe_raw_run):
         sel.select('FXE_DET_LPD1M-1/DET/0CH0:xtdf', '*') \
            .keys_for_source('FXE_DET_LPD1M-1/DET/0CH0:xtdf')
     assert sel.keys_for_source('FXE_DET_LPD1M-1/DET/0CH0:xtdf') == \
-        sel.select({'FXE_DET_LPD1M-1/DET/0CH0:xtdf': set()}) \
+        sel.select({'FXE_DET_LPD1M-1/DET/0CH0:xtdf': {}}) \
            .keys_for_source('FXE_DET_LPD1M-1/DET/0CH0:xtdf')
 
     # Re-select a different but originally valid key, should fail.

--- a/extra_data/tests/test_reader_mockdata.py
+++ b/extra_data/tests/test_reader_mockdata.py
@@ -530,8 +530,10 @@ def test_select(mock_fxe_raw_run):
     assert sel_by_dc.train_ids == sel.train_ids
 
 
-@pytest.mark.parametrize('select_str',
-                         ['*/BEAMVIEW2:daqOutput', '*/BEAMVIEW2*', '*'])
+@pytest.mark.parametrize(
+    'select_str',
+    ['*/BEAMVIEW2:daqOutput', '*/BEAMVIEW2*', '*', [('*/BEAMVIEW2:*', 'data.image.*')]]
+)
 def test_select_require_all(mock_sa3_control_data, select_str):
     # De-select two sources in this example set, which have no trains
     # at all, to allow matching trains across all sources with the same

--- a/extra_data/tests/test_reader_mockdata.py
+++ b/extra_data/tests/test_reader_mockdata.py
@@ -511,7 +511,7 @@ def test_select(mock_fxe_raw_run):
         sel.select('FXE_DET_LPD1M-1/DET/0CH0:xtdf', '*') \
            .keys_for_source('FXE_DET_LPD1M-1/DET/0CH0:xtdf')
     assert sel.keys_for_source('FXE_DET_LPD1M-1/DET/0CH0:xtdf') == \
-        sel.select({'FXE_DET_LPD1M-1/DET/0CH0:xtdf': {}}) \
+        sel.select({'FXE_DET_LPD1M-1/DET/0CH0:xtdf': set()}) \
            .keys_for_source('FXE_DET_LPD1M-1/DET/0CH0:xtdf')
 
     # Re-select a different but originally valid key, should fail.
@@ -764,8 +764,8 @@ def test_open_run(mock_spb_raw_run, mock_spb_proc_run, tmpdir):
         # Proc is a true subset.
         assert proc_run.all_sources < all_run.all_sources
 
-        for source, files in all_run._source_index.items():
-            for file in files:
+        for source, srcdata in all_run._sources_data.items():
+            for file in srcdata.files:
                 if '/DET/' in source:
                     # AGIPD data is in proc.
                     assert '/raw/' not in file.filename

--- a/extra_data/tests/test_sourcedata.py
+++ b/extra_data/tests/test_sourcedata.py
@@ -29,3 +29,28 @@ def test_keys(mock_spb_raw_run):
     assert 'beamPosition.ixPos.value' not in xgm.keys(inc_timestamps=False)
     assert 'beamPosition.ixPos.timestamp' not in xgm.keys(inc_timestamps=False)
     assert 'beamPosition.ixPos' in xgm.keys(inc_timestamps=False)
+
+def test_select_keys(mock_spb_raw_run):
+    run = RunDirectory(mock_spb_raw_run)
+    xgm = run['SPB_XTD9_XGM/DOOCS/MAIN']
+
+    # Select exact key
+    xpos_key = 'beamPosition.ixPos.value'
+    assert xgm.select_keys('beamPosition.ixPos.value').keys() == {xpos_key}
+    assert xgm.select_keys('beamPosition.ixPos').keys() == {xpos_key}
+    assert xgm.select_keys({'beamPosition.ixPos.value'}).keys() == {xpos_key}
+    assert xgm.select_keys({'beamPosition.ixPos'}).keys() == {xpos_key}
+
+    # Select all keys
+    all_keys = xgm.keys()
+    assert xgm.select_keys(set()).keys() == all_keys
+    assert xgm.select_keys(None).keys() == all_keys
+    assert xgm.select_keys('*').keys() == all_keys
+
+    # Select keys with glob pattern
+    beampos_keys = {
+        'beamPosition.ixPos.value', 'beamPosition.ixPos.timestamp',
+        'beamPosition.iyPos.value', 'beamPosition.iyPos.timestamp'
+    }
+    assert xgm.select_keys('beamPosition.*').keys() == beampos_keys
+    assert xgm.select_keys('beamPosition.*').select_keys('*').keys() == beampos_keys

--- a/extra_data/write_cxi.py
+++ b/extra_data/write_cxi.py
@@ -335,7 +335,7 @@ class XtdfCXIWriter(VirtualCXIWriterBase):
           to h5py virtual layouts.
         """
         src = next(iter(self.detdata.source_to_modno))
-        h5file = self.data._source_index[src][0].file
+        h5file = self.data[src].files[0].file
         image_grp = h5file['INSTRUMENT'][src][self.group_label]
 
         VLayout = h5py.VirtualLayout
@@ -418,7 +418,7 @@ class JUNGFRAUCXIWriter(VirtualCXIWriterBase):
           to h5py virtual layouts.
         """
         src = next(iter(self.detdata.source_to_modno))
-        h5file = self.data._source_index[src][0].file
+        h5file = self.data[src].files[0].file
         image_grp = h5file['INSTRUMENT'][src][self.group_label]
 
         VLayout = h5py.VirtualLayout

--- a/extra_data/writer.py
+++ b/extra_data/writer.py
@@ -26,7 +26,7 @@ class FileWriter:
         for key in sorted(self.data.keys_for_source(source)):
             path = f"{self._section(source)}/{source}/{key.replace('.', '/')}"
             nentries = self._guess_number_of_storing_entries(source, key)
-            src_ds1 = self.data._source_index[source][0].file[path]
+            src_ds1 = self.data[source].files[0].file[path]
             self.file.create_dataset_like(
                 path, src_ds1, shape=(nentries,) + src_ds1.shape[1:],
                 # Corrected detector data has maxshape==shape, but if any max
@@ -245,7 +245,7 @@ class VirtualFileWriter(FileWriter):
 
         # Add a link in RUN for control sources
         if source in self.data.control_sources:
-            src_file = self.data._source_index[source][0]
+            src_file = self.data[source].files[0]
             run_path = f'RUN/{source}'
             self.file[run_path] = h5py.ExternalLink(src_file.filename, run_path)
 


### PR DESCRIPTION
This allows you to deselect some sources from a file, and then union the result with data which also contains those sources. This will be necessary once we make virtual overview files and don't copy all the raw data to proc, because we need to deselect part of the raw data.

Previously, the set of open files and the selected sources were tracked separately, so an included source would look at all files in the pool and see if they had that source. This change tracks both the files and keys selected in the `SourceData` interface, so you can have a source that doesn't look at all open files. I tried a couple of ideas, but this one seems fairly elegant, and adds minimal complexity.

As a side effect, a DataCollection now keeps concrete SourceData objects internally, rather than creating them on demand.

Closes #273.

TBD: I broke a couple of small things which were never documented, but were used in tests - the private `._source_index` attribute, and passing an empty dict instead of an empty set to select keys. They'd both be easy to add a compatibility hack for, so I could do that just to be extra cautious. I think it's possible that some people discovered and used `._source_index`.

I hope no-one was manually instantiating `DataCollection(...)` with the selection parameter, because that would be less easy to accommodate.