### PR TITLE
Fix pickling FileAccess objects with cloudpickle

### DIFF
--- a/.github/dependabot/constraints.txt
+++ b/.github/dependabot/constraints.txt
@@ -1,3 +1,4 @@
+cloudpickle==2.0.0
 coverage==6.2
 h5py<3.7.0
 karabo-bridge==0.6.1

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setup(name="EXtra-data",
               'psutil',
           ],
           'test': [
+              'cloudpickle',
               'coverage',
               'dask[array]',
               'nbval',


### PR DESCRIPTION
[cloudpickle](https://pypi.org/project/cloudpickle/#description) is an extended Pickle library used by projects like Dask and clusterfutures to send objects around. @tmichela found that it wasn't working with EXtra-data 1.10, probably because of #264.

The issue was the `FileAccess._from_pickle` classmethod. cloudpickle attempted to save this 'by value', and since it uses the file access registry, it tried to pickle the registry as well, and it can't handle the weakref objects stored there. The best option I can see is to make it a staticmethod instead (i.e. a plain function defined in a class), which cloudpickle pickles 'by reference' - i.e. it stores the path to import and look up the function in the destination.

This would make subclassing FileAccess a bit more work, but I'm not aware of anyone doing that, and I wouldn't encourage it - subclasses are quite likely to break when details change.