### PR TITLE
select_trains() and split_trains() methods for detector data classes

### DIFF
--- a/docs/agipd_lpd_data.rst
+++ b/docs/agipd_lpd_data.rst
@@ -35,6 +35,10 @@ DSSC and JUNGFRAU, pulling together the separate modules into a single array.
 
    .. automethod:: trains
 
+   .. automethod:: select_trains
+
+   .. automethod:: split_trains
+
    .. automethod:: write_frames
 
    .. automethod:: write_virtual_cxi
@@ -50,6 +54,12 @@ DSSC and JUNGFRAU, pulling together the separate modules into a single array.
    .. automethod:: get_dask_array
 
    .. automethod:: trains
+
+   .. automethod:: select_trains
+
+   .. automethod:: split_trains
+
+   .. automethod:: write_virtual_cxi
 
 .. autofunction:: identify_multimod_detectors
 

--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -288,7 +288,18 @@ class MultimodDetectorBase:
         )
 
     def select_trains(self, trains):
-        """Select a subset of trains from this data as a new object."""
+        """Select a subset of trains from this data as a new object.
+
+        Slice trains by position within this data::
+
+            sel = det.select_trains(np.s_[:5])
+
+        Or select trains by train ID, with a slice or a list::
+
+            from extra_data import by_id
+            sel1 = det.select_trains(by_id[142844490 : 142844495])
+            sel2 = det.select_trains(by_id[[142844490, 142844493, 142844494]])
+        """
         # Using a copy to bypass the source & train checks in __init__
         res = copy(self)
         res.data = self.data.select_trains(trains)

--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -1,9 +1,11 @@
 """Interfaces to data from specific instruments
 """
 import logging
+import re
+from warnings import warn
+
 import numpy as np
 import pandas as pd
-import re
 import xarray
 
 from .exceptions import SourceNameError
@@ -135,17 +137,11 @@ class MultimodDetectorBase:
         self.modno_to_source = {m: s for (s, m) in source_to_modno.items()}
         assert len(self.modno_to_source) == len(self.source_to_modno)
 
-        train_id_arr = np.asarray(self.data.train_ids)
-        split_indices = np.where(np.diff(train_id_arr) != 1)[0] + 1
-        self.train_id_chunks = np.split(train_id_arr, split_indices)
-        self.frame_counts = frame_counts[train_id_arr]
+        self.frame_counts = frame_counts[self.data.train_ids]
 
         self.train_ids_perframe = np.repeat(
             self.frame_counts.index.values, self.frame_counts.values.astype(np.intp)
         )
-
-        # Cumulative sum gives the end of each train, subtract to get start
-        self.train_id_to_ix = self.frame_counts.cumsum() - self.frame_counts
 
     @classmethod
     def _find_detector_name(cls, data):
@@ -251,6 +247,29 @@ class MultimodDetectorBase:
     @property
     def train_ids(self):
         return self.data.train_ids
+
+    @property
+    def train_id_chunks(self):
+        # Used to be used internally. Kept temporarily in case anyone else used it.
+        warn(
+            "detector.train_id_chunks is likely to be removed in the future. "
+            "Please contact da-support@xfel.eu if you're using it",
+            stacklevel=2
+        )
+        train_id_arr = np.asarray(self.data.train_ids)
+        split_indices = np.where(np.diff(train_id_arr) != 1)[0] + 1
+        return np.split(train_id_arr, split_indices)
+
+    @property
+    def train_id_to_ix(self):
+        # Used to be used internally. Kept temporarily in case anyone else used it.
+        warn(
+            "detector.train_id_to_ix is likely to be removed in the future. "
+            "Please contact da-support@xfel.eu if you're using it",
+            stacklevel=2
+        )
+        # Cumulative sum gives the end of each train, subtract to get start
+        return self.frame_counts.cumsum() - self.frame_counts
 
     @property
     def frames_per_train(self):

--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -11,7 +11,7 @@ import xarray
 
 from .exceptions import SourceNameError
 from .reader import DataCollection, by_id, by_index
-from .read_machinery import roi_shape, DataChunk
+from .read_machinery import DataChunk, roi_shape, split_trains
 from .writer import FileWriter
 from .write_cxi import XtdfCXIWriter, JUNGFRAUCXIWriter
 
