### PR TITLE
Get run metadata and run values from a SourceData object

### DIFF
--- a/extra_data/read_machinery.py
+++ b/extra_data/read_machinery.py
@@ -2,15 +2,17 @@
 
 The public API is in extra_data.reader; this is internal code.
 """
-from glob import iglob
 import logging
 import math
-import numpy as np
 import os.path as osp
 import re
 import time
+from collections import defaultdict
+from glob import iglob
+from typing import Union
 from warnings import warn
 
+import numpy as np
 
 log = logging.getLogger(__name__)
 
@@ -250,6 +252,24 @@ def find_proposal(propno):
         return d
 
     raise Exception("Couldn't find proposal dir for {!r}".format(propno))
+
+
+def same_run(*args) -> bool:
+    """return True if arguments objects contain data from the same RUN
+
+    arguments can be of type *DataCollection* or *SourceData*
+    """
+    # DataCollection union of format version = 0.5 (no run/proposal # in
+    # files) is not considered a single run.
+    proposal_nos = set()
+    run_nos = set()
+    for dc in args:
+        md = dc.run_metadata() if dc.is_single_run else {}
+        proposal_nos.add(md.get("proposalNumber", -1))
+        run_nos.add(md.get("runNumber", -1))
+
+    return (len(proposal_nos) == 1 and (-1 not in proposal_nos)
+            and len(run_nos) == 1 and (-1 not in run_nos))
 
 
 glob_wildcards_re = re.compile(r'([*?[])')

--- a/extra_data/read_machinery.py
+++ b/extra_data/read_machinery.py
@@ -7,9 +7,7 @@ import math
 import os.path as osp
 import re
 import time
-from collections import defaultdict
 from glob import iglob
-from typing import Union
 from warnings import warn
 
 import numpy as np

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -544,11 +544,7 @@ class DataCollection:
         key: str
             Key of parameter within that device, e.g. "triggerMode".
         """
-        try:
-            source_data = self._sources_data[source]
-        except KeyError:
-            raise SourceNameError(source)
-        return source_data.run_value(key)
+        return self._get_source_data(source).run_value(key)
 
     def get_run_values(self, source) -> dict:
         """Get a dict of all RUN values for the given source
@@ -561,11 +557,7 @@ class DataCollection:
         source: str
             Control device name, e.g. "HED_OPT_PAM/CAM/SAMPLE_CAM_4".
         """
-        try:
-            source_data = self._sources_data[source]
-        except KeyError:
-            raise SourceNameError(source)
-        return source_data.run_values()
+        return self._get_source_data(source).run_values()
 
     def union(self, *others):
         """Join the data in this collection with one or more others.

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -10,16 +10,9 @@ You should have received a copy of the 3-Clause BSD License along with this
 program. If not, see <https://opensource.org/licenses/BSD-3-Clause>
 """
 
-from collections import defaultdict
-from collections.abc import Iterable
 import datetime
 import fnmatch
-import h5py
-from itertools import groupby
 import logging
-from multiprocessing import Pool
-import numpy as np
-from operator import index
 import os
 import os.path as osp
 import re
@@ -27,27 +20,27 @@ import signal
 import sys
 import tempfile
 import time
+from collections import defaultdict
+from collections.abc import Iterable
+from itertools import groupby
+from multiprocessing import Pool
+from operator import index
 from typing import Tuple
 from warnings import warn
 
-from .exceptions import (
-    SourceNameError, PropertyNameError, TrainIDError, MultiRunError,
-)
+import h5py
+import numpy as np
+
+from . import locality, voview
+from .exceptions import (MultiRunError, PropertyNameError, SourceNameError,
+                         TrainIDError)
+from .file_access import FileAccess
 from .keydata import KeyData
-from .read_machinery import (
-    DETECTOR_SOURCE_RE,
-    FilenameInfo,
-    by_id,
-    by_index,
-    select_train_ids,
-    split_trains,
-    find_proposal,
-    glob_wildcards_re,
-)
+from .read_machinery import (DETECTOR_SOURCE_RE, FilenameInfo, by_id, by_index,
+                             find_proposal, glob_wildcards_re, same_run,
+                             select_train_ids, split_trains)
 from .run_files_map import RunFilesMap
 from .sourcedata import SourceData
