### PR TITLE
Add mockdata for CONTROL sources for AGIPD1M and AGIPD500

### DIFF
--- a/extra_data/tests/mockdata/agipd.py
+++ b/extra_data/tests/mockdata/agipd.py
@@ -1,5 +1,3 @@
-import numpy as np
-
 from .base import DeviceBase
 
 
@@ -18,9 +16,12 @@ class AGIPDMDL(DeviceBase):
         # A sample of some of the available keys.
         self.control_keys = [
             ('acquisitionTime', 'u2', ()),
-            ('bunchStructure.nPulses', 'u2', ()),
-            ('bunchStructure.firstPulse', 'u2', ()),
-            ('bunchStructure.methodIndex', 'u2', ()),
+            ('bunchStructure/nPulses', 'u2', ()),
+            ('bunchStructure/firstPulse', 'u2', ()),
+            ('bunchStructure/methodIndex', 'u2', ()),
+            ('setupr', 'u2', ()),
+            ('patternTypeIndex', 'u2', ()),
+            ('gainModeIndex', 'u2', ()),
             ('egsgat', 'u2', ()),
             ('g1sgat', 'u2', ()),
             ('g2sgat', 'u2', ()),
@@ -30,26 +31,33 @@ class AGIPDMDL(DeviceBase):
             ('vrfcds', 'u2', ()),
         ]
 
+        if integration_time:
+            self.control_keys.append(('integrationTime', 'u2', ()))
+        if rep_rate:
+            self.control_keys.append(
+                ('bunchStructure/repetitionRate', 'f8', ()))
+        if self.gain_setting:
+            self.control_keys.append(('gain', 'u2', ()))
+
     def write_control(self, f):
         super().write_control(f)
 
-        ctrl_grp = f'CONTROL/{self.device_id}'
-        run_grp = f'RUN/{self.device_id}'
+        ctrl_grp = f'CONTROL/{self.device_id}/'
+        run_grp = f'RUN/{self.device_id}/'
         for grp in [ctrl_grp, run_grp]:
-            length = self.ntrains if grp == ctrl_grp else 1
 
-            f[f"{grp}/setupr/value"] = np.array([32]*length)
-            f[f"{grp}/patternTypeIndex/value"] = np.array([4]*length)
-            f[f"{grp}/gainModeIndex/value"] = np.array([0]*length)
+            g = f[grp]
+
+            g['setupr/value'][()] = 32
+            g['patternTypeIndex/value'][()] = 4
+            g['gainModeIndex/value'][()] = 0
 
             if self.integration_time:
-                f[f"{grp}/integrationTime/value"] = np.array([15]*length)
-
+                g['integrationTime/value'][()] = 15
             if self.rep_rate:
-                f[f"{grp}/bunchStructure/repetitionRate/value"] = np.array(
-                    [4.5]*length)
+                g['bunchStructure/repetitionRate/value'][()] = 4.5
             if self.gain_setting:
-                f[f"{grp}/gain/value"] = np.array([0]*length)
+                g['gain/value'][()] = 0
 
 
 class AGIPD1MFPGA(DeviceBase):
@@ -65,12 +73,12 @@ class AGIPD1MFPGA(DeviceBase):
         ('integrationOffset', 'u4', ()),
         ('integrationPeriod', 'u4', ()),
         ('mask', 'u4', ()),
-        ('performanceStatistics.messagingProblems', '|u1', ()),
-        ('performanceStatistics.enable', '|u1', ()),
-        ('performanceStatistics.processingLatency', 'f4', ()),
-        ('performanceStatistics.maxProcessingLatency', 'u4', ()),
-        ('performanceStatistics.numMessages', 'u4', ()),
-        ('performanceStatistics.maxEventLoopLatency', 'u4', ()),
+        ('performanceStatistics/messagingProblems', '|u1', ()),
+        ('performanceStatistics/enable', '|u1', ()),
+        ('performanceStatistics/processingLatency', 'f4', ()),
+        ('performanceStatistics/maxProcessingLatency', 'u4', ()),
+        ('performanceStatistics/numMessages', 'u4', ()),
+        ('performanceStatistics/maxEventLoopLatency', 'u4', ()),
         ('port', 'i4', ()),
         ('sleepTime', 'f4', ()),
     ]
@@ -79,17 +87,16 @@ class AGIPD1MFPGA(DeviceBase):
 class AGIPD500KFPGA(DeviceBase):
     # A sample of some of the available keys.
     control_keys = [
-        ('highVoltage.actual', 'u2', ()),
-        ('highVoltage.target', 'u2', ()),
+        ('highVoltage/actual', 'u2', ()),
+        ('highVoltage/target', 'u2', ()),
     ]
 
     def write_control(self, f):
         super().write_control(f)
