### PR TITLE
Raise more explicit exceptions when HDF5 files are missing essential datasets

### DIFF
--- a/extra_data/exceptions.py
+++ b/extra_data/exceptions.py
@@ -1,6 +1,10 @@
 """Exception classes specific to extra_data."""
 
 
+class FileStructureError(Exception):
+    pass
+
+
 class SourceNameError(KeyError):
     def __init__(self, source):
         self.source = source

--- a/extra_data/tests/conftest.py
+++ b/extra_data/tests/conftest.py
@@ -157,6 +157,17 @@ def empty_h5_file():
 
         yield path
 
+
+@pytest.fixture(scope='session')
+def mock_no_metadata_file():
+    with TemporaryDirectory() as td:
+        path = osp.join(td, 'no_metadata.h5')
+        with h5py.File(path, 'w') as f:
+            f.create_dataset('INDEX/trainId', data=[], dtype=np.uint64)
+
+        yield path
+
+
 @pytest.fixture(scope='session')
 def mock_empty_file():
     with TemporaryDirectory() as td:

--- a/extra_data/tests/test_file_access.py
+++ b/extra_data/tests/test_file_access.py
@@ -5,6 +5,7 @@ import cloudpickle
 import pytest
 
 from ..file_access import FileAccess
+from ..exceptions import FileStructureError
 
 
 def test_registry(mock_sa3_control_data):
@@ -57,3 +58,13 @@ def test_pickle(pickle_mod, mock_sa3_control_data):
     assert len(fa3._keys_cache) == 0
     assert 'SA3_XTD10_IMGFEL/CAM/BEAMVIEW2:daqOutput' in fa3.instrument_sources
     assert len(fa3.train_ids) == 500
+
+
+def test_no_index(empty_h5_file):
+    with pytest.raises(FileStructureError):
+        FileAccess(empty_h5_file)
+
+
+def test_no_metadata(mock_no_metadata_file):
+    with pytest.raises(FileStructureError):
+        FileAccess(mock_no_metadata_file)


### PR DESCRIPTION
Scanning all proposals and their runs for statistics on the file format version also yielded data on the kind of _corrupt_ files out there in the wild.

For those files which are HDF but are missing enough critical structure to not be readable, I found the two possible options of missing the `INDEX` group (actually missing everything except `INSTRUMENT`) and missing the `METADATA` section. While EXtra-data technically handles that already, it fails rather cryptically with HDF's original exception of `Unable to open object (component not found)`. This PR adds checks at the first instances of accessing these datasets and throws a custom exception.

Really unsure about the exception text, any opinions? It's featured in particular when using `RunDirectory.from_paths` and `extra-data-validate`.