### PR TITLE
Rename test with duplicated name

### DIFF
--- a/extra_data/tests/test_stacking.py
+++ b/extra_data/tests/test_stacking.py
@@ -148,7 +148,7 @@ def test_stack_detector_data_jungfrau(mock_jungfrau_run):
     assert comb.shape == (16, 8, 512, 1024)
 
 
-def test_stack_detector_data_jungfrau(mock_jungfrau_run):
+def test_stack_detector_data_jungfrau_keep_dims(mock_jungfrau_run):
     run = RunDirectory(mock_jungfrau_run)
     _, data = run.select('*JF4M/DET/*', 'data.adc').train_from_index(0, keep_dims=True)
 


### PR DESCRIPTION
Static analysis [picked up](https://github.com/European-XFEL/EXtra-data/security/code-scanning/21) that this test had the same name as the one just above it, so the first one isn't being run.