-        ctrl_grp = f'CONTROL/{self.device_id}'
-        run_grp = f'RUN/{self.device_id}'
+        ctrl_grp = f'CONTROL/{self.device_id}/'
+        run_grp = f'RUN/{self.device_id}/'
         for grp in [ctrl_grp, run_grp]:
-            length = self.ntrains if grp == ctrl_grp else 1
-            f[f"{grp}/highVoltage/actual/value"] = np.array([200]*length)
+            f[grp + 'highVoltage/actual/value'][()] = 200
 
 
 class AGIPD1MPSC(DeviceBase):
@@ -103,28 +110,27 @@ class AGIPD1MPSC(DeviceBase):
         self.control_keys = [
             ('applyInProgress', '|u1', ()),
             ('autoRearm', '|u1', ()),
-            ('channels.U0.status', 'i4', ()),
-            ('channels.U0.switch', 'i4', ()),
-            ('channels.U0.voltage', 'f4', ()),
-            ('channels.U0.superVisionMaxTerminalVoltage', 'f4', ()),
-            ('channels.U0.voltageRampRate', 'f4', ()),
-            ('channels.U0.measurementCurrent', 'f4', ()),
-            ('channels.U0.current', 'f4', ()),
-            ('channels.U0.supervisionMaxCurrent', 'f4', ()),
-            ('channels.U0.currentRiseRate', 'f4', ()),
-            ('channels.U0.currentFallRate', 'f4', ()),
-            ('channels.U0.measurementTemperature', 'i4', ()),
-            ('channels.U0.supervisionBehavior', 'i4', ()),
-            ('channels.U0.tripTimeMaxCurrent', 'i4', ()),
-            ('channels.U0.configMaxSenseVoltage', 'f4', ()),
+            ('channels/U0/status', 'i4', ()),
+            ('channels/U0/switch', 'i4', ()),
+            ('channels/U0/voltage', 'f4', ()),
+            ('channels/U0/superVisionMaxTerminalVoltage', 'f4', ()),
+            ('channels/U0/voltageRampRate', 'f4', ()),
+            ('channels/U0/measurementCurrent', 'f4', ()),
+            ('channels/U0/measurementSenseVoltage', 'f4', ()),
+            ('channels/U0/current', 'f4', ()),
+            ('channels/U0/supervisionMaxCurrent', 'f4', ()),
+            ('channels/U0/currentRiseRate', 'f4', ()),
+            ('channels/U0/currentFallRate', 'f4', ()),
+            ('channels/U0/measurementTemperature', 'i4', ()),
+            ('channels/U0/supervisionBehavior', 'i4', ()),
+            ('channels/U0/tripTimeMaxCurrent', 'i4', ()),
+            ('channels/U0/configMaxSenseVoltage', 'f4', ()),
         ]
 
     def write_control(self, f):
         super().write_control(f)
-        ctrl_grp = f'CONTROL/{self.device_id}'
-        run_grp = f'RUN/{self.device_id}'
+        ctrl_grp = f'CONTROL/{self.device_id}/'
+        run_grp = f'RUN/{self.device_id}/'
         if self.bias_voltage:
             for grp in [ctrl_grp, run_grp]:
-                length = self.ntrains if grp == ctrl_grp else 1
-                f[f"{grp}/channels/U0/measurementSenseVoltage/value"] = np.array(  # noqa
-                    [300]*length)
+                f[grp + 'channels/U0/measurementSenseVoltage/value'][()] = 300

--- a/extra_data/tests/mockdata/agipd.py
+++ b/extra_data/tests/mockdata/agipd.py
@@ -15,6 +15,7 @@ class AGIPDMDL(DeviceBase):
         self.gain_setting = gain_setting
         self.integration_time = integration_time
 
