### PR TITLE
introduce keep_dims flag to preserve the cell dimension for the selec…

### DIFF
--- a/extra_data/keydata.py
+++ b/extra_data/keydata.py
@@ -403,7 +403,7 @@ class KeyData:
 
         return None, 0
 
-    def train_from_id(self, tid):
+    def train_from_id(self, tid, keep_dims=False):
         """Get data for the given train ID as a numpy array.
 
         Returns (train ID, array)
@@ -417,19 +417,19 @@ class KeyData:
 
         firsts, counts = fa.get_index(self.source, self._key_group)
         first, count = firsts[ix], counts[ix]
-        if count == 1:
+        if count == 1 and not keep_dims:
             return tid, fa.file[self.hdf5_data_path][first]
         else:
             return tid, fa.file[self.hdf5_data_path][first: first+count]
 
-    def train_from_index(self, i):
+    def train_from_index(self, i, keep_dims=False):
         """Get data for a train by index (starting at 0) as a numpy array.
 
         Returns (train ID, array)
         """
-        return self.train_from_id(self.train_ids[i])
+        return self.train_from_id(self.train_ids[i], keep_dims=keep_dims)
 
-    def trains(self):
+    def trains(self, keep_dims=False):
         """Iterate through trains containing data for this key
 
         Yields pairs of (train ID, array). Skips trains where data is missing.
@@ -438,7 +438,7 @@ class KeyData:
             start = chunk.first
             ds = chunk.dataset
             for tid, count in zip(chunk.train_ids, chunk.counts):
-                if count > 1:
+                if count > 1 or keep_dims:
                     yield tid, ds[start: start+count]
                 elif count == 1:
                     yield tid, ds[start]

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -296,7 +296,7 @@ class DataCollection:
         return False
 
     def trains(self, devices=None, train_range=None, *, require_all=False,
-               flat_keys=False):
+               flat_keys=False, keep_dims=False):
         """Iterate over all trains in the data and gather all sources.
 
         ::
@@ -327,6 +327,10 @@ class DataCollection:
             iteration indexed by source and then key. True returns a
             flat dictionary indexed by (source, key) tuples.
 
+        keep_dims: bool
+            False (default) based on count index or slice the data.
+            True returns a sliced data to preserve the dimensions.
+
         Yields
         ------
 
@@ -341,9 +345,10 @@ class DataCollection:
         if train_range is not None:
             dc = dc.select_trains(train_range)
         return iter(TrainIterator(dc, require_all=require_all,
-                                  flat_keys=flat_keys))
+                                  flat_keys=flat_keys, keep_dims=keep_dims))
 
-    def train_from_id(self, train_id, devices=None, *, flat_keys=False):
+    def train_from_id(
+        self, train_id, devices=None, *, flat_keys=False, keep_dims=False):
         """Get train data for specified train ID.
 
         Parameters
@@ -357,6 +362,9 @@ class DataCollection:
         flat_keys: bool
             False (default) returns a nested dict indexed by source and then key.
             True returns a flat dictionary indexed by (source, key) tuples.
+        keep_dims: bool
+            False (default) based on count index or slice the data.
+            True returns a sliced data to preserve the dimensions.
 
         Returns
         -------
@@ -406,7 +414,7 @@ class DataCollection:
                     continue
 
                 path = '/INSTRUMENT/{}/{}'.format(source, key.replace('.', '/'))
-                if count == 1:
+                if count == 1 and not keep_dims:
                     source_data[key] = file.file[path][first]
                 else:
                     source_data[key] = file.file[path][first : first + count]
@@ -418,7 +426,8 @@ class DataCollection:
 
         return train_id, res
 
-    def train_from_index(self, train_index, devices=None, *, flat_keys=False):
+    def train_from_index(
+        self, train_index, devices=None, *, flat_keys=False, keep_dims=False):
         """Get train data of the nth train in this data.
 
         Parameters
@@ -431,6 +440,9 @@ class DataCollection:
         flat_keys: bool
             False (default) returns a nested dict indexed by source and then key.
             True returns a flat dictionary indexed by (source, key) tuples.
+        keep_dims: bool
+            False (default) based on count index or slice the data.
+            True returns a sliced data to preserve the dimensions.
 
         Returns
         -------
@@ -441,7 +453,9 @@ class DataCollection:
             The data for this train, keyed by device name
         """
         train_id = self.train_ids[train_index]
-        return self.train_from_id(int(train_id), devices=devices, flat_keys=flat_keys)
+        return self.train_from_id(
+            int(train_id), devices=devices,
+            flat_keys=flat_keys, keep_dims=keep_dims)
 
     def get_data_counts(self, source, key):
         """Get a count of data points in each train for the given data field.
@@ -1271,9 +1285,11 @@ class TrainIterator:
 
     Created by :meth:`DataCollection.trains`.
     """
-    def __init__(self, data, require_all=True, flat_keys=False):
+    def __init__(
+        self, data, require_all=True, flat_keys=False, keep_dims=False):
         self.data = data
         self.require_all = require_all
+        self.keep_dims = keep_dims
         # {(source, key): (f, dataset)}
         self._datasets_cache = {}
 
@@ -1336,7 +1352,7 @@ class TrainIterator:
                 group = key.partition('.')[0]
                 firsts, counts = file.get_index(source, group)
                 first, count = firsts[pos], counts[pos]
