### PR TITLE
Avoid a race condition opening/closing HDF5 files

### DIFF
--- a/extra_data/file_access.py
+++ b/extra_data/file_access.py
@@ -180,10 +180,12 @@ class FileAccess(metaclass=MetaFileAccess):
     @property
     def file(self):
         open_files_limiter.touch(self.filename)
-        if self._file is None:
-            self._file = h5py.File(self.filename, 'r')
+        # Local var to avoid a race condition when another thread calls .close()
+        file = self._file
+        if file is None:
+            file = self._file = h5py.File(self.filename, 'r')
 
-        return self._file
+        return file
 
     @property
     def valid_train_ids(self):


### PR DESCRIPTION
This should hopefully fix the race condition described in https://github.com/European-XFEL/pasha/pull/13 .

I think there's still a separate race condition with `open_files_limiter` - if the timing is right, the file may be open when `open_files_limiter` thinks it's closed. But the limiter aims for half the process limit on the number of files, so it's unlikely to be a big problem if files sometimes leak. There may well also be race conditions if FileAccess objects are created/unpickled in different threads. We may need to tackle these at some point, but they're harder to solve than this one. I'm reluctant to focus too much on threading support, because only a single thread can access HDF5 files at a time anyway.