### PR TITLE
FIX: handle empty CONTROL datasets

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
     - name: Checkout

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -1298,11 +1298,12 @@ class TrainIterator:
                 if ds is None:
                     continue
 
-                count = file.get_index(source, '')[1][pos]
+                firsts, counts = file.get_index(source, group)
+                first, count = firsts[pos], counts[pos]
                 if not count:
                     continue
 
-                self._set_result(res, source, key, ds[pos])
+                self._set_result(res, source, key, ds[first])
 
         for source in self.data.instrument_sources:
             self._set_result(res, source, 'metadata',

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -388,7 +388,7 @@ class DataCollection:
             if file is None:
                 continue
 
-            firsts, counts = file.get_index(source, group)
+            firsts, counts = file.get_index(source, '')
             first, count = firsts[pos], counts[pos]
             if not count:
                 continue
@@ -1298,7 +1298,7 @@ class TrainIterator:
                 if ds is None:
                     continue
 
-                firsts, counts = file.get_index(source, group)
+                firsts, counts = file.get_index(source, '')
                 first, count = firsts[pos], counts[pos]
                 if not count:
                     continue

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -388,13 +388,14 @@ class DataCollection:
             if file is None:
                 continue
 
-            count = file.get_index(source, '')[1][pos]
+            firsts, counts = file.get_index(source, group)
+            first, count = firsts[pos], counts[pos]
             if not count:
                 continue
 
             for key in self.keys_for_source(source):
                 path = '/CONTROL/{}/{}'.format(source, key.replace('.', '/'))
-                source_data[key] = file.file[path][pos]
+                source_data[key] = file.file[path][first]
 
         for source in self.instrument_sources:
             source_data = res[source] = {

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -388,6 +388,10 @@ class DataCollection:
             if file is None:
                 continue
 
+            count = file.get_index(source, '')[1][pos]
+            if not count:
+                continue
+
             for key in self.keys_for_source(source):
                 path = '/CONTROL/{}/{}'.format(source, key.replace('.', '/'))
                 source_data[key] = file.file[path][pos]
@@ -1288,11 +1292,15 @@ class TrainIterator:
             self._set_result(res, source, 'metadata',
                              {'source': source, 'timestamp.tid': tid})
 
-
             for key in self.data.keys_for_source(source):
-                _, pos, ds = self._find_data(source, key, tid)
+                file, pos, ds = self._find_data(source, key, tid)
                 if ds is None:
                     continue
+
+                count = file.get_index(source, '')[1][pos]
+                if not count:
+                    continue
+
                 self._set_result(res, source, key, ds[pos])
 
         for source in self.data.instrument_sources:

--- a/extra_data/tests/conftest.py
+++ b/extra_data/tests/conftest.py
@@ -57,6 +57,14 @@ def mock_sa3_control_data(format_version):
 
 
 @pytest.fixture(scope='module')
+def mock_control_data_with_empty_source(format_version):
+    with TemporaryDirectory() as td:
+        path = osp.join(td, 'RAW-R0451-DA01-S00001.h5')
+        make_examples.make_da_file_with_empty_source(path, format_version=format_version)
+        yield path
+
+
+@pytest.fixture(scope='module')
 def mock_spb_control_data_badname(format_version):
     with TemporaryDirectory() as td:
         path = osp.join(td, 'RAW-R0309-DA01-S00000.h5')

--- a/extra_data/tests/make_examples.py
+++ b/extra_data/tests/make_examples.py
@@ -185,7 +185,6 @@ def make_sa3_da_file(path, ntrains=500, format_version='0.5'):
         Gauge('SA3_XTD10_VAC/GAUGE/G30490D_IN'),
         Gauge('SA3_XTD10_VAC/GAUGE/G30500P'),
         Gauge('SA3_XTD10_VAC/GAUGE/G30510C'),
-        Gauge('SA3_XTD10_VAC/GAUGE/G30520C', no_ctrl_data=True),
         DCtrl('SA3_XTD10_VAC/DCTRL/D6_APERT_IN_OK'),
         DCtrl('SA3_XTD10_VAC/DCTRL/D12_APERT_IN_OK'),
         XGM('SA3_XTD10_XGM/XGM/DOOCS'),
@@ -193,6 +192,26 @@ def make_sa3_da_file(path, ntrains=500, format_version='0.5'):
         IMGFELCamera('SA3_XTD10_IMGFEL/CAM/BEAMVIEW2', nsamples=250),
         IMGFELMotor('SA3_XTD10_IMGFEL/MOTOR/FILTER'),
         IMGFELMotor('SA3_XTD10_IMGFEL/MOTOR/SCREEN'),
+        MPOD('SA3_XTD10_MCP/MCPS/MPOD'),
+    ], ntrains=ntrains, chunksize=50, format_version=format_version)
+
+def make_da_file_with_empty_source(path, ntrains=500, format_version='0.5'):
+    write_file(path, [
+        ADC('SA3_XTD10_MCP/ADC/1', nsamples=0, channels=(
+            'channel_3.output/data',
+            'channel_5.output/data',
+            'channel_9.output/data',
+        )),
+        UVLamp('SA3_XTD10_MCP/DCTRL/UVLAMP'),
+        Motor('SA3_XTD10_MCP/MOTOR/X2'),
+        TemperatureSensor('SA3_XTD10_VAC/TSENS/S30100K'),
+        Gauge('SA3_XTD10_VAC/GAUGE/G30510C'),
+        Gauge('SA3_XTD10_VAC/GAUGE/G30520C', no_ctrl_data=True),
+        DCtrl('SA3_XTD10_VAC/DCTRL/D6_APERT_IN_OK'),
+        XGM('SA3_XTD10_XGM/XGM/DOOCS'),
+        IMGFELCamera('SA3_XTD10_IMGFEL/CAM/BEAMVIEW', nsamples=0),
+        IMGFELCamera('SA3_XTD10_IMGFEL/CAM/BEAMVIEW2', nsamples=250),
+        IMGFELMotor('SA3_XTD10_IMGFEL/MOTOR/FILTER'),
         MPOD('SA3_XTD10_MCP/MCPS/MPOD'),
     ], ntrains=ntrains, chunksize=50, format_version=format_version)
 

