### PR TITLE
Preserve sources with no data recorded in virtual overview files

### DIFF
--- a/extra_data/tests/test_writer.py
+++ b/extra_data/tests/test_writer.py
@@ -59,3 +59,6 @@ def test_write_virtual(mock_fxe_raw_run):
 
             r = f.get_run_value('SPB_XTD9_XGM/DOOCS/MAIN', 'beamPosition.ixPos.value')
             assert isinstance(r, np.float32)
+
+            cam_nodata = f['FXE_XAD_GEC/CAM/CAMERA_NODATA:daqOutput', 'data.image.pixels']
+            assert cam_nodata.shape == (0, 255, 1024)

--- a/extra_data/writer.py
+++ b/extra_data/writer.py
@@ -263,7 +263,7 @@ class VirtualFileWriter(FileWriter):
         else:
             self.data_sources.add(f"CONTROL/{source}")
 
-        return path
+        return keydata.hdf5_data_path
 
     def copy_source(self, source):
         pass  # Override base class copying data

--- a/extra_data/writer.py
+++ b/extra_data/writer.py
@@ -250,13 +250,12 @@ class VirtualFileWriter(FileWriter):
 
     def add_dataset(self, source, key):
         keydata = self.data[source, key]
-        path = f"{keydata.section}/{source}/{key.replace('.', '/')}"
 
         if keydata.shape[0] == 0:  # No data
-            self.file.create_dataset(path, shape=keydata.shape, dtype=keydata.dtype)
+            self.file.create_dataset(keydata.hdf5_data_path, shape=keydata.shape, dtype=keydata.dtype)
         else:
             layout = self._assemble_data(keydata)
-            self.file.create_virtual_dataset(path, layout)
+            self.file.create_virtual_dataset(keydata.hdf5_data_path, layout)
 
         self._make_index(source, key, keydata.train_id_coordinates())
         if source in self.data.instrument_sources:

--- a/extra_data/writer.py
+++ b/extra_data/writer.py
@@ -251,7 +251,6 @@ class VirtualFileWriter(FileWriter):
     def add_dataset(self, source, key):
         keydata = self.data[source, key]
         path = f"{keydata.section}/{source}/{key.replace('.', '/')}"
-        print("path", path)
 
         if keydata.shape[0] == 0:  # No data
             self.file.create_dataset(path, shape=keydata.shape, dtype=keydata.dtype)


### PR DESCRIPTION
I'm not entirely sure if it's possible to make a virtual dataset with no source data - h5py will just make it a regular dataset instead, so I've opted to make that explicit.

Closes #285.