-from . import locality, voview
-from .file_access import FileAccess
 from .utils import available_cpu_cores
 
 __all__ = [
@@ -108,6 +101,7 @@ class DataCollection:
                     train_ids=train_ids,
                     files=files,
                     section=section,
+                    is_single_run=self.is_single_run,
                     inc_suspect_trains=self.inc_suspect_trains,
                 )
                 for ((src, section), files) in files_by_sources.items()
@@ -550,25 +544,11 @@ class DataCollection:
         key: str
             Key of parameter within that device, e.g. "triggerMode".
         """
-        if not self.is_single_run:
-            raise MultiRunError
-
-        if source not in self.control_sources:
+        try:
+            source_data = self._sources_data[source]
+        except KeyError:
             raise SourceNameError(source)
-
-        # Arbitrary file - should be the same across a run
-        fa = self._sources_data[source].files[0]
-        ds = fa.file['RUN'][source].get(key.replace('.', '/'))
-        if isinstance(ds, h5py.Group):
-            # Allow for the .value suffix being omitted
-            ds = ds.get('value')
-        if not isinstance(ds, h5py.Dataset):
-            raise PropertyNameError(key, source)
-
-        val = ds[0]
-        if isinstance(val, bytes):  # bytes -> str
-            return val.decode('utf-8', 'surrogateescape')
-        return val
+        return source_data.run_value(key)
 
     def get_run_values(self, source) -> dict:
         """Get a dict of all RUN values for the given source
@@ -581,24 +561,11 @@ class DataCollection:
         source: str
             Control device name, e.g. "HED_OPT_PAM/CAM/SAMPLE_CAM_4".
         """
-        if not self.is_single_run:
-            raise MultiRunError
-
-        if source not in self.control_sources:
+        try:
+            source_data = self._sources_data[source]
+        except KeyError:
             raise SourceNameError(source)
-
-        # Arbitrary file - should be the same across a run
-        fa = self._sources_data[source].files[0]
-        res = {}
-        def visitor(path, obj):
-            if isinstance(obj, h5py.Dataset):
-                val = obj[0]
-                if isinstance(val, bytes):
-                    val = val.decode('utf-8', 'surrogateescape')
-                res[path.replace('/', '.')] = val
-
-        fa.file['RUN'][source].visititems(visitor)
-        return res
+        return source_data.run_values()
 
     def union(self, *others):
         """Join the data in this collection with one or more others.
@@ -610,24 +577,12 @@ class DataCollection:
         Returns a new :class:`DataCollection` object.
         """
         sources_data_multi = defaultdict(list)
-        # DataCollection union of format version = 0.5 (no run/proposal # in
-        # files) is not considered a single run.
-        proposal_nos = set()
-        run_nos = set()
         for dc in (self,) + others:
-            md = dc.run_metadata() if dc.is_single_run else {}
-            proposal_nos.add(md.get("proposalNumber", -1))
-            run_nos.add(md.get("runNumber", -1))
             for source, srcdata in dc._sources_data.items():
                 sources_data_multi[source].append(srcdata)
 
         sources_data = {src: src_datas[0].union(*src_datas[1:])
                         for src, src_datas in sources_data_multi.items()}
-
-        same_run = (
-            len(proposal_nos) == 1 and (-1 not in proposal_nos)
-            and len(run_nos) == 1 and (-1 not in run_nos)
-        )
 
         train_ids = sorted(set().union(*[sd.train_ids for sd in sources_data.values()]))
         files = set().union(*[sd.files for sd in sources_data.values()])
@@ -635,7 +590,7 @@ class DataCollection:
         return DataCollection(
             files, sources_data=sources_data, train_ids=train_ids,
             inc_suspect_trains=self.inc_suspect_trains,
-            is_single_run=same_run,
+            is_single_run=same_run(self, *others),
         )
 
     def _expand_selection(self, selection):

--- a/extra_data/sourcedata.py
+++ b/extra_data/sourcedata.py
@@ -235,7 +235,8 @@ class SourceData:
             raise MultiRunError()
 
         if not self._is_control:
-            raise SourceNameError(self.source)
+            raise ValueError('Only CONTROL sources have run values, '
+                             f'{self.source} is an INSTRUMENT source')
 
         # Arbitrary file - should be the same across a run
         ds = self.files[0].file['RUN'][self.source].get(key.replace('.', '/'))
@@ -259,7 +260,8 @@ class SourceData:
             raise MultiRunError()
 
         if not self._is_control:
-            raise SourceNameError(self.source)
+            raise ValueError('Only CONTROL sources have run values, '
+                             f'{self.source} is an INSTRUMENT source')
 
         res = {}
         def visitor(path, obj):

--- a/extra_data/tests/conftest.py
+++ b/extra_data/tests/conftest.py
@@ -40,6 +40,14 @@ def mock_fxe_control_data(format_version):
 
 
 @pytest.fixture(scope='module')
+def mock_fxe_control_data1(format_version):
+    with TemporaryDirectory() as td:
+        path = osp.join(td, 'RAW-R0451-DA01-S00001.h5')
+        make_examples.make_fxe_da_file(path, firsttrain=20000, format_version=format_version)
+        yield path
+
+
+@pytest.fixture(scope='module')
 def mock_sa3_control_data(format_version):
     with TemporaryDirectory() as td:
         path = osp.join(td, 'RAW-R0450-DA01-S00001.h5')

--- a/extra_data/tests/make_examples.py
+++ b/extra_data/tests/make_examples.py
@@ -143,7 +143,7 @@ def make_agipd_example_file(path, format_version='0.5'):
     f.create_dataset('INSTRUMENT/SPB_DET_AGIPD1M-1/DET/7CH0:xtdf/trailer/status',
                         (256,), 'u8', maxshape=(None,))  # Empty in example
 
-def make_fxe_da_file(path, format_version='0.5'):
+def make_fxe_da_file(path, format_version='0.5', firsttrain=10000):
     """Make the structure of a file with non-detector data from the FXE experiment
 
     Based on .../FXE/201830/p900023/r0450/RAW-R0450-DA01-S00001.h5