+        # A sample of some of the available keys.
         self.control_keys = [
             ('acquisitionTime', 'u2', ()),
             ('bunchStructure.nPulses', 'u2', ()),
@@ -52,6 +53,7 @@ class AGIPDMDL(DeviceBase):
 
 
 class AGIPD1MFPGA(DeviceBase):
+    # A sample of some of the available keys.
     control_keys = [
         ('adcLatency', 'u4', ()),
         ('adcTrigger', 'u4', ()),
@@ -75,6 +77,7 @@ class AGIPD1MFPGA(DeviceBase):
 
 
 class AGIPD500KFPGA(DeviceBase):
+    # A sample of some of the available keys.
     control_keys = [
         ('highVoltage.actual', 'u2', ()),
         ('highVoltage.target', 'u2', ()),
@@ -85,8 +88,6 @@ class AGIPD500KFPGA(DeviceBase):
         ctrl_grp = f'CONTROL/{self.device_id}'
         run_grp = f'RUN/{self.device_id}'
         for grp in [ctrl_grp, run_grp]:
-            print("grp", grp)
-
             length = self.ntrains if grp == ctrl_grp else 1
             f[f"{grp}/highVoltage/actual/value"] = np.array([200]*length)
 
@@ -98,7 +99,7 @@ class AGIPD1MPSC(DeviceBase):
     ):
         super().__init__(device_id)
         self.bias_voltage = bias_voltage
-
+        # A sample of some of the available keys.
         self.control_keys = [
             ('applyInProgress', '|u1', ()),
             ('autoRearm', '|u1', ()),
@@ -107,17 +108,15 @@ class AGIPD1MPSC(DeviceBase):
             ('channels.U0.voltage', 'f4', ()),
             ('channels.U0.superVisionMaxTerminalVoltage', 'f4', ()),
             ('channels.U0.voltageRampRate', 'f4', ()),
-            ('channels.U0.measurmentCurrent', 'f4', ()),
+            ('channels.U0.measurementCurrent', 'f4', ()),
             ('channels.U0.current', 'f4', ()),
             ('channels.U0.supervisionMaxCurrent', 'f4', ()),
             ('channels.U0.currentRiseRate', 'f4', ()),
             ('channels.U0.currentFallRate', 'f4', ()),
-            ('channels.U0.measurmentTemperature', 'i4', ()),
+            ('channels.U0.measurementTemperature', 'i4', ()),
             ('channels.U0.supervisionBehavior', 'i4', ()),
             ('channels.U0.tripTimeMaxCurrent', 'i4', ()),
             ('channels.U0.configMaxSenseVoltage', 'f4', ()),
-            ('channels.U0.measurmentSenseVoltage', 'f4', ()),
-
         ]
 
     def write_control(self, f):
@@ -127,5 +126,5 @@ class AGIPD1MPSC(DeviceBase):
         if self.bias_voltage:
             for grp in [ctrl_grp, run_grp]:
                 length = self.ntrains if grp == ctrl_grp else 1
-                f[f"{grp}/channels/U0/measurmentSenseVoltage/value"] = np.array(  # noqa
+                f[f"{grp}/channels/U0/measurementSenseVoltage/value"] = np.array(  # noqa
                     [300]*length)

--- a/extra_data/tests/mockdata/agipd.py
+++ b/extra_data/tests/mockdata/agipd.py
@@ -1,0 +1,131 @@
+import numpy as np
+
+from .base import DeviceBase
+
+
+class AGIPDMDL(DeviceBase):
+    def __init__(
+        self, device_id,
+        rep_rate=True,
+        gain_setting=True,
+        integration_time=True
+    ):
+        super().__init__(device_id)
+        self.rep_rate = rep_rate
+        self.gain_setting = gain_setting
+        self.integration_time = integration_time
+
+        self.control_keys = [
+            ('acquisitionTime', 'u2', ()),
+            ('bunchStructure.nPulses', 'u2', ()),
+            ('bunchStructure.firstPulse', 'u2', ()),
+            ('bunchStructure.methodIndex', 'u2', ()),
+            ('egsgat', 'u2', ()),
+            ('g1sgat', 'u2', ()),
+            ('g2sgat', 'u2', ()),
+            ('pcRowNr', 'u2', ()),
+            ('t0Delay', 'u8', ()),
+            ('ticolm', 'u2', ()),
+            ('vrfcds', 'u2', ()),
+        ]
+
+    def write_control(self, f):
+        super().write_control(f)
+
+        ctrl_grp = f'CONTROL/{self.device_id}'
+        run_grp = f'RUN/{self.device_id}'
+        for grp in [ctrl_grp, run_grp]:
+            length = self.ntrains if grp == ctrl_grp else 1
+
+            f[f"{grp}/setupr/value"] = np.array([32]*length)
+            f[f"{grp}/patternTypeIndex/value"] = np.array([4]*length)
+            f[f"{grp}/gainModeIndex/value"] = np.array([0]*length)
+
+            if self.integration_time:
+                f[f"{grp}/integrationTime/value"] = np.array([15]*length)
+
+            if self.rep_rate:
+                f[f"{grp}/bunchStructure/repetitionRate/value"] = np.array(
+                    [4.5]*length)
+            if self.gain_setting:
+                f[f"{grp}/gain/value"] = np.array([0]*length)
+
+
+class AGIPD1MFPGA(DeviceBase):
+    control_keys = [
+        ('adcLatency', 'u4', ()),
+        ('adcTrigger', 'u4', ()),
+        ('asicCS', 'u4', ()),
+        ('bootId', 'u4', ()),
+        ('commandCounter', 'u4', ()),
+        ('delays', 'u4', (8,)),
+        ('heartbeatInterval', 'i4', ()),
+        ('integrationOffset', 'u4', ()),
+        ('integrationPeriod', 'u4', ()),
+        ('mask', 'u4', ()),
+        ('performanceStatistics.messagingProblems', '|u1', ()),
+        ('performanceStatistics.enable', '|u1', ()),
+        ('performanceStatistics.processingLatency', 'f4', ()),
+        ('performanceStatistics.maxProcessingLatency', 'u4', ()),
+        ('performanceStatistics.numMessages', 'u4', ()),
+        ('performanceStatistics.maxEventLoopLatency', 'u4', ()),
+        ('port', 'i4', ()),
+        ('sleepTime', 'f4', ()),
+    ]
+
+
+class AGIPD500KFPGA(DeviceBase):
+    control_keys = [
+        ('highVoltage.actual', 'u2', ()),
+        ('highVoltage.target', 'u2', ()),
+    ]
+
+    def write_control(self, f):
+        super().write_control(f)
+        ctrl_grp = f'CONTROL/{self.device_id}'
+        run_grp = f'RUN/{self.device_id}'
+        for grp in [ctrl_grp, run_grp]:
+            print("grp", grp)
+
+            length = self.ntrains if grp == ctrl_grp else 1
+            f[f"{grp}/highVoltage/actual/value"] = np.array([200]*length)
+
+
+class AGIPD1MPSC(DeviceBase):
+    def __init__(
+        self, device_id,
+        bias_voltage=True,
+    ):
+        super().__init__(device_id)
+        self.bias_voltage = bias_voltage
+
+        self.control_keys = [
+            ('applyInProgress', '|u1', ()),
+            ('autoRearm', '|u1', ()),
+            ('channels.U0.status', 'i4', ()),
+            ('channels.U0.switch', 'i4', ()),
+            ('channels.U0.voltage', 'f4', ()),
+            ('channels.U0.superVisionMaxTerminalVoltage', 'f4', ()),
+            ('channels.U0.voltageRampRate', 'f4', ()),
+            ('channels.U0.measurmentCurrent', 'f4', ()),
+            ('channels.U0.current', 'f4', ()),
+            ('channels.U0.supervisionMaxCurrent', 'f4', ()),
+            ('channels.U0.currentRiseRate', 'f4', ()),
+            ('channels.U0.currentFallRate', 'f4', ()),
+            ('channels.U0.measurmentTemperature', 'i4', ()),
+            ('channels.U0.supervisionBehavior', 'i4', ()),
+            ('channels.U0.tripTimeMaxCurrent', 'i4', ()),
+            ('channels.U0.configMaxSenseVoltage', 'f4', ()),
+            ('channels.U0.measurmentSenseVoltage', 'f4', ()),
+
+        ]
+
+    def write_control(self, f):
+        super().write_control(f)
+        ctrl_grp = f'CONTROL/{self.device_id}'
+        run_grp = f'RUN/{self.device_id}'
+        if self.bias_voltage:
+            for grp in [ctrl_grp, run_grp]:
+                length = self.ntrains if grp == ctrl_grp else 1
+                f[f"{grp}/channels/U0/measurmentSenseVoltage/value"] = np.array(  # noqa
+                    [300]*length)


### PR DESCRIPTION
While working on adding some tests for methods in pyCalibration to read parameter values from INSTRUMENT and RUN sources from AGIPD runs. I was wondering if I should use actual files or mock the data needed for tests.

After realizing that pyCalibration already uses the mocked examples in EXtra-data, I though that I might add to it in the purpose for using it for more pyCalibration unit tests.

In this MR, there is the new `mockdata/agipd.py` file with classes for writing CONTROL and RUN parameters needed for  the tests on https://git.xfel.eu/detectors/pycalibration/-/merge_requests/646

And three functions to make different agipd runs

1. `make_agipd1m_run`: AGIPD1M run with INSTRUMENT and subset of needed parameters at CONTROL and RUN sources.
2. `make_agipd1m_run_old`: AGIPD1M run with INSTRUMENT and subset of needed parameters at CONTROL and RUN sources. And with missing parameters compared to `make_agipd1m_run`
3. `make_agipd500k_run`: AGIPD500K run which differ in some of the CONTROL and RUN sources and keys.

