### PR TITLE
First draft of file format definition overhaul

### DIFF
--- a/docs/data_format.rst
+++ b/docs/data_format.rst
@@ -1,119 +1,200 @@
+
 Data files format
 =================
 
-The main unit of data this tool works with is a *run*. A run is data collected
-in a specific period, and each research proposal given beantime at European XFEL
-may collect hundreds of runs.
+Scientific data at European XFEL is saved as structured HDF5 files in format
+called EXDF. Each file contains data for one or more *sources* having multiple
+*keys* that carry values for certain *trains*. Most sources, in particular for
+raw data, correspond to an entity in the Karabo control system called a *device*,
+which may manage physical hardware but also purely perform software functions.
 
-A run is stored as a directory containing HDF5 data files from different
-sources. These fall into two important categories:
+In most cases at European XFEL, such files are encountered with raw data recorded
+during an experiment by its data acquisition system (DAQ) or with automatically
+processed data created afterwards. Here, sources and trains are generally split
+across multiple files with sources grouped by an *aggregator* and trains by
+enumerated *sequences*. Sources with a very large data volume often have their own
+aggregator (e.g. very fast digitizers) or are even be spread across multiple of
+them (e.g. multi-module detectors). It is not guaranteed that the same sequence
+for different aggregators will cover the same set of trains.
 
-1. Detector data, from the main X-ray detectors in the various experiments.
+A continuous DAQ recording over a period of time is a *run* and includes all the
+structured HDF5 in a single directory. Here these files follow a naming pattern::
 
-   - Each detector module writes separate files, e.g. ``RAW-R0348-AGIPD00-S00000.h5``.
-     The number in the third part of the filename identifies the module (0 in
-     this example).
-   - The detectors in use as of April 2018 are *LPD* and *AGIPD* in the file
-     names. Each has 16 modules numbered 0–15.
+    RAW-R0348-AGIPD04-S00002.h5
+    
+which denotes the HDF5 file with ``raw`` data for sequence ``2`` of the aggregator
+``AGIPD04`` in run ``348``. Within a run the grouping of sources into aggregators
+does not change. Each *proposal* can collect any number of runs during their granted
+beamtime.
 
-2. All the other data, such as motor positions, beam measurements, etc., are
-   recorded through a *data aggregator*, and stored in a file with the letters
-   *DA* in the name, e.g. ``RAW-R0450-DA01-S00000.h5``.
+This document describes the most recent version ``1.2`` of this file format. While
+earlier version are used for data written at the time, their use is discouraged
+for any new files. The appendix lists the differences between each versions.
 
-The last part of the file name (e.g. ``S00000``) is a sequence number. The
-data within a run may be broken into a number of sequences. So
-``RAW-R0450-DA01-S00000.h5`` and ``RAW-R0450-DA01-S00001.h5`` will contain data
-from the same set of devices, with sequence 1 continuing just after the end of
-sequence 0. Though all data within a run may be broken into sequences, different
-data sets do not necessarily break at the same point, so the various 'sequence 0'
-data files in a run do not have corresponding data.
+
+Data sources
+------------
+
+[went back and forth on this having its own section, but too often it seemed confusing to
+leave it. I've tried to keep this description agnostic of Karabo, but ultimately of course
+it does map back to it]
+
+Sources differ in the semantics of data generation and validity by either being
+*control data* (also called slow or broker data) or *instrument data*
+(also called fast, pipeline or XTDF data). In terms of the Karabo control system,
+control sources represent device properties while instrument sources are the data
+sent by device output channels. As such, it is recommended to follow the Karabo
+device naming convention [1] for source names.
+
+* Control data represents a steady state that retains its value until changed again.
+  Examples for this are motor positions or detector configuration like the frame rate.
+  In general control data has a single value for every train in a file, as any train
+  without it changing carries the value of the previous train. As such each value is
+  accompanied by the timestamp this value became current. Based on the Karabo device
+  naming convention, control sources should follow the pattern ``DOMAIN/TYPE/MEMBER``.
+  Their data is saved in the ``CONTROL`` and ``RUN`` top-level groups described
+  further below.
+ 
+* Instrument sources represent momentary data that is only valid for a single train
+  or pulse. This covers most scientific detectors such as digitizers, cameras and
+  more. These sources are never guaranteed to have data for every train, but may
+  also have multiple and varying entries per train. Their names should follow the
+  pattern ``DOMAIN/TYPE/MEMBER:PIPELINE/ROOT``. The data is saved in the ``INSTRUMENT``
+  top-level groups described further below.
+
+  The last component ``ROOT`` is often considered part of key rathern than the source
+  itself and in a Karabo perspective equivalent to the top-level key in pipeline data.
+  In files however, a Karabo pipeline source may have different entries based on
+  this ``ROOT``.
+
+[insert reference for train structure somewhere?]
 
 
 HDF5 file structure
 -------------------
 
