### PR TITLE
Allow KeyData.ndarray to read into a pre-allocated array

### DIFF
--- a/extra_data/keydata.py
+++ b/extra_data/keydata.py
@@ -216,18 +216,22 @@ class KeyData:
 
     # Getting data as different kinds of array: -------------------------------
 
-    def ndarray(self, roi=()):
+    def ndarray(self, roi=(), out=None):
         """Load this data as a numpy array
 
         *roi* may be a ``numpy.s_[]`` expression to load e.g. only part of each
-        image from a camera.
+        image from a camera. If *out* is not given, a suitable array will be
+        allocated.
         """
         if not isinstance(roi, tuple):
             roi = (roi,)
 
-        out = np.empty(
-            self.shape[:1] + roi_shape(self.entry_shape, roi), dtype=self.dtype
-        )
+        req_shape = self.shape[:1] + roi_shape(self.entry_shape, roi)
+
+        if out is None:
+            out = np.empty(req_shape, dtype=self.dtype)
+        elif out is not None and out.shape != req_shape:
+            raise ValueError(f'requires output array of shape {req_shape}')
 
         # Read the data from each chunk into the result array
         dest_cursor = 0

--- a/extra_data/tests/test_keydata.py
+++ b/extra_data/tests/test_keydata.py
@@ -236,6 +236,7 @@ def test_drop_empty_trains(mock_sa3_control_data):
     assert frame_counts.shape == (250,)
     assert frame_counts.min() == 1
 
+
 def test_single_value(mock_sa3_control_data, monkeypatch):
     f = H5File(mock_sa3_control_data)
 
@@ -282,6 +283,18 @@ def test_single_value(mock_sa3_control_data, monkeypatch):
         intensity.as_single_value()
 
     np.testing.assert_equal(intensity.as_single_value(rtol=1), np.median(data))
+
+
+def test_ndarray_out(mock_spb_raw_run):
+    f = RunDirectory(mock_spb_raw_run)
+    cam = f['SPB_IRU_CAM/CAM/SIDEMIC:daqOutput', 'data.image.dims']
+
+    buf_new = cam.ndarray()  # New copy of data.
+    buf_in = np.zeros(cam.shape, dtype=cam.dtype)
+    buf_out = cam.ndarray(out=buf_in)  # In-place copy of data.
+
+    np.testing.assert_allclose(buf_new, buf_out)
+    assert buf_in is buf_out
 
 
 @pytest.fixture()


### PR DESCRIPTION
Noticed on the side while discussing AGIPD's memory problems during corrections, it' fairly easy to allow `KeyData.ndarray()` to accept a pre-allocated array.

I decided to only check for the correct shape rather than dtype, as `Dataset.read_direct`'s semantics allow for type coercion during reading.