### PR TITLE
Allow .select() to take a list of just source patterns

### DIFF
--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -652,8 +652,14 @@ class DataCollection:
 
         elif isinstance(selection, Iterable):
             # selection = [('src_glob', 'key_glob'), ...]
+            # OR          ['src_glob', 'src_glob', ...]
             sources_data_multi = defaultdict(list)
-            for (src_glob, key_glob) in selection:
+            for globs in selection:
+                if isinstance(globs, str):
+                    src_glob = globs
+                    key_glob = '*'
+                else:
+                    src_glob, key_glob = globs
                 for source, keys in self._select_glob(src_glob, key_glob).items():
                     sources_data_multi[source].append(
                         self._sources_data[source].select_keys(keys)
@@ -720,10 +726,13 @@ class DataCollection:
             # Select data in the image group for any detector sources
             sel = run.select('*/DET/*', 'image.*')
 
-        2. With an iterable of (source, key) glob patterns::
+        2. With an iterable of source glob patterns, or (source, key) patterns::
 
             # Select image.data and image.mask for any detector sources
             sel = run.select([('*/DET/*', 'image.data'), ('*/DET/*', 'image.mask')])
+
+            # Select & align undulator & XGM devices
+            sel = run.select(['*XGM/*', 'MID_XTD1_UND/DOOCS/ENERGY'], require_all=True)
 
            Data is included if it matches any of the pattern pairs.
 

--- a/extra_data/tests/test_reader_mockdata.py
+++ b/extra_data/tests/test_reader_mockdata.py
@@ -496,6 +496,16 @@ def test_select(mock_fxe_raw_run):
     for source, source_data in data.items():
         assert set(source_data.keys()) == {'image.pulseId', 'metadata'}
 
+    sel_by_list = run.select([
+        ('*/DET/*', 'image.pulseId'),
+        'FXE_XAD_GEC/CAM/*',
+    ])
+    assert 'SPB_XTD9_XGM/DOOCS/MAIN' not in sel_by_list.control_sources
+    assert 'FXE_DET_LPD1M-1/DET/0CH0:xtdf' in sel_by_list.instrument_sources
+    assert sel_by_list['FXE_DET_LPD1M-1/DET/0CH0:xtdf'].keys() == {'image.pulseId'}
+    assert 'FXE_XAD_GEC/CAM/CAMERA_NODATA' in sel_by_list.control_sources
+    assert 'FXE_XAD_GEC/CAM/CAMERA_NODATA:daqOutput' in sel_by_list.instrument_sources
+
     # Basic selection machinery, dict-based API
     sel_by_dict = run.select({
         'SA1_XTD2_XGM/DOOCS/MAIN': None,


### PR DESCRIPTION
A tweak to reduce the amount of punctuation you need:

```python
# Currently:
sel = run.select([
    ('MID_EXP_FASTADC/ADC/DESTEST:channel_2.output', '*'),   # DES
    ('MID_XTD1_UND/DOOCS/ENERGY', '*'),  # Undulators
    ('MID_DET_AGIPD1M-1/DET/*CH0:xtdf', '*'),  # AGIPD
], require_all=True)

# With this PR:
sel = run.select([
    'MID_EXP_FASTADC/ADC/DESTEST:channel_2.output',   # DES
    'MID_XTD1_UND/DOOCS/ENERGY',  # Undulators
    'MID_DET_AGIPD1M-1/DET/*CH0:xtdf',  # AGIPD
], require_all=True)
```

When we added selection to control what the `.trains()` iterator loads and yields, you often wanted to select both sources and keys. The addition of the `require_all` option made it also useful for aligning data by trains, but for this purpose it's often sufficient to select only using source names, and keep all keys.