### PR TITLE
Map function over detector frames

### DIFF
--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -531,7 +531,7 @@ class MultimodDetectorBase:
 
         def chunk_func(chunk):
             if out_shape is not None:
-                out = self._out_array((chunk.n_frames, *out_shape), dtype=out_dtype)
+                out = chunk._out_array((chunk.n_frames, *out_shape), dtype=out_dtype)
             else:
                 out = [None] * chunk.n_frames
             chunk._apply_framewise(f, out, data_params)

--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -1,5 +1,6 @@
 """Interfaces to data from specific instruments
 """
+import functools
 import logging
 import re
 from copy import copy
@@ -98,6 +99,7 @@ class MultimodDetectorBase:
     # Override in subclass
     _main_data_key = ''  # Key to use for checking data counts match
     _frames_per_entry = 1  # Override if separate pulse dimension in files
+    _modnos_start_at = 0  # Override if module numbers start at 1 (JUNGFRAU)
     module_shape = (0, 0)
     n_modules = 0
 
@@ -282,6 +284,10 @@ class MultimodDetectorBase:
             raise ValueError(f"Varying number of frames per train: {counts}")
         return counts.pop() * self._frames_per_entry
 
+    @property
+    def n_frames(self):
+        return self.frame_counts.sum() * self._frames_per_entry
+
     def __repr__(self):
         return "<{}: Data interface for detector {!r} with {} modules>".format(
             type(self).__name__, self.detector_name, len(self.source_to_modno),
@@ -407,7 +413,7 @@ class MultimodDetectorBase:
           Specify e.g. ``np.s_[10:60, 100:200]`` to select pixels within each
           module when reading data. The selection is applied to each individual
           module, so it may only be useful when working with a single module.
-        astype: Type
+        astype: dtype
           Data type of the output array. If None (default) the dtype matches the
           input array dtype
         """
@@ -465,6 +471,115 @@ class MultimodDetectorBase:
             arrays.append(mod_arr)
 
         return self._concat(arrays, modnos, fill_value, astype)
+
+    def _get_data(self, key, *, fill_value=None, roi=(), astype=None):
+        """Get data as a plain NumPy array with no labels"""
+        train_ids = np.asarray(self.data.train_ids)
+
+        eg_src = min(self.source_to_modno)
+        eg_keydata = self.data[eg_src, key]
+
+        # Find the shape of 1 frame for 1 module with the ROI applied
+        out_shape = ((self.n_modules, len(train_ids))
+                     + roi_shape(eg_keydata.entry_shape, roi))
+
+        dtype = eg_keydata.dtype if astype is None else np.dtype(astype)
+        out = self._out_array(out_shape, dtype, fill_value=fill_value)
+
+        for modno, source in sorted(self.modno_to_source.items()):
+            mod_ix = modno - self._modnos_start_at
+            for chunk in self.data._find_data_chunks(source, key):
+                for tgt_slice, chunk_slice in self._split_align_chunk(chunk, train_ids):
+                    chunk.dataset.read_direct(
+                        out[mod_ix, tgt_slice], source_sel=(chunk_slice,) + roi
+                    )
+
+        return out
+
+    def _apply_framewise(self, f, out, data_params={}):
+        arr = self._get_data(self._main_data_key)
+        # Array should be (modules, frames, *pixel_dims)
+        ndim_px = len(self.module_shape)
+        ndim_iter = arr.ndim - 1 - ndim_px
+        arr = arr.reshape((arr.shape[0], -1, *arr.shape[-ndim_px:]))
+
+        # Prepare arrays for data to be passed as kwargs (mask, pulseId, etc.)
+        kw_arrs = {}
+        for param, key in data_params.items():
+            a = self._get_data(key)
+            ndim_inner = a.ndim - 1 - ndim_iter
+            kw_arrs[param] = a.reshape((a.shape[0], -1, *arr.shape[-ndim_inner:]))
+
+        for i in range(arr.shape[1]):
+            kw = {p: a[:, i] for (p, a) in kw_arrs.items()}
+            out[i] = f(arr[:, i], **kw)
+
+    def _frame_func_to_chunk_func(self, f, out_shape=None, out_dtype=None):
+        import inspect
+
+        eg_srcdata = self.data[min(self.source_to_modno)]
+        main_group = self._main_data_key.rpartition('.')[0] + '.'
+        data_keys = {k.rpartition('.')[2]: k for k in eg_srcdata.keys()
+                     if k.startswith(main_group)}
+        data_params = {}
+        for param_name in list(inspect.signature(f).parameters)[1:]:
+            if param_name in data_keys:
+                data_params[param_name] = data_keys[param_name]
+            else:
+                raise KeyError(f"No {param_name} data available; "
+                               f"possible names are {', '.join(data_keys)}")
+
+        def chunk_func(chunk):
+            if out_shape is not None:
+                out = self._out_array((chunk.n_frames, *out_shape), dtype=out_dtype)
+            else:
+                out = [None] * chunk.n_frames
+            chunk._apply_framewise(f, out, data_params)
+            return out
+
+        return chunk_func
+
+    def map_frames(
+            self, f, mapper=None, *,
+            out=None, out_shape=None, out_dtype=None,
+            parts=None, trains_per_part=None, frames_per_part=None
+    ):
+        if mapper is None:
+            # Default to using multiprocessing with up to 16 cores.
+            # We're likely to spend a fair bit of
+            import multiprocessing
+            with multiprocessing.Pool(min(multiprocessing.cpu_count(), 16)) as p:
+                return self.map_frames(
+                    f, p.imap, out=out, out_shape=out_shape, out_dtype=out_dtype,
+                    parts=parts, trains_per_part=trains_per_part,
+                    frames_per_part=frames_per_part,
+                )
+
+        if parts is None and trains_per_part is None and frames_per_part is None:
+            # Default ~4 GiB chunks for 1 MPx detectors. This is probably too
+            # big for all cores in parallel on one node, but in many cases the
+            # limiting step will be loading data, so you want fewer workers
+            # (or split it over multiple nodes)
+            frames_per_part = 1000
+        chunks = self.split_trains(parts, trains_per_part, frames_per_part)
+
+        chunk_func = self._frame_func_to_chunk_func(f)
+        results_iter = mapper(chunk_func, chunks)
+
+        if out is None:
+            if out_shape is not None:
+                out = self._out_array((self.n_frames, *out_shape), dtype=out_dtype)
+            else:
+                out = [None] * self.n_frames
+
+        # Assemble per-chunk results into output list/array
+        out_cursor = 0
+        for chunk_res in results_iter:
+            to = out_cursor + len(chunk_res)
+            out[out_cursor : to] = chunk_res
+            out_cursor = to
+
+        return out
 
     def trains(self, require_all=True):
         """Iterate over trains for detector data.
@@ -1429,6 +1544,7 @@ class JUNGFRAU(MultimodDetectorBase):
         r'(MODULE_|RECEIVER-|JNGFR)(?P<modno>\d+)'
     )
     _main_data_key = 'data.adc'