+Every HDF5 file must contain the top-level groups ``METADATA`` and ``INDEX``.
+Depending on the included sources, there may additionally be the groups
+``CONTROL``, ``RUN`` and ``INSTRUMENT``.
+[note 1: is this clear enough it may be a combination of those?]
+[note 2: based on actual files, ``RUN`` seems to always be there even without 
+``CONTROL`` albeit empty, move it to the first list?]
+
+
 METADATA
 ~~~~~~~~
 
-The ``METADATA`` group in an HDF5 file contains three datasets, each of which
-is a 1D array of strings:
+The ``METADATA`` group in an HDF5 file contains auxiliary information as
+individual datasets, most of which are constant across a run and or even
+proposal. Some of these datasets may not be present in any given file depending
+on how it was created. 
 
-* ``METADATA/dataSourceId`` lists data groups in the file. The values are either:
+This list contains all the datasets to be expected for data recorded with the
+EuXFEL DAQ software. Even when only containing a single entry, all these datasets
+are 1D with a length of 1 or more.
 
-  * ``CONTROL/`` followed by a Karabo device name, e.g.
-    ``CONTROL/SA1_XTD2_XGM/DOOCS/MAIN``.
-  * ``INSTRUMENT/`` followed by a Karabo device name, a colon, the name of the
-    output channel, a slash, and the name of a data group (?), e.g.
-    ``INSTRUMENT/SA1_XTD2_XGM/DOOCS/MAIN:output/data``
+[`ascii` is supposed to refer to "String (fixed-length)"]
 
-* ``METADATA/deviceId`` lists the part of each *dataSourceId* after the first
-  slash.
-* ``METADATA/root`` lists the parts before the first slash, so
-  ``concat(root, "/", deviceId) == dataSourceId``.
+* ``creationDate [ascii]`` [what was this time again?]
 