--- a/extra_data/tests/make_examples.py
+++ b/extra_data/tests/make_examples.py
@@ -185,6 +185,7 @@ def make_sa3_da_file(path, ntrains=500, format_version='0.5'):
         Gauge('SA3_XTD10_VAC/GAUGE/G30490D_IN'),
         Gauge('SA3_XTD10_VAC/GAUGE/G30500P'),
         Gauge('SA3_XTD10_VAC/GAUGE/G30510C'),
+        Gauge('SA3_XTD10_VAC/GAUGE/G30520C', no_ctrl_data=True),
         DCtrl('SA3_XTD10_VAC/DCTRL/D6_APERT_IN_OK'),
         DCtrl('SA3_XTD10_VAC/DCTRL/D12_APERT_IN_OK'),
         XGM('SA3_XTD10_XGM/XGM/DOOCS'),

--- a/extra_data/tests/mockdata/base.py
+++ b/extra_data/tests/mockdata/base.py
@@ -17,7 +17,7 @@ class DeviceBase:
     firsttrain = 10000
     chunksize = 200
 
-    def __init__(self, device_id, nsamples=None):
+    def __init__(self, device_id, nsamples=None, no_ctrl_data=False):
         """Create a dummy device
 
         :param str device_id: e.g. "SA1_XTD2_XGM/DOOCS/MAIN"
@@ -27,24 +27,30 @@ class DeviceBase:
             spread evenly across the trains.
         :param int chunksize: The sample dimension will be padded to a multiple
             of this.
+        :param bool no_ctrl_data: mock a device that did not save data if set to True.
         """
         self.device_id = device_id
         self.nsamples = nsamples
+        self.no_ctrl_data = no_ctrl_data
 
     def write_control(self, f):
         """Write the CONTROL and RUN data, and the relevant parts of INDEX"""
-        N = self.ntrains
+        N = self.ntrains 
 
         # INDEX
         i_first = f.create_dataset('INDEX/%s/first' % self.device_id,
                                    (N,), 'u8', maxshape=(None,))
         i_count = f.create_dataset('INDEX/%s/count' % self.device_id,
                                    (N,), 'u8', maxshape=(None,))
-        i_first[:] = np.arange(N)
-        i_count[:] = 1
+        i_first[:] = 0 if self.no_ctrl_data else np.arange(N)
+        i_count[:] = 0 if self.no_ctrl_data else 1
 
         # CONTROL & RUN
         # Creating empty datasets for now.
+
+        if self.no_ctrl_data:
+            N = 0
+
         for (topic, datatype, dims) in self.control_keys:
             f.create_dataset('CONTROL/%s/%s/timestamp' % (self.device_id, topic),
                              (N,), 'u8', maxshape=(None,))

--- a/extra_data/tests/mockdata/base.py
+++ b/extra_data/tests/mockdata/base.py
@@ -35,7 +35,7 @@ class DeviceBase:
 
     def write_control(self, f):
         """Write the CONTROL and RUN data, and the relevant parts of INDEX"""
