### PR TITLE
FIX: open run with data='all' when proc folder exists but is empty

### DIFF
--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -1382,7 +1382,7 @@ def RunDirectory(
     files = [osp.join(path, f) for f in fnmatch.filter(files, include)]
     sel_files = file_filter(files)
     if not sel_files:
-        raise Exception(
+        raise FileNotFoundError(
             f"No HDF5 files found in {path} with glob pattern {include}")
 
     if _use_voview and (sel_files == files):

--- a/extra_data/tests/test_reader_mockdata.py
+++ b/extra_data/tests/test_reader_mockdata.py
@@ -841,6 +841,11 @@ def test_open_run(mock_spb_raw_run, mock_spb_proc_run, tmpdir):
         with pytest.raises(Exception):
             open_run(proposal=2012, run=999)
 
+        # run directory exists but contains no data
+        os.makedirs(os.path.join(prop_dir, 'proc', 'r0238'))
+        with catch_warnings(record=True) as w:
+            open_run(proposal=2012, run=238, data='all')
+            assert len(w) == 1
 
 def test_open_file(mock_sa3_control_data):
     f = H5File(mock_sa3_control_data)


### PR DESCRIPTION
[open_run](https://github.com/European-XFEL/EXtra-data/blob/master/extra_data/reader.py#L1459) expects a `FileNotFoundError` when opening `data='all'` if the proc folder does not exist. Sometimes, a proc folder is created, but does not contain any data. In this case, `RunDirectory` throws a generic `Exception` when a `FileNotFoundException` is expected.