-These three data sets always have the same number of values. They may be padded
-with empty strings, so empty entries are ignored.
+* ``daqLibrary [ascii]`` EuXFEL DAQ software version used to write this file, only applicable to raw recordings.
+
+* ``dataFormatVersion [ascii]`` Data file format version of this file.
+
+* ``dataSources`` describes the sources in this file in three different representations.
+
+  * ``dataSources/root [ascii]`` lists the top-level group a source is found in, ``CONTROL`` or ``INSTRUMENT``.
+
+  * ``dataSources/deviceId [ascii]`` lists the source names itself. For instrument sources, this includes the top-level key and the same source may thus be listed multiple times for each of its top-level keys.
+
+  * ``dataSources/dataSourceId [ascii]`` lists the combination of the prior two, i.e. the full path to each source's top-level group.
+
+* ``karaboFramework [ascii]`` Karabo framework version the DAQ software ran in, only applicable to raw recordings.
+
+* ``proposalNumber [uint32]`` Proposal number this file belongs to.
+
+* ``runNumber [uint32]``  Run number this file belongs to.
+
+* ``sequenceNumber [uint32]``  Sequence number this file has for the aggregator it belongs to.
+
+* ``updateDate [ascii]``  [probably last change to this file?]
+
+[we should add the ```pycalibration`` release here, or some form of version in case of processing]
+
 
 INDEX
 ~~~~~
 
-``INDEX/trainId`` is a 1D array of uint64, listing the pulse trains which the
-file holds data for. This is crucial, since all other data has to be matched up
-according to train IDs.
+The ``INDEX`` group contains information about the *trains* contained in the file and how
+the actual data rows in `CONTROL` and `INSTRUMENT` relate to them. All datasets in this group
+are 1D and have a length identical to the number of trains in the file.
 
-For each entry in ``METADATA/deviceId``, the ``INDEX`` group contains two
-datasets, both uint64 data with the same length as the train IDs:
+There are three datasets at the top-level of this group:
 
-* ``INDEX/{ deviceId }/count``: for each train ID, how many data samples did
-  this device record. This may be 0 if no data was recorded for this train.
-* ``INDEX/{ deviceId }/first``: for each train ID, the index at which the
+* ``trainId [uint64]`` lists the global train ID for this train entry.
+
+* ``timestamp [uint64]`` lists the number of nanseconds since the Epoch for this train entry.
+
+* ``flag [int32]`` lists ``1`` for safe train entries and ``0`` for train entries where the timing
+  may be unreliable, e.g. because it is attributed to the wrong train ID. For DAQ recordings up
+  to `EXDF-v1.2`, this is only the case when a source different than the timeserver sent the first
+  data entry for a given train.
+
+* ``origin [int32]`` lists the actual source index into `METADATA/dataSources` that sent that first
+  entry for each given train entry, or ``-1`` if it is the timeserver. For DAQ recordings up to
+  `EXDF-v1.2`, every entry with a non-negative ``origin`` will have a ``flag`` of ``0``.
+
+For each source in ``METADATA/dataSources/deviceId``, the ``INDEX`` group then also contains two
+datasets that map the train entries in the top-level datasets above to each source's data rows
+in ``CONTROL`` or ``INSTRUMENT``:
+
+* ``INDEX/{deviceId}/count [uint64]``: For each train ID, how many data samples did
+  this source record. This may be 0 if no data was recorded for this train.
+* ``INDEX/{deviceId}/first [uint64]``: for each train ID, the index at which the
   corresponding data starts in the arrays for this device.
 
 Thus, to find the data for a given train ID, we could do::
 
-    train_index = trainIds.index(train_id)
-    first = device_firsts[train_index]
-    count = device_counts[train_index]
-    train_data = data[first : first+count]
-
-Control data is always (?) recorded once per train, so *count* is 1 and *first*
-counts up from 0 to the number of trains. Instrument data is more variable.
+    train_index = list(file['INDEX/trainId']).index(train_id)
+    first = file[f'INDEX/{device_id}/first'][train_index]
+    count = file[f'INDEX/{device_id}/count'][train_index]
+    train_data = file[f'INSTRUMENT/{device_id}/{key}][first:first+count]
 
 Some older files use a different index format with first/last/status instead of
 first/count. In this case, a status of 0 means that no data was recorded
-for that train.
+for that train. [never saw those files, is it relevant enough to list it?]
 
 CONTROL and RUN
 ~~~~~~~~~~~~~~~
 
-For each *CONTROL* entry in ``METADATA/dataSourceId``, there is a group with
-that name in the file. This may have further arbitrarily nested subgroups
-representing different properties of that device, e.g.
-``/CONTROL/SA1_XTD2_XGM/DOOCS/MAIN/current/bottom/output``.
+For each *CONTROL* entry in ``METADATA/dataSources``, there is a group with
+that name in the file with further arbitrarily nested subgroups representing different
+keys of that device, e.g. ``/CONTROL/SA1_XTD2_XGM/DOOCS/MAIN/current/bottom/output``
+for the key ``current/bottom/output`` of source ``SA1_XTD2_XG/DOOCs/MAIN``.
 
 The leaves of this tree are pairs of datasets called ``timestamp`` and ``value``.
 Each dataset has one entry per train, and the ``timestamp`` record when the
-value was updated, which is typically less than once per train. The ``value``
-dataset may have extra dimensions, but in most cases it is 1D.
-
-(Does timestamp update if value is re-read but doesn't change?)
+current value was updated, which is typically less than once per train and thus
+likely in the past.
 
 ``RUN`` holds a complete duplicate of the ``CONTROL`` hierarchy, but each pair
-of ``timestamp`` and ``value`` contain only one entry, taken at the start of
-the run. There is still a dimension for this, so 2D value datasets in CONTROL
-have corresponding 2D datasets in RUN, but the first dimension has length 1.
-
-(Is RUN exactly duplicated in subsequent sequence files?)
+of ``timestamp`` and ``value`` contain only one entry taken at the start of
+the run. All datasets continue to be vectors, so even for scalar values the
+first dimension has length 1.
 
 INSTRUMENT
 ~~~~~~~~~~
 
 For each *INSTRUMENT* entry in ``METADATA/dataSourceId``, there is a group with
-that name in the file. Each such group holds a 1D ``trainId`` dataset, and a
-number of other datasets (possibly nested in subgroups). All these datasets have
-the same length in the first dimension: this represents the successive readings
-taken. The slices defined by the corresponding datasets in *INDEX* work on
-this dimension.
+that name in the file. All these datasets have the same length in the first dimension:
+this represents the successive readings taken. The slices defined by the corresponding
+datasets in *INDEX* work on this dimension.
 
-The ``trainId`` dataset for each instrument group thus appears to be redundant
-with the information in INDEX.
+Format versions
+---------------
+
+1.2, 1.0, 0.5: TBD
+
+
+[1] Karabo device naming convention
+[2] Something for EuXFEL train structure


### PR DESCRIPTION
As part of the PRWG discussions and unrelated discussions in the CAL team, we realized our "documentation" of the EuXFEL file structure is both the only one existing as well as out of date. In addition as part of the former, it would be useful to describe the file format in a more generic way and not only bound to files written by the DAQ from Karabo.

This is a first draft of this. I expect a lot of discussions and further work on this. The intention was to describe the structure as abstract as possible to how and what data actually ends up there, yet still with comments to how the "typical use case" in the form of recorded DAQ runs looks like.

I left some of my own open questions in the document, but a brief summary:
* Do we keep the specification to the last version (at the moment `1.2`) and only track changes?
* Do we make the distinction explicit between slow and fast data? Unfortunately there is difference in the file structure, but likely only actual Karabo data cares
* We should add references all over the place for EuXFEL-specific terminology, starting with things like _train_
* Grey areas of quirky DAQ behaviour, e.g. you got an empty `RUN` top-level group even if there's no `CONTROL` group
* How DAQ-specific are most of the `METADATA` datasets? What about custom datasets, like for `pycalibration`?
* What about `first/last/status` datasets in `INDEX/<source>`? Never saw those myself, move to appendix or ignore entirely?

You can find a built version of this branch [here])(https://extra-data.readthedocs.io/en/docs-update-file-format/).