-        N = self.ntrains 
+        N = self.ntrains
 
         # INDEX
         i_first = f.create_dataset('INDEX/%s/first' % self.device_id,

--- a/extra_data/tests/test_reader_mockdata.py
+++ b/extra_data/tests/test_reader_mockdata.py
@@ -21,7 +21,7 @@ from extra_data import (
     MultiRunError
 )
 
-def test_iterate_trains(mock_agipd_data):
+def test_iterate_trains(mock_agipd_data, mock_sa3_control_data):
     with H5File(mock_agipd_data) as f:
         for train_id, data in islice(f.trains(), 10):
             assert train_id in range(10000, 10250)
@@ -29,6 +29,10 @@ def test_iterate_trains(mock_agipd_data):
             assert len(data) == 1
             assert 'image.data' in data['SPB_DET_AGIPD1M-1/DET/7CH0:xtdf']
 
+    with H5File(mock_sa3_control_data) as f:
+        # smoke test
+        tid, data = next(f.trains())
+        assert list(data['SA3_XTD10_VAC/GAUGE/G30520C'].keys()) == ['metadata']
 
 def test_iterate_trains_flat_keys(mock_agipd_data):
     with H5File(mock_agipd_data) as f:
@@ -264,7 +268,8 @@ def test_iterate_run_glob_devices(mock_fxe_raw_run):
     assert 'FXE_XAD_GEC/CAM/CAMERA' not in data
 
 
-def test_train_by_id_fxe_run(mock_fxe_raw_run):
+def test_train_by_id(mock_fxe_raw_run, mock_sa3_control_data):
+    # full run
     run = RunDirectory(mock_fxe_raw_run)
     _, data = run.train_from_id(10024)
     assert 'FXE_DET_LPD1M-1/DET/15CH0:xtdf' in data
@@ -272,13 +277,18 @@ def test_train_by_id_fxe_run(mock_fxe_raw_run):
     assert 'FXE_XAD_GEC/CAM/CAMERA' in data
     assert 'firmwareVersion.value' in data['FXE_XAD_GEC/CAM/CAMERA']
 
-
-def test_train_by_id_fxe_run_selection(mock_fxe_raw_run):
+    # selection
     run = RunDirectory(mock_fxe_raw_run)
     _, data = run.train_from_id(10024, [('*/DET/*', 'image.data')])
     assert 'FXE_DET_LPD1M-1/DET/15CH0:xtdf' in data
     assert 'image.data' in data['FXE_DET_LPD1M-1/DET/15CH0:xtdf']
     assert 'FXE_XAD_GEC/CAM/CAMERA' not in data
+
+    # missing control data
+    with H5File(mock_sa3_control_data) as f:
+        _, data = f.train_from_id(10000)
+        assert 'SA3_XTD10_VAC/GAUGE/G30520C' in data
+        assert ['metadata'] == list(data['SA3_XTD10_VAC/GAUGE/G30520C'].keys())
 
 
 def test_train_from_index_fxe_run(mock_fxe_raw_run):

--- a/extra_data/tests/test_reader_mockdata.py
+++ b/extra_data/tests/test_reader_mockdata.py
@@ -21,7 +21,7 @@ from extra_data import (
     MultiRunError
 )
 
-def test_iterate_trains(mock_agipd_data, mock_sa3_control_data):
+def test_iterate_trains(mock_agipd_data, mock_control_data_with_empty_source):
     with H5File(mock_agipd_data) as f:
         for train_id, data in islice(f.trains(), 10):
             assert train_id in range(10000, 10250)
@@ -29,7 +29,7 @@ def test_iterate_trains(mock_agipd_data, mock_sa3_control_data):
             assert len(data) == 1
             assert 'image.data' in data['SPB_DET_AGIPD1M-1/DET/7CH0:xtdf']
 
-    with H5File(mock_sa3_control_data) as f:
+    with H5File(mock_control_data_with_empty_source) as f:
         # smoke test
         tid, data = next(f.trains())
         assert list(data['SA3_XTD10_VAC/GAUGE/G30520C'].keys()) == ['metadata']
@@ -268,7 +268,7 @@ def test_iterate_run_glob_devices(mock_fxe_raw_run):
     assert 'FXE_XAD_GEC/CAM/CAMERA' not in data
 
 
-def test_train_by_id(mock_fxe_raw_run, mock_sa3_control_data):
+def test_train_by_id(mock_fxe_raw_run, mock_control_data_with_empty_source):
     # full run
     run = RunDirectory(mock_fxe_raw_run)
     _, data = run.train_from_id(10024)
@@ -285,7 +285,7 @@ def test_train_by_id(mock_fxe_raw_run, mock_sa3_control_data):
     assert 'FXE_XAD_GEC/CAM/CAMERA' not in data
 
     # missing control data
-    with H5File(mock_sa3_control_data) as f:
+    with H5File(mock_control_data_with_empty_source) as f:
         _, data = f.train_from_id(10000)
         assert 'SA3_XTD10_VAC/GAUGE/G30520C' in data
         assert ['metadata'] == list(data['SA3_XTD10_VAC/GAUGE/G30520C'].keys())


### PR DESCRIPTION
It happens to have empty CONTROL datasets (e.g. `/gpfs/exfel/exp/SPB/202202/p003111/raw/r0111/RAW-R0111-DA02-S00000.h5`)
The `INDEX/SOURCE/[first|count]` report correctly 0 on both datasets, but we don't check that case in `DataCollection.train_from_id` and `trains()`.
