### PR TITLE
Update Python versions tested on Github actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
     - name: Checkout


### PR DESCRIPTION
Remove Python 3.6, which is no longer conveniently available on `ubuntu-latest`, and add 3.10.

I'll wait to add 3.11 until we've made pre-built wheels available for h5py.