### PR TITLE
Add support for checking missing sources with extra-data-validate

### DIFF
--- a/extra_data/tests/conftest.py
+++ b/extra_data/tests/conftest.py
@@ -63,6 +63,13 @@ def mock_fxe_raw_run(format_version):
 
 
 @pytest.fixture(scope='session')
+def mock_fxe_raw_half_missing_run(format_version):
+    with TemporaryDirectory() as td:
+        make_examples.make_fxe_run(td, missing_data_ratio=0.5, format_version=format_version)
+        yield td
+
+
+@pytest.fixture(scope='session')
 def mock_lpd_parallelgain_run():
     with TemporaryDirectory() as td:
         make_examples.make_lpd_parallelgain_run(td, format_version='1.0')

--- a/extra_data/tests/make_examples.py
+++ b/extra_data/tests/make_examples.py
@@ -209,7 +209,7 @@ def make_lpd_file(path, format_version='0.5'):
         LPDModule('FXE_DET_LPD1M-1/DET/0CH0', frames_per_train=128)
     ], ntrains=480, chunksize=32, format_version=format_version)
 
-def make_fxe_run(dir_path, raw=True, format_version='0.5'):
+def make_fxe_run(dir_path, raw=True, missing_data_ratio=1, format_version='0.5'):
     prefix = 'RAW' if raw else 'CORR'
     for modno in range(16):
         path = osp.join(dir_path,
@@ -220,17 +220,21 @@ def make_fxe_run(dir_path, raw=True, format_version='0.5'):
         ], ntrains=480, chunksize=32, format_version=format_version)
     if not raw:
         return
+
+    # Calculate nsamples for the given missing_data_ratio
+    compute_nsamples = lambda ntrains: int((1 - missing_data_ratio) * ntrains)
+
     write_file(osp.join(dir_path, 'RAW-R0450-DA01-S00000.h5'), [
         XGM('SA1_XTD2_XGM/DOOCS/MAIN'),
         XGM('SPB_XTD9_XGM/DOOCS/MAIN'),
         GECCamera('FXE_XAD_GEC/CAM/CAMERA'),
-        GECCamera('FXE_XAD_GEC/CAM/CAMERA_NODATA', nsamples=0),
+        GECCamera('FXE_XAD_GEC/CAM/CAMERA_NODATA', nsamples=compute_nsamples(400)),
     ], ntrains=400, chunksize=200, format_version=format_version)
     write_file(osp.join(dir_path, '{}-R0450-DA01-S00001.h5'.format(prefix)), [
         XGM('SA1_XTD2_XGM/DOOCS/MAIN'),
         XGM('SPB_XTD9_XGM/DOOCS/MAIN'),
         GECCamera('FXE_XAD_GEC/CAM/CAMERA'),
-        GECCamera('FXE_XAD_GEC/CAM/CAMERA_NODATA', nsamples=0),
+        GECCamera('FXE_XAD_GEC/CAM/CAMERA_NODATA', nsamples=compute_nsamples(80)),
     ], ntrains=80, firsttrain=10400, chunksize=200, format_version=format_version)
 
 def make_lpd_parallelgain_run(dir_path, raw=True, format_version='0.5'):