-                if count == 1:
+                if count == 1 and not self.keep_dims:
                     self._set_result(res, source, key, ds[first])
                 elif count > 0:
                     self._set_result(res, source, key,

--- a/extra_data/tests/test_keydata.py
+++ b/extra_data/tests/test_keydata.py
@@ -93,6 +93,15 @@ def test_iter_trains(mock_spb_raw_run):
         assert isinstance(v, np.float32)
         break
 
+
+def test_iter_trains_keep_dims(mock_jungfrau_run):
+    run = RunDirectory(mock_jungfrau_run)
+    jf_data = run['SPB_IRDA_JF4M/DET/JNGFR01:daqOutput', 'data.adc']
+
+    for _, v in jf_data.trains(keep_dims=True):
+        assert v.shape == (1, 16, 512, 1024)
+
+
 def test_get_train(mock_spb_raw_run):
     run = RunDirectory(mock_spb_raw_run)
     xgm_beam_x = run['SPB_XTD9_XGM/DOOCS/MAIN', 'beamPosition.ixPos.value']
@@ -109,6 +118,17 @@ def test_get_train(mock_spb_raw_run):
 
     with pytest.raises(IndexError):
         xgm_beam_x.train_from_index(9999)
+
+
+def test_get_train_keep_dims(mock_jungfrau_run):
+    run = RunDirectory(mock_jungfrau_run)
+    jf_adc = run['SPB_IRDA_JF4M/DET/JNGFR01:daqOutput', 'data.adc']
+
+    _, val = jf_adc.train_from_id(10005, keep_dims=True)
+    assert val.shape == (1, 16, 512, 1024)
+
+    _, val = jf_adc.train_from_index(-10, keep_dims=True)
+    assert val.shape == (1, 16, 512, 1024)
 
 
 def test_data_counts(mock_reduced_spb_proc_run):

--- a/extra_data/tests/test_reader_mockdata.py
+++ b/extra_data/tests/test_reader_mockdata.py
@@ -36,6 +36,26 @@ def test_iterate_trains_flat_keys(mock_agipd_data):
             assert ('SPB_DET_AGIPD1M-1/DET/7CH0:xtdf', 'image.data') in data
 
 
+def test_iterate_trains_keep_dims(mock_jungfrau_run):
+    run = RunDirectory(mock_jungfrau_run)
+    for _, data in islice(run.select(
+        '*JF4M/DET/*', 'data.adc'
+    ).trains(keep_dims=True), 10):
+
+        assert data[
+            'SPB_IRDA_JF4M/DET/JNGFR01:daqOutput']['data.adc'].shape == (
+                1, 16, 512, 1024)
+
+
+def test_get_train_keep_dims(mock_jungfrau_run):
+    run = RunDirectory(mock_jungfrau_run)
+    _, data = run.select(
+        '*JF4M/DET/*', 'data.adc').train_from_index(0, keep_dims=True)
+    assert data[
+        'SPB_IRDA_JF4M/DET/JNGFR01:daqOutput']["data.adc"].shape == (
+            1, 16, 512, 1024)
+
+
 def test_get_train_bad_device_name(mock_spb_control_data_badname):
     # Check that we can handle devices which don't have the standard Karabo
     # name structure A/B/C.
@@ -167,6 +187,17 @@ def test_iterate_spb_raw_run(mock_spb_raw_run):
     device = 'SPB_IRU_CAM/CAM/SIDEMIC:daqOutput'
     assert device in data
     assert data[device]['data.image.pixels'].shape == (1024, 768)
+
+
+def test_iterate_spb_raw_run_keep_dims(mock_spb_raw_run):
+    run = RunDirectory(mock_spb_raw_run)
+    trains_iter = run.trains(keep_dims=True)
+    _, data = next(trains_iter)
+
+    assert data[
+        'SPB_IRU_CAM/CAM/SIDEMIC:daqOutput']['data.image.pixels'
+    ].shape == (1, 1024, 768)
+
 
 def test_properties_fxe_raw_run(mock_fxe_raw_run):
     run = RunDirectory(mock_fxe_raw_run)

--- a/extra_data/tests/test_stacking.py
+++ b/extra_data/tests/test_stacking.py
@@ -148,6 +148,16 @@ def test_stack_detector_data_jungfrau(mock_jungfrau_run):
     assert comb.shape == (16, 8, 512, 1024)
 
 
+def test_stack_detector_data_jungfrau(mock_jungfrau_run):
+    run = RunDirectory(mock_jungfrau_run)
+    _, data = run.select('*JF4M/DET/*', 'data.adc').train_from_index(0, keep_dims=True)
+
+    comb = stack_detector_data(
+        data, 'data.adc', modules=8, pattern=r'/DET/JNGFR(\d+)', starts_at=1
+    )
+    assert comb.shape == (1, 16, 8, 512, 1024)
+
+
 def test_stackview_squeeze():
     # Squeeze not dropping stacking dim
     data = {0: np.zeros((1, 4)), 1: np.zeros((1, 4))}


### PR DESCRIPTION
MID requested correcting one cellId for AGIPD in the offline calibration.

As mentioned in this MR: https://git.xfel.eu/detectors/pycalibration/-/merge_requests/640

There was an error in correcting one cellId. This was a result of wrong expected dimensions.

When the CORR data is read for one train using `train_from_id` to plot AGIPD images, all arrays were returned without preserving the `1` for the cell dimensions.

Based on @philsmt 's advice. I added `keep_dims` flags for `trains()`, `train_from_id`, `train_from_index` for data collections and key data to have the option in preserving the cell dimension and slice the required data even though `count == 1`


I have added some tests as well for having `keep_dims = True`, I tried to only use already available tests and add test functions based on it.