@@ -296,6 +296,25 @@ class MultimodDetectorBase:
             res.frame_counts.index.values, res.frame_counts.values.astype(np.intp)
         )
         return res
+
+    def split_trains(self, parts=None, trains_per_part=None):
+        """Split this data into chunks with a fraction of the trains each.
+
+        Either *parts* or *trains_per_part* must be specified.
+
+        Parameters
+        ----------
+
+        parts: int
+            How many parts to split the data into. If trains_per_part is also
+            specified, this is a minimum, and it may make more parts.
+            It may also make fewer if there are fewer trains in the data.
+        trains_per_part: int
+            A maximum number of trains in each part. Parts will often have
+            fewer trains than this.
+        """
+        for s in split_trains(len(self.train_ids), parts, trains_per_part):
+            yield self.select_trains(s)
 
     @staticmethod
     def _concat(arrays, index, fill_value, astype):

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -850,18 +850,15 @@ class DataCollection:
     def select_trains(self, train_range):
         """Select a subset of trains from this data.
 
-        Choose a slice of trains by train ID::
-
-            from extra_data import by_id
-            sel = run.select_trains(by_id[142844490:142844495])
-
-        Or select a list of trains::
-
-            sel = run.select_trains(by_id[[142844490, 142844493, 142844494]])
-
-        Or select trains by index within this collection::
+        Slice trains by position within this data::
 
             sel = run.select_trains(np.s_[:5])
+
+        Or select trains by train ID, with a slice or a list::
+
+            from extra_data import by_id
+            sel1 = run.select_trains(by_id[142844490 : 142844495])
+            sel2 = run.select_trains(by_id[[142844490, 142844493, 142844494]])
 
         Returns a new :class:`DataCollection` object for the selected trains.
 

--- a/extra_data/tests/test_components.py
+++ b/extra_data/tests/test_components.py
@@ -276,6 +276,20 @@ def test_select_trains(mock_fxe_raw_run):
     assert arr.shape == (16, 2, 128, 256, 256)
 
 
+def test_split_trains(mock_fxe_raw_run):
+    run = RunDirectory(mock_fxe_raw_run)
+    det = LPD1M(run.select_trains(np.s_[:20]))
+    assert len(det.train_ids) == 20
+
+    parts = list(det.split_trains(parts=4))
+    assert len(parts) == 4
+    assert [len(p.train_ids) for p in parts] == [5, 5, 5, 5]
+    assert sum([p.train_ids for p in parts], []) == det.train_ids
+
+    arr = parts[-1].get_array('image.data', pulses=np.s_[:1])
+    assert arr.shape == (16, 5, 1, 256, 256)
+
+
 def test_iterate(mock_fxe_raw_run):
     run = RunDirectory(mock_fxe_raw_run)
     det = LPD1M(run.select_trains(by_index[:2]))

--- a/extra_data/tests/test_components.py
+++ b/extra_data/tests/test_components.py
@@ -313,6 +313,16 @@ def test_split_trains(mock_fxe_raw_run):
     parts = list(det.split_trains(frames_per_part=3000))
     assert [len(p.train_ids) for p in parts] == [20]
 
+
+def test_split_trains_jungfrau(mock_jungfrau_run):
+    run = RunDirectory(mock_jungfrau_run)
+    jf = JUNGFRAU(run.select_trains(np.s_[:20]))
+    assert jf.frames_per_train == 16
+
+    parts = list(jf.split_trains(frames_per_part=64))
+    assert [len(p.train_ids) for p in parts] == [4] * 5
+
+
 def test_iterate(mock_fxe_raw_run):
     run = RunDirectory(mock_fxe_raw_run)
     det = LPD1M(run.select_trains(by_index[:2]))

--- a/extra_data/tests/test_components.py
+++ b/extra_data/tests/test_components.py
@@ -301,10 +301,6 @@ def test_split_trains(mock_fxe_raw_run):
     parts = list(det.split_trains(trains_per_part=3, frames_per_part=1024))
     assert [len(p.train_ids) for p in parts] == ([3] * 6) + [2]
 
-    # trains_per_part cuts off before frames_per_part
-    parts = list(det.split_trains(trains_per_part=3, frames_per_part=1024))
-    assert [len(p.train_ids) for p in parts] == ([3] * 6) + [2]
-
     # parts cuts off before frames_per_part
     parts = list(det.split_trains(parts=6, frames_per_part=1024))
     assert [len(p.train_ids) for p in parts] == ([3] * 6) + [2]

--- a/extra_data/tests/test_components.py
+++ b/extra_data/tests/test_components.py
@@ -289,6 +289,29 @@ def test_split_trains(mock_fxe_raw_run):
     arr = parts[-1].get_array('image.data', pulses=np.s_[:1])
     assert arr.shape == (16, 5, 1, 256, 256)
 
+    # Split by a number of frames
+    parts = list(det.split_trains(frames_per_part=256))
+    assert [len(p.train_ids) for p in parts] == [2] * 10
+
+    # frames_per_part less than one train (128 frames in this example)
+    parts = list(det.split_trains(frames_per_part=100))
+    assert [len(p.train_ids) for p in parts] == [1] * 20
+
+    # trains_per_part cuts off before frames_per_part
+    parts = list(det.split_trains(trains_per_part=3, frames_per_part=1024))
+    assert [len(p.train_ids) for p in parts] == ([3] * 6) + [2]
+
+    # trains_per_part cuts off before frames_per_part
+    parts = list(det.split_trains(trains_per_part=3, frames_per_part=1024))
+    assert [len(p.train_ids) for p in parts] == ([3] * 6) + [2]
+
+    # parts cuts off before frames_per_part
+    parts = list(det.split_trains(parts=6, frames_per_part=1024))
+    assert [len(p.train_ids) for p in parts] == ([3] * 6) + [2]
+
+    # frames_per_part > all frames in selection
+    parts = list(det.split_trains(frames_per_part=3000))
+    assert [len(p.train_ids) for p in parts] == [20]
 
 def test_iterate(mock_fxe_raw_run):
     run = RunDirectory(mock_fxe_raw_run)

--- a/extra_data/tests/test_components.py
+++ b/extra_data/tests/test_components.py
@@ -265,6 +265,17 @@ def test_get_dask_array_jungfrau(mock_jungfrau_run):
     np.testing.assert_array_equal(arr.coords['train'], np.arange(10000, 10100))
 
 
+def test_select_trains(mock_fxe_raw_run):
+    run = RunDirectory(mock_fxe_raw_run)
+    det = LPD1M(run.select_trains(np.s_[:20]))
+    assert len(det.train_ids) == 20
+    det = det.select_trains(np.s_[:2])
+    assert len(det.train_ids) == 2
+
+    arr = det.get_array('image.data')
+    assert arr.shape == (16, 2, 128, 256, 256)
+
+
 def test_iterate(mock_fxe_raw_run):
     run = RunDirectory(mock_fxe_raw_run)
     det = LPD1M(run.select_trains(by_index[:2]))

--- a/extra_data/write_cxi.py
+++ b/extra_data/write_cxi.py
@@ -46,9 +46,6 @@ class VirtualCXIWriterBase:
             frame_counts.index.values, frame_counts.values.astype(np.intp)
         )
 
-        # Cumulative sum gives the end of each train, subtract to get start
-        self.train_id_to_ix = frame_counts.cumsum() - frame_counts
-
         # For AGIPD, DSSC & LPD detectors modules are numbered from 0.
         # Overridden for JUNGFRAU to number from 1.
         self.modulenos = list(range(self.nmodules))


### PR DESCRIPTION
`DataCollection` and `KeyData` both have methods to select a subset of data by trains, and to split the data along the trains dimension. Various examples would be simpler if the classes for multi-module detector data offered the same API. At present, you have to split your `DataCollection` and call e.g. `AGIPD1M(chunk)` on each piece. This API would let you call `AGIPD1M(run)` up front, and then split the result, which would make various examples more straightforward.

TBD: A `frames_per_part` option for splitting? This would let you split based on a maximum number of frames in a chunk, rather than a maximum number of trains, which would make it easier to write code that stays within a memory budget if the number of frames per train changes.

Closes #255