+    _modnos_start_at = 1
     module_shape = (512, 1024)
 
     def __init__(self, data: DataCollection, detector_name=None, modules=None,

--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -474,7 +474,7 @@ class MultimodDetectorBase:
 
     def _get_data(self, key, *, fill_value=None, roi=(), astype=None):
         """Get data as a plain NumPy array with no labels"""
-        train_ids = np.asarray(self.data.train_ids)
+        train_ids = self.train_ids_perframe
 
         eg_src = min(self.source_to_modno)
         eg_keydata = self.data[eg_src, key]


### PR DESCRIPTION
This aims to make it easier to apply a function to each frame of multi-module detector data, like in this screenshot:

![image](https://user-images.githubusercontent.com/327925/182563988-009239cc-df0a-4252-b10e-0bf8b28d1bd7.png)

Azimuthal integration is one particular motivating use case.

Design:

* The core idea is to batch frames together, so we're submitting fewer, larger tasks
  * Each task loads a chunk of data (by default ~1000 frames), and then runs the function on these sequentially
* You can ideally use any `map` method - local thread/process pools, Dask (as in the screenshot), clusterfutures...
* If the per-frame function has parameter names like `mask` or `cellId`, the corresponding data will be loaded and passed to it.
* It returns a list (one result per frame) by default, but you also have the option to make an array, which should be a bit more efficient than using `np.stack()`.

Concerns & questions:

- I needed some kludgy specific workarounds to get this working nicely with Dask, which was one of my main goals. In particular, Dask was spending an inordinately long time making unique names for the tasks, until I overrode it with random names.
- Azimuthal integration was the motivating use case, but it's actually kind of inefficient for that. If you construct the AzimuthalIntegrator outside the function, you have to send about 100 MB of data for each batch task (for AGIPD-1M: 3D positions of each corner of 1 million pixels). If you construct it inside the function, you're redoing that for every frame. :thinking: 
- Possible extension: add a parameter so that if `out_shared=True`, workers write directly to a shared output array, rather than serialising data to send back.