### PR TITLE
Propagate the parallelize option in open_run()

### DIFF
--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -1448,7 +1448,8 @@ def open_run(
     if data == 'all':
         common_args = dict(
             proposal=proposal, run=run, include=include,
-            file_filter=file_filter, inc_suspect_trains=inc_suspect_trains)
+            file_filter=file_filter, inc_suspect_trains=inc_suspect_trains,
+            parallelize=parallelize)
 
         # Open the raw data
         dc = open_run(**common_args, data='raw')

--- a/extra_data/tests/conftest.py
+++ b/extra_data/tests/conftest.py
@@ -1,3 +1,4 @@
+import os
 import os.path as osp
 
 import h5py
@@ -106,6 +107,24 @@ def mock_spb_raw_run(format_version):
     with TemporaryDirectory() as td:
         make_examples.make_spb_run(td, format_version=format_version)
         yield td
+
+
+@pytest.fixture(scope='session')
+def mock_spb_raw_and_proc_run():
+    with TemporaryDirectory() as td:
+        prop_dir = osp.join(str(td), 'SPB', '201830', 'p002012')
+
+        # Set up raw
+        raw_run_dir = osp.join(prop_dir, 'raw', 'r0238')
+        os.makedirs(raw_run_dir)
+        make_examples.make_spb_run(raw_run_dir)
+
+        # Set up proc
+        proc_run_dir = osp.join(prop_dir, 'proc', 'r0238')
+        os.makedirs(proc_run_dir)
+        make_examples.make_spb_run(proc_run_dir, raw=False)
+
+        yield td, raw_run_dir, proc_run_dir
 
 
 @pytest.fixture(scope='session')


### PR DESCRIPTION
This comes up when using `open_run(data="all")`, which will make another call
internally to load proc data with `open_run(data="proc")`. Since the
parallelize option wasn't passed, the call to open proc data would use the
default of `parallelize=True`.

Note: I refactored `test_open_run()` to re-use the code for creating a mock root directory with raw and proc directories etc, but I'm not sure I like how messy it is to return so many paths from a fixture :shrug: I could also copy and paste the setup lines into `test_open_run_daemonized()`.