### PR TITLE
Fix and improve some links

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -50,7 +50,7 @@ exit with status 1. See :doc:`validation` for details of what it checks.
 -----------------------------
 
 Stream data from files in the `Karabo bridge
-<https://in.xfel.eu/readthedocs/docs/data-analysis-user-documentation/en/latest/online.html#data-stream-to-user-tools>`_
+<https://rtd.xfel.eu/docs/data-analysis-user-documentation/en/latest/online.html#streaming-from-karabo-bridge>`_
 format. See :doc:`streaming` for more information.
 
 .. code-block:: shell

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -295,3 +295,8 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {'https://docs.python.org/': None}
+
+
+# Release notes link to a lot of Github pull requests, and linkcheck hits a
+# rate limit fetching them. We'll just ignore them all.
+linkcheck_ignore = [r'https://github.com/European-XFEL/EXtra-data/pull/\d+/']

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -89,7 +89,7 @@ Documentation contents
 .. seealso::
 
    `Data Analysis at European XFEL
-   <https://in.xfel.eu/readthedocs/docs/data-analysis-user-documentation/en/latest/>`_
+   <https://rtd.xfel.eu/docs/data-analysis-user-documentation/en/latest/>`_
 
 Indices and tables
 ==================

--- a/docs/lpd_data.ipynb
+++ b/docs/lpd_data.ipynb
@@ -243,7 +243,7 @@
    "metadata": {},
    "source": [
     "The returned array is an *xarray* object with labelled axes.\n",
-    "See [Indexing and selecting data](http://xarray.pydata.org/en/stable/indexing.html) in the xarray docs\n",
+    "See [Indexing and selecting data](https://xarray.pydata.org/en/stable/indexing.html) in the xarray docs\n",
     "for more on what you can do with it."
    ]
   },

--- a/docs/reading_files.rst
+++ b/docs/reading_files.rst
@@ -121,7 +121,7 @@ below, e.g.::
    .. automethod:: xarray
 
      .. seealso::
-       `xarray documentation <http://xarray.pydata.org/en/stable/indexing.html>`__
+       `xarray documentation <https://xarray.pydata.org/en/stable/indexing.html>`__
          How to use the arrays returned by :meth:`DataCollection.get_array`
 
        :doc:`xpd_examples`
@@ -292,7 +292,7 @@ missing from the data returned by ``extra_data``:
 - :meth:`~.DataCollection.get_dataframe` includes rows for which any column has
   data. Where some but not all columns have data, the missing values are filled
   with ``NaN`` by pandas' `missing data handling
-  <http://pandas.pydata.org/pandas-docs/stable/user_guide/missing_data.html>`__.
+  <https://pandas.pydata.org/pandas-docs/stable/user_guide/missing_data.html>`__.
 
 Missing data does not necessarily mean that something has gone wrong:
 some devices send data at less than 10 Hz (the train rate), so they always

--- a/docs/xpd_examples.ipynb
+++ b/docs/xpd_examples.ipynb
@@ -78,7 +78,7 @@
     "These measure properties of the X-ray beam in different parts of the tunnel.\n",
     "This data refers to one XGM in XTD2 and one in XTD9.\n",
     "\n",
-    "[pandas](http://pandas.pydata.org/pandas-docs/stable/) is a popular Python library for working with tabular data.\n",
+    "[pandas](https://pandas.pydata.org/pandas-docs/stable/) is a popular Python library for working with tabular data.\n",
     "We'll create a pandas dataframe containing the beam x and y position at each XGM, and the photon flux.\n",
     "We can select the columns using 'glob' patterns, like selecting files in the terminal.\n",
     "\n",
@@ -339,7 +339,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can also export the dataframe to a CSV file - or [any other format pandas supports](http://pandas.pydata.org/pandas-docs/stable/io.html) - for further analysis with other tools."
+    "We can also export the dataframe to a CSV file - or [any other format pandas supports](https://pandas.pydata.org/pandas-docs/stable/io.html) - for further analysis with other tools."
    ]
   },
   {

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -1214,7 +1214,7 @@ class DataCollection:
 
         This is *not* the same as `building virtual datasets to combine
         multi-module detector data
-        <https://in.xfel.eu/readthedocs/docs/data-analysis-user-documentation/en/latest/datafiles.html#combining-detector-data-from-multiple-modules>`__.
+        <https://rtd.xfel.eu/docs/data-analysis-user-documentation/en/latest/datafiles.html#combining-detector-data-from-multiple-modules>`__.
         See :doc:`agipd_lpd_data` for that.
 
         Creating and reading virtual datasets requires HDF5 version 1.10.


### PR DESCRIPTION
Some links to our [data analysis user docs](https://rtd.xfel.eu/docs/data-analysis-user-documentation/en/latest/) were broken. Some others now redirect to https:// addresses, so we may as well point to those directly.