@@ -154,7 +154,7 @@ def make_fxe_da_file(path, format_version='0.5'):
         XGM('SPB_XTD9_XGM/DOOCS/MAIN'),
         GECCamera('FXE_XAD_GEC/CAM/CAMERA'),
         GECCamera('FXE_XAD_GEC/CAM/CAMERA_NODATA', nsamples=0)
-    ], ntrains=400, chunksize=200, format_version=format_version)
+    ], ntrains=400, chunksize=200, firsttrain=firsttrain, format_version=format_version)
 
 def make_sa3_da_file(path, ntrains=500, format_version='0.5'):
     """Make the structure of a file with non-detector data from SASE3 tunnel

--- a/extra_data/tests/test_read_machinery.py
+++ b/extra_data/tests/test_read_machinery.py
@@ -2,7 +2,9 @@ import os
 import os.path as osp
 from unittest import mock
 
-from extra_data import read_machinery
+import numpy as np
+from extra_data import RunDirectory, read_machinery
+
 
 def test_find_proposal(tmpdir):
     prop_dir = osp.join(str(tmpdir), 'SPB', '201701', 'p002012')
@@ -12,3 +14,40 @@ def test_find_proposal(tmpdir):
         assert read_machinery.find_proposal('p002012') == prop_dir
 
         assert read_machinery.find_proposal(prop_dir) == prop_dir
+
+
+def test_same_run(mock_spb_raw_run, mock_jungfrau_run, mock_scs_run):
+    run_spb = RunDirectory(mock_spb_raw_run)
+    run_jf = RunDirectory(mock_jungfrau_run)
+    run_scs = RunDirectory(mock_scs_run)
+
+    assert run_spb.is_single_run
+    assert run_jf.is_single_run
+    assert run_scs.is_single_run
+
+    assert not read_machinery.same_run(run_spb, run_scs, run_jf)
+
+    format_version = run_spb.files[0].format_version
+    s1 = run_spb.select_trains(np.s_[:1])
+    s2 = run_spb.select_trains(np.s_[:-1])
+    s3 = run_spb.select_trains(np.s_[3])
+
+    s4 = run_spb.select('SA1_XTD2_XGM/DOOCS/MAIN', '*')
+    s5 = run_spb.select('SPB_IRU_CAM/CAM/SIDEMIC:daqOutput', '*')
+
+    if run_spb.run_metadata()['dataFormatVersion'] != '0.5':
+        assert read_machinery.same_run(s1, s2, s3)
+        assert read_machinery.same_run(s4, s5)
+    else:
+        assert not read_machinery.same_run(s1, s2, s3)
+        assert not read_machinery.same_run(s4, s5)
+
+    # SourceData
+    sd = run_spb['SA1_XTD2_XGM/DOOCS/MAIN']
+    sd1 = sd.select_trains(np.s_[:1])
+    sd2 = sd.select_trains(np.s_[-1:])
+    assert sd.is_single_run
+    if sd.run_metadata()['dataFormatVersion'] != '0.5':
+        assert read_machinery.same_run(sd1, sd2)
+    else:
+        assert not read_machinery.same_run(sd1, sd2)

--- a/extra_data/tests/test_reader_mockdata.py
+++ b/extra_data/tests/test_reader_mockdata.py
@@ -906,6 +906,9 @@ def test_get_run_value_union_multirun(mock_fxe_control_data, mock_fxe_control_da
     f2 = H5File(mock_fxe_control_data1)
     data = f.union(f2)
     with pytest.raises(MultiRunError):
+        data.run_metadata()
+
+    with pytest.raises(MultiRunError):
         data.get_run_value('FXE_XAD_GEC/CAM/CAMERA', 'firmwareVersion')
 
     with pytest.raises(MultiRunError):

--- a/extra_data/tests/test_reader_mockdata.py
+++ b/extra_data/tests/test_reader_mockdata.py
@@ -901,10 +901,10 @@ def test_get_run_value(mock_fxe_control_data):
         f.get_run_value(src, 'non.existant')
 
 
-def test_get_run_value_union_multirun(mock_fxe_control_data, mock_lpd_data):
+def test_get_run_value_union_multirun(mock_fxe_control_data, mock_fxe_control_data1):
     f = H5File(mock_fxe_control_data)
-    f2 = H5File(mock_lpd_data)
-    data = f.union(f2)
+    f3 = H5File(mock_fxe_control_data1)
+    data = f.union(f2, f3)
     with pytest.raises(MultiRunError):
         data.get_run_value('FXE_XAD_GEC/CAM/CAMERA', 'firmwareVersion')
 

--- a/extra_data/tests/test_reader_mockdata.py
+++ b/extra_data/tests/test_reader_mockdata.py
@@ -903,8 +903,8 @@ def test_get_run_value(mock_fxe_control_data):
 
 def test_get_run_value_union_multirun(mock_fxe_control_data, mock_fxe_control_data1):
     f = H5File(mock_fxe_control_data)
-    f3 = H5File(mock_fxe_control_data1)
-    data = f.union(f2, f3)
+    f2 = H5File(mock_fxe_control_data1)
+    data = f.union(f2)
     with pytest.raises(MultiRunError):
         data.get_run_value('FXE_XAD_GEC/CAM/CAMERA', 'firmwareVersion')
 

--- a/extra_data/tests/test_sourcedata.py
+++ b/extra_data/tests/test_sourcedata.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 from extra_data import RunDirectory, by_id, by_index
-from extra_data.exceptions import PropertyNameError
+from extra_data.exceptions import PropertyNameError, SourceNameError
 
 def test_get_sourcedata(mock_spb_raw_run):
     run = RunDirectory(mock_spb_raw_run)
@@ -91,3 +91,16 @@ def test_union(mock_spb_raw_run):
 
     with pytest.raises(ValueError):
         xgm.union(am0)
+
+
+def test_run_value(mock_spb_raw_run):
+    run = RunDirectory(mock_spb_raw_run)
+    xgm = run['SPB_XTD9_XGM/DOOCS/MAIN']
+    am0 = run['SPB_DET_AGIPD1M-1/DET/0CH0:xtdf']
+
+    value = xgm.run_value('pulseEnergy.conversion.value')
+    assert isinstance(value, np.float64)
+
+    with pytest.raises(SourceNameError):
+        # no run values for instrument sources
+        am0.run_values()

--- a/extra_data/tests/test_sourcedata.py
+++ b/extra_data/tests/test_sourcedata.py
@@ -101,6 +101,6 @@ def test_run_value(mock_spb_raw_run):
     value = xgm.run_value('pulseEnergy.conversion.value')
     assert isinstance(value, np.float64)
 
-    with pytest.raises(SourceNameError):
+    with pytest.raises(ValueError):
         # no run values for instrument sources
         am0.run_values()


### PR DESCRIPTION
closes #263 

Slight difference with past behavior: now if you union multiple runs and a source is only present in one of the runs, this source can still get run metadata and run values.