### PR TITLE
Use Dataset instead of DataArray for structured xarray data

### DIFF
--- a/extra_data/keydata.py
+++ b/extra_data/keydata.py
@@ -267,10 +267,16 @@ class KeyData:
     def xarray(self, extra_dims=None, roi=(), name=None):
         """Load this data as a labelled xarray array or dataset.
 
-        The first dimension is labelled with train IDs. Other dimensions may be
-        named by passing a list of names to *extra_dims*. For scalar datatypes,
-        an xarray.DataArray is returned. If the data is stored in a structured
-        datatype, an xarray.Dataset is returned with a variable for each field.
+        The first dimension is labelled with train IDs. Other dimensions
+        may be named by passing a list of names to *extra_dims*.
+
+        For scalar datatypes, an xarray.DataArray is returned using either
+        the supplied *name* or the concatenated source and key name if omitted.
+
+        If the data is stored in a structured datatype, an xarray.Dataset
+        is returned with a variable for each field. The data of these
+        variables will be non-contiguous in memory, use
+        `Dataset.copy(deep=true)` to obtain a contiguous copy.
 
         Parameters
         ----------

--- a/extra_data/tests/conftest.py
+++ b/extra_data/tests/conftest.py
@@ -115,6 +115,13 @@ def mock_scs_run():
 
 
 @pytest.fixture(scope='session')
+def mock_remi_run():
+    with TemporaryDirectory() as td:
+        make_examples.make_remi_run(td)
+        yield td
+
+
+@pytest.fixture(scope='session')
 def empty_h5_file():
     with TemporaryDirectory() as td:
         path = osp.join(td, 'empty.h5')

--- a/extra_data/tests/make_examples.py
+++ b/extra_data/tests/make_examples.py
@@ -17,6 +17,7 @@ from .mockdata.jungfrau import (
 )
 from .mockdata.motor import Motor
 from .mockdata.mpod import MPOD
+from .mockdata.proc import ReconstructedDLD6
 from .mockdata.tsens import TemperatureSensor
 from .mockdata.uvlamp import UVLamp
 from .mockdata.xgm import XGM
@@ -326,6 +327,11 @@ def make_jungfrau_run(dir_path):
         JUNGFRAUControl('SPB_IRDA_JF4M/DET/CONTROL'),
         JUNGFRAUMonitor('SPB_IRDA_JF4M/MDL/MONITOR'),
         JUNGFRAUPower('SPB_IRDA_JF4M/MDL/POWER'),
+    ], ntrains=100, chunksize=1, format_version='1.0')
+
+def make_remi_run(dir_path):
+    write_file(osp.join(dir_path, f'CORR-R0210-REMI01-S00000.h5'), [
+        ReconstructedDLD6('SQS_REMI_DLD6/DET/TOP'),
     ], ntrains=100, chunksize=1, format_version='1.0')
 
 def make_scs_run(dir_path):

--- a/extra_data/tests/mockdata/proc.py
+++ b/extra_data/tests/mockdata/proc.py
@@ -1,0 +1,29 @@
+
+"""Script that creates mock-data for virtual processed devices.
+
+These are virtual devices that do not actually exist in Karabo for real,
+but are the result of processing raw data into a scientifically more
+useful representation or as a form of data reduction.
+"""
+
+import numpy as np
+
+from .base import DeviceBase
+
+
+class ReconstructedDLD6(DeviceBase):
+    """
+    Reconstructed DLD6 data from ADQ digitizer traces.
+    Based on example /gpfs/exfel/exp/SQS/202101/p002448/proc/r0210/CORR-R0210-REMI01-S00000.h5
+    """
+
+    hits_dt = np.dtype([
+        ('x', 'f8'), ('y', 'f8'), ('t', 'f8'), ('m', 'i4')
+    ])
+    signals_dt = np.dtype([
+        (key, 'f8') for key in ['u1', 'u2', 'v1', 'v2', 'w1', 'w2', 'mcp']
+    ])
+
+    output_channels = ('output/rec',)
+    instrument_keys = [('signals', signals_dt, (50,)),
+                       ('hits', hits_dt, (50,))]

--- a/extra_data/tests/test_keydata.py
+++ b/extra_data/tests/test_keydata.py
@@ -1,5 +1,6 @@
 import os
 import numpy as np
+import xarray as xr
 import pytest
 
 import h5py
@@ -282,6 +283,22 @@ def test_single_value(mock_sa3_control_data, monkeypatch):
         intensity.as_single_value()
 
     np.testing.assert_equal(intensity.as_single_value(rtol=1), np.median(data))
+
+
+def test_xarray_structured_data(mock_remi_run):
+    run = RunDirectory(mock_remi_run)
+    dset = run['SQS_REMI_DLD6/DET/TOP:output', 'rec.hits'].xarray()
+
+    assert isinstance(dset, xr.Dataset)
+    assert list(dset.data_vars.keys()) == ['x', 'y', 't', 'm']
+
+    arrs = list(dset.data_vars.values())
+
+    assert all([arr.shape == (100, 50) for arr in arrs])
+    assert all([arr.dtype == np.float64 for arr in arrs[:3]])
+    assert arrs[3].dtype == np.int32
+
+    np.testing.assert_equal(dset.coords['trainId'], np.arange(10000, 10100))
 
 
 @pytest.fixture()


### PR DESCRIPTION
We've recently begun using structured datatypes for the result of processing data. In particular when the output is of arbitrary length such as for REMI reconstruction and now TIMEPIX centroiding, this is significantly more efficient both in terms of storage space as well as access.

Today a user tipped me off that `xarray.DataArray` basically does not support structured datatypes, making access very complicated and its features almost useless. Instead, the canonical way to handle this in `xarray` appears to wrap it into an `xarray.Dataset` with each field its own variable over common coordinates. For that purpose, I've changed `KeyData.xarray()` to return such a dataset in the case of structured data:

![image](https://user-images.githubusercontent.com/56224768/159887494-cdbe6585-dc9f-4de1-ad3a-ab07a8734240.png)

Before adding structured data to the test framework, I'd like to discuss whether we can agree on this approach.