### PR TITLE
Catch PermissionError when trying to open run files map

### DIFF
--- a/extra_data/run_files_map.py
+++ b/extra_data/run_files_map.py
@@ -103,7 +103,7 @@ class RunFilesMap:
                 self.cache_file = path
                 log.debug("Loaded cached files map from %s", path)
                 break
-            except (FileNotFoundError, json.JSONDecodeError):
+            except (FileNotFoundError, PermissionError, json.JSONDecodeError,):
                 pass
 
         for info in loaded_data:


### PR DESCRIPTION
Just happened in the field with example data that had been moved to `/gpfs/exfel/data/scratch`, users in the `upex` group were not able to load the `karabo_data_map.json` file created by someone in `exfel`. This situation is possible as that mount point does not enforce the same ACLs as those found in proposal directories, resulting in `640` files.

While a proper fix may be to set the chmod of created files to always be world-readable, the reading code should still not throw an exception in this case but ignore the file. The same exception is already caught when writing it.