### PR TITLE
WIP: Layers

### DIFF
--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -571,6 +571,16 @@ class DataCollection:
             return self._sources_data.maps
         return [self._sources_data]
 
+    def layer(self, name):
+        ix = self._layer_names.index(name)
+        sources_dict = self._layers[ix]
+        files = set().union(*[sd.files for sd in sources_dict.values()])
+        return DataCollection(
+            files, sources_data=sources_dict, train_ids=self.train_ids,
+            inc_suspect_trains=self.inc_suspect_trains,
+            is_single_run=self.is_single_run, layer_names=(name,),
+        )
+
     def union(self, *others):
         """Join the data in this collection with one or more others.
 

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -98,13 +98,13 @@ class DataCollection:
                     files_by_sources[source, 'INSTRUMENT'].append(f)
             sources_data = {
                 src: SourceData(src,
-                                sel_keys=None,
-                                train_ids=train_ids,
-                                files=files,
-                                section=section,
-                                is_single_run=self.is_single_run,
-                                inc_suspect_trains=self.inc_suspect_trains,
-                                )
+                    sel_keys=None,
+                    train_ids=train_ids,
+                    files=files,
+                    section=section,
+                    is_single_run=self.is_single_run,
+                    inc_suspect_trains=self.inc_suspect_trains,
+                )
                 for ((src, section), files) in files_by_sources.items()
             }
         elif isinstance(sources_data, list):


### PR DESCRIPTION
The idea of this is that you can 'overlay' raw & proc data and still be able to access either:

```
In [2]: run = open_run(2734, 182, data=('raw', 'proc'))

# Find the source in the first data section where it exists (here raw):
In [5]: run['SPB_DET_AGIPD1M-1/DET/10CH0:xtdf', 'image.data'].dtype
Out[5]: dtype('uint16')

# Get the source from a specific layer (syntax up for discussion):
In [7]: run.layer('raw')['SPB_DET_AGIPD1M-1/DET/10CH0:xtdf', 'image.data'].dtype
Out[7]: dtype('uint16')

In [8]: run.layer('proc')['SPB_DET_AGIPD1M-1/DET/10CH0:xtdf', 'image.data'].dtype
Out[8]: dtype('<f4')
```

I'm not sure about this yet - it makes bits of the code rather more complex, and it might not be used that often.

The aim is that you can have a combined view of the data - e.g. to do `.select(..., require_all=True)` - and specifically access e.g. AGIPD proc data, telling it that you want proc data so it fails if that's missing rather than quietly switching to raw (#292). We could even make `data=('raw', 'proc')` the default without changing things that already work (mostly).

@philsmt this would be an alternative to your #298. In this PR, the first named origin containing a source 'wins', as opposed to the last in your PR.