--- a/extra_data/tests/mockdata/base.py
+++ b/extra_data/tests/mockdata/base.py
@@ -21,7 +21,6 @@ class DeviceBase:
         """Create a dummy device
 
         :param str device_id: e.g. "SA1_XTD2_XGM/DOOCS/MAIN"
-        :param int ntrains: e.g. 256
         :param int nsamples: For INSTRUMENT data only. Default is ntrains.
             If more, should be a multiple of ntrains. If fewer, samples will be
             spread evenly across the trains.

--- a/extra_data/validation.py
+++ b/extra_data/validation.py
@@ -1,4 +1,4 @@
-from argparse import ArgumentParser
+from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
 from multiprocessing import Pool
 from functools import partial
 import numpy as np
@@ -8,7 +8,7 @@ from shutil import get_terminal_size
 from signal import signal, SIGINT, SIG_IGN
 import sys
 
-from .reader import H5File, FileAccess
+from .reader import H5File, FileAccess, RunDirectory
 from .run_files_map import RunFilesMap
 
 
@@ -239,13 +239,14 @@ def _check_file(args):
 
 
 class RunValidator:
-    def __init__(self, run_dir: str, term_progress=False):
+    def __init__(self, run_dir: str, missing_data_threshold: float, term_progress=False):
         self.run_dir = run_dir
+        self.missing_data_threshold = missing_data_threshold
         self.term_progress = term_progress
         self.filenames = [f for f in os.listdir(run_dir) if f.endswith('.h5')]
         self.file_accesses = []
         self.problems = []
-        self.progress_stages = 1
+        self.progress_stages = 2
 
     def validate(self):
         problems = self.run_checks()
@@ -256,6 +257,7 @@ class RunValidator:
         self.problems = []
         self.check_files(progress_stage=1)
         self.check_files_map()
+        self.check_missing_sources(progress_stage=2)
         return self.problems
 
     def progress(self, stage_done, stage_total, stage, badfiles=None):
@@ -323,19 +325,58 @@ class RunValidator:
 
             f_access.close()
 
+    def check_missing_sources(self, progress_stage):
+        run = RunDirectory(self.run_dir)
+        run_tid_count = len(run.train_ids)
+        sources = sorted(run.all_sources)
+
+        for done, source in enumerate(sources, start=1):
+            bad_keys = []
+
+            # Look through all keys for missing data
+            for key in sorted(run[source].keys()):
+                counts = run[source, key].data_counts(labelled=False)
+                missing_data_ratio = (run_tid_count - np.count_nonzero(counts)) / run_tid_count
+
+                # If the missing data ratio is above the threshold, record it
+                # for printing.
+                if missing_data_ratio > self.missing_data_threshold:
+                    missing_percentage = missing_data_ratio * 100
+                    missing_count = run_tid_count - np.count_nonzero(counts)
+                    bad_keys.append((key, missing_percentage, missing_count))
+
+            # Often a source will be missing data for all of its keys, so to be
+            # less spammy we record a single problem per-source instead of
+            # per-key.
+            if len(bad_keys) > 0:
+                msg = f"{source} is missing data for the following keys:"
+                for key, missing_percentage, missing_count in bad_keys:
+                    msg += f"\n  - {key} is missing from {missing_percentage:.2f}% ({missing_count}/{run_tid_count}) of trains"
+
+                self.problems.append(dict(msg=msg, directory=self.run_dir))
+
+            self.progress(done, len(sources), progress_stage)
+
+
 def main(argv=None):
     if argv is None:
         argv = sys.argv[1:]
 
-    ap = ArgumentParser(prog='extra-data-validate')
+    ap = ArgumentParser(prog='extra-data-validate',
+                        formatter_class=ArgumentDefaultsHelpFormatter)
     ap.add_argument('path', help="HDF5 file or run directory of HDF5 files.")
+    ap.add_argument('--missing-data-threshold', help="Threshold from 0-1 for the ratio of trains with missing data for a "
+                                                     "source. For example, a threshold of 0.1 means report an error for all "
+                                                     "sources missing from more than 10%% of trains for the run. "
+                                                     "Only applicable to runs, not individual files.",
+                    type=float, default=0.05)
     args = ap.parse_args(argv)
 
     path = args.path
     if os.path.isdir(path):
         print("Checking run directory:", path)
         print()
-        validator = RunValidator(path, term_progress=True)
+        validator = RunValidator(path, args.missing_data_threshold, term_progress=True)
     else:
         print("Checking file:", path)
         validator = FileValidator(H5File(path).files[0])


### PR DESCRIPTION
This adds support for checking that sources in runs are not missing from more than some percentage of trains. MID noticed that occasionally certain devices (particularly cameras and fastADCs) would be missing from runs, and this wasn't noticed until later when they tried to analyze the data.

The goal is for this to be run automatically by the RunValidator device, perhaps with a setting to change the missing data threshold. You can test it with this run, which is missing a bunch of data from the AGIPD and some cameras: `/gpfs/exfel/exp/MID/202221/p003210/raw/r0008`.

Couple of things I'm not too sure about:
- Does performance matter? This is implemented quite naively, and on the above run it takes ~8s (vs ~2s without checking sources). Since every file is checked anyway I imagine it's possible to modify the `FileValidator` to report the data counts for each source/key it contains.
- Is it necessary to report every single key that is missing data? I don't know exactly how the DAQ works, but if it's guaranteed to dump all data for a source per-train, then I think it'd be enough to show e.g. `<source> is missing data for <n> trains` instead of listing every key. But maybe pipeline data is handled differently, e.g. for the big detectors?
- Should there be a way to limit which sources are checked? I think not, unless for the sake of performance (in which case I'd rather optimize this implementation as in the first point).
- Should it be possible to set a threshold per-source? As this is not much more than a sanity check, I think not.

(BTW it's probably easiest to review each commit individually, they're fairly atomic)