### PR TITLE
Options to read & decompress data in parallel

### DIFF
--- a/extra_data/keydata.py
+++ b/extra_data/keydata.py
@@ -365,7 +365,7 @@ class KeyData:
         ]
         return np.concatenate(chunks_trainids)
 
-    def xarray(self, extra_dims=None, roi=(), name=None):
+    def xarray(self, extra_dims=None, roi=(), name=None, read_procs=1, decomp_threads=1):
         """Load this data as a labelled xarray array or dataset.
 
         The first dimension is labelled with train IDs. Other dimensions
@@ -395,10 +395,20 @@ class KeyData:
         name: str
             Name the array itself. The default is the source and key joined
             by a dot. Ignored for structured data when a dataset is returned.
+        read_procs: int
+            Use this many processes to read data. Using up to 8-10 processes
+            seems to accelerate data access.
+        decomp_threads: int
+            Use this many threads to decompress certain data, or -1 for one
+            thread per CPU core. This only applies to compressed gain/mask
+            data from corrected 2D detectors, and will be ignored for other
+            keys.
         """
         import xarray
 
-        ndarr = self.ndarray(roi=roi)
+        ndarr = self.ndarray(
+            roi=roi, read_procs=read_procs, decomp_threads=decomp_threads
+        )
 
         # Dimension labels
         if extra_dims is None:

--- a/extra_data/keydata.py
+++ b/extra_data/keydata.py
@@ -5,7 +5,8 @@ import numpy as np
 from .exceptions import TrainIDError, NoDataError
 from .file_access import FileAccess
 from .read_machinery import (
-    contiguous_regions, DataChunk, select_train_ids, split_trains, roi_shape
+    contiguous_regions, DataChunk, select_train_ids, split_trains, roi_shape,
+    zeros_shared
 )
 from .utils import available_cpu_cores
 
@@ -239,7 +240,10 @@ class KeyData:
         req_shape = self.shape[:1] + roi_shape(self.entry_shape, roi)
 
         if out is None:
-            out = np.empty(req_shape, dtype=self.dtype)
+            if read_procs == 1:
+                out = np.empty(req_shape, dtype=self.dtype)
+            else:
+                out = zeros_shared(req_shape, self.dtype)
         elif out is not None and out.shape != req_shape:
             raise ValueError(f'requires output array of shape {req_shape}')
 

--- a/extra_data/keydata.py
+++ b/extra_data/keydata.py
@@ -291,6 +291,13 @@ class KeyData:
         *roi* may be a ``numpy.s_[]`` expression to load e.g. only part of each
         image from a camera. If *out* is not given, a suitable array will be
         allocated.
+
+        Passing *read_procs* will use multiple processes to read the data in
+        parallel; using up to 8-10 processes seems to speed up reading larger
+        data, if your code is not parallelised at another level. For certain
+        compressed data (gain & mask information from corrected 2D detectors),
+        you can decompress it in parallel by passing *decomp_threads*. A value
+        of -1 will use one thread per CPU core.
         """
         if not isinstance(roi, tuple):
             roi = (roi,)

--- a/extra_data/read_machinery.py
+++ b/extra_data/read_machinery.py
@@ -271,3 +271,22 @@ def same_run(*args) -> bool:
 
 
 glob_wildcards_re = re.compile(r'([*?[])')
+
+
+# Based on _alloc function in pasha
+def zeros_shared(shape, dtype):
+    # Allocate shared memory via mmap.
+    import mmap
+
+    n_elements = 1
+    for _s in shape:
+        n_elements *= _s
+
+    n_bytes = n_elements * np.dtype(dtype).itemsize
+    n_pages = n_bytes // mmap.PAGESIZE + 1
+
+    buf = mmap.mmap(-1, n_pages * mmap.PAGESIZE,
+                    flags=mmap.MAP_SHARED | mmap.MAP_ANONYMOUS,
+                    prot=mmap.PROT_READ | mmap.PROT_WRITE)
+
+    return np.frombuffer(memoryview(buf)[:n_bytes], dtype=dtype).reshape(shape)

--- a/extra_data/tests/test_keydata.py
+++ b/extra_data/tests/test_keydata.py
@@ -298,6 +298,15 @@ def test_ndarray_out(mock_spb_raw_run):
     assert buf_in is buf_out
 
 
+def test_ndarray_read_multiproc(mock_spb_raw_run):
+    f = RunDirectory(mock_spb_raw_run)
+    cam = f['SPB_IRU_CAM/CAM/SIDEMIC:daqOutput', 'data.image.dims']
+
+    arr = cam.ndarray()
+    arr_p = cam.ndarray(read_procs=4)
+    np.testing.assert_array_equal(arr_p, arr)
+
+
 def test_xarray_structured_data(mock_remi_run):
     run = RunDirectory(mock_remi_run)
     dset = run['SQS_REMI_DLD6/DET/TOP:output', 'rec.hits'].xarray()


### PR DESCRIPTION
This adds `read_procs` and `decomp_threads` parameters to `KeyData.ndarray()` and `.xarray()`. They control the number of processes used to read data from HDF5 files, and threads used to decompress data in the specific pattern we use for gain/mask datasets in 2D data. They both default to 1, i.e. the status quo, and we avoid launching separate processes/threads when they're 1.

Testing with ~55 GB of JUNGFRAU data, I got a better-than-2x speedup reading uncompressed data with 10 processes (~1 minute -> ~24 seconds), and something like a 10x speedup reading compressed data with `decomp_threads=-1`, i.e. 1 thread per core, on a 72-core node (~1 min 40 s -> 10 s). The timings are pretty variable - AFAICT, filesystem access always is.

The `read_procs` option is kind of incompatible with passing in an `out` array, because the array needs to be in shared memory. I'm not sure how to deal with that in the API - we could reject using `out` and `read_procs` together, but you could also pass in an array in shared memory, and I don't know of any way to check for that.

Future work:

- Extend this to multi-module detector data (waiting on #337)
- More efficient decompression, with fewer temporary memory allocations (@JamesWrigley has been experimenting with this).

Closes #49.