### PR TITLE
Add support for source and key aliases

### DIFF
--- a/extra_data/__init__.py
+++ b/extra_data/__init__.py
@@ -37,7 +37,7 @@ __version__ = "1.12.0"
 
 
 from .exceptions import (
-    SourceNameError, PropertyNameError, TrainIDError, MultiRunError
+    SourceNameError, PropertyNameError, TrainIDError, AliasError, MultiRunError
 )
 from .keydata import KeyData
 from .reader import *

--- a/extra_data/exceptions.py
+++ b/extra_data/exceptions.py
@@ -33,6 +33,14 @@ class TrainIDError(KeyError):
         return "Train ID {!r} not found in this data".format(self.train_id)
 
 
+class AliasError(KeyError):
+    def __init__(self, alias):
+        self.alias = alias
+
+    def __str__(self):
+        return f"'{self.alias}' not known as alias for this data"
+
+
 class MultiRunError(ValueError):
     def __str__(self):
         return (

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -572,10 +572,12 @@ class DataCollection:
 
         This can be used to join multiple sources for the same trains,
         or to extend the same sources with data for further trains.
-        The order of the datasets doesn't matter.
+        The order of the datasets doesn't matter. Any aliases defined on
+        the collections are combined as well unless their values conflict.
 
         Returns a new :class:`DataCollection` object.
         """
+
         sources_data_multi = defaultdict(list)
         for dc in (self,) + others:
             for source, srcdata in dc._sources_data.items():
@@ -584,12 +586,29 @@ class DataCollection:
         sources_data = {src: src_datas[0].union(*src_datas[1:])
                         for src, src_datas in sources_data_multi.items()}
 
+        # Check for alias conflicts across all data collections.
+        duplicate_aliases = set(self._aliases.keys()).intersection(
+            *[dc._aliases for dc in others])
+
+        for alias in duplicate_aliases:
+            # Find all values occuring for duplicate aliases.
+            duplicate_alias_values = set([self._aliases[alias]]).union(
+                [dc._aliases[alias] for dc in others])
+
+            if len(duplicate_alias_values) > 1:
+                raise ValueError('conflicting aliases across data collections '
+                                 'to be merged')
+
+        aliases = self._aliases.copy()
+        for dc in others:
+            aliases.update(dc._aliases)
+
         train_ids = sorted(set().union(*[sd.train_ids for sd in sources_data.values()]))
         files = set().union(*[sd.files for sd in sources_data.values()])
 
         return DataCollection(
             files, sources_data=sources_data, train_ids=train_ids,
-            inc_suspect_trains=self.inc_suspect_trains,
+            aliases=aliases, inc_suspect_trains=self.inc_suspect_trains,
             is_single_run=same_run(self, *others),
         )
 
@@ -901,7 +920,7 @@ class DataCollection:
         files = set().union(*[sd.files for sd in sources_data.values()])
 
         return DataCollection(
-            files, sources_data, train_ids=train_ids,
+            files, sources_data, train_ids=train_ids, aliases=self._aliases,
             inc_suspect_trains=self.inc_suspect_trains,
             is_single_run=self.is_single_run
         )
@@ -939,7 +958,7 @@ class DataCollection:
 
         return DataCollection(
             files, sources_data=sources_data, train_ids=self.train_ids,
-            inc_suspect_trains=self.inc_suspect_trains,
+            aliases=self._aliases, inc_suspect_trains=self.inc_suspect_trains,
             is_single_run=self.is_single_run,
         )
 
@@ -974,7 +993,7 @@ class DataCollection:
 
         return DataCollection(
             files, sources_data=sources_data, train_ids=new_train_ids,
-            inc_suspect_trains=self.inc_suspect_trains,
+            aliases=self._aliases, inc_suspect_trains=self.inc_suspect_trains,
             is_single_run=self.is_single_run,
         )
 

--- a/extra_data/tests/conftest.py
+++ b/extra_data/tests/conftest.py
@@ -56,6 +56,29 @@ def mock_sa3_control_data(format_version):
         yield path
 
 
+@pytest.fixture
+def mock_sa3_control_aliases():
+    return {
+        'sa3-xgm': 'SA3_XTD10_XGM/XGM/DOOCS',
+        'hv': ('SA3_XTD10_XGM/XGM/DOOCS', 'pulseEnergy.wavelengthUsed'),
+        'beam-x': ('SA3_XTD10_XGM/XGM/DOOCS', 'beamPosition.ixPos'),
+        'beam-y': ('SA3_XTD10_XGM/XGM/DOOCS', 'beamPosition.iyPos'),
+
+        'imgfel-frames': ('SA3_XTD10_IMGFEL/CAM/BEAMVIEW:daqOutput', 'data.image.pixels'),
+        'imgfel-frames2': ('SA3_XTD10_IMGFEL/CAM/BEAMVIEW2:daqOutput', 'data.image.pixels'),
+        'imgfel-screen-pos': ('SA3_XTD10_IMGFEL/MOTOR/SCREEN', 'actualPosition'),
+        'imgfel-filter-pos': ('SA3_XTD10_IMGFEL/MOTOR/FILTER', 'actualPosition'),
+
+        'mcp-adc': 'SA3_XTD10_MCP/ADC/1',
+        'mcp-mpod': 'SA3_XTD10_MCP/MCPS/MPOD',
+        'mcp-voltage': ('SA3_XTD10_MCP/MCPS/MPOD', 'channels.U3.voltage'),
+        'mcp-trace': ('SA3_XTD10_MCP/ADC/1:channel_5.output', 'data.rawData'),
+
+        'bogus-source': 'SA4_XTD20_XGM/XGM/DOOCS',
+        'bogus-key': ('SA3_XTD10_XGM/XGM/DOOCS', 'foo')
+    }
+
+
 @pytest.fixture(scope='module')
 def mock_control_data_with_empty_source(format_version):
     with TemporaryDirectory() as td:

--- a/extra_data/tests/test_aliases.py
+++ b/extra_data/tests/test_aliases.py
@@ -1,0 +1,277 @@
+
+from itertools import islice
+
+import pytest
+import numpy as np
+
+from extra_data import (
+    H5File, KeyData, by_index, by_id,
+    AliasError, SourceNameError, PropertyNameError
+)
+
+
+def test_with_aliases(mock_sa3_control_data, mock_sa3_control_aliases):
+    run = H5File(mock_sa3_control_data).with_aliases(mock_sa3_control_aliases)
+
+    def assert_equal_keydata(kd1, kd2):
+        assert isinstance(kd1, KeyData)
+        assert isinstance(kd2, KeyData)
+        assert kd1.source == kd2.source
+        assert kd1.key == kd2.key
+        assert kd1.train_ids == kd2.train_ids
+
+    # Test whether source alias yields identical SourceData.
+    assert run.alias['sa3-xgm'] is run['SA3_XTD10_XGM/XGM/DOOCS']
+
+    # Test whether source alias plus literal key yields equal KeyData.
+    assert_equal_keydata(
+        run.alias['sa3-xgm', 'pulseEnergy.wavelengthUsed'],
+        run['SA3_XTD10_XGM/XGM/DOOCS', 'pulseEnergy.wavelengthUsed'])
+
+    # Test whether key alias yields equal KeyData.
+    assert_equal_keydata(
+        run.alias['hv'],
+        run['SA3_XTD10_XGM/XGM/DOOCS', 'pulseEnergy.wavelengthUsed'])
+
+    # Test undefined aliases.
+    with pytest.raises(AliasError):
+        run.alias['foo']
+        run.alias['foo', 'bar']
+
+    # Test using a literal key with a key alias.
+    with pytest.raises(ValueError):
+        run.alias['hv', 'pressure']
+
+    # Test using an existing source alias for a non-existing source.
+    with pytest.raises(SourceNameError):
+        run.alias['bogus-source']
+
+    # Test using an existing key alias for a non-existing key.
+    with pytest.raises(PropertyNameError):
+        run.alias['bogus-key']
+
+
+def test_json_alias_file(mock_sa3_control_data, mock_sa3_control_aliases, tmp_path):
+    aliases_path = tmp_path / 'aliases.json'
+    aliases_path.write_text('''
+{
+    "sa3-xgm": "SA3_XTD10_XGM/XGM/DOOCS",
+    "SA3_XTD10_XGM/XGM/DOOCS": {
+        "hv": "pulseEnergy.wavelengthUsed",
+        "beam-x": "beamPosition.ixPos",
+        "beam-y": "beamPosition.iyPos"
+    },
+
+    "imgfel-frames": ["SA3_XTD10_IMGFEL/CAM/BEAMVIEW:daqOutput", "data.image.pixels"],
+    "imgfel-frames2": ["SA3_XTD10_IMGFEL/CAM/BEAMVIEW2:daqOutput", "data.image.pixels"],
+    "imgfel-screen-pos": ["SA3_XTD10_IMGFEL/MOTOR/SCREEN", "actualPosition"],
+    "imgfel-filter-pos": ["SA3_XTD10_IMGFEL/MOTOR/FILTER", "actualPosition"],
+
+    "mcp-adc": "SA3_XTD10_MCP/ADC/1",
+    "mcp-mpod": "SA3_XTD10_MCP/MCPS/MPOD",
+    "mcp-voltage": ["SA3_XTD10_MCP/MCPS/MPOD", "channels.U3.voltage"],
+    "mcp-trace": ["SA3_XTD10_MCP/ADC/1:channel_5.output", "data.rawData"],
+
+    "bogus-source": "SA4_XTD20_XGM/DOOCS/MAIN",
+    "bogus-key": ["SA1_XTD2_XGM/DOOCS/MAIN", "foo"]
+}
+    ''')
+
+    run = H5File(mock_sa3_control_data).with_aliases(mock_sa3_control_aliases)
+    assert run._aliases == mock_sa3_control_aliases
+
+
+def test_yaml_alias_file(mock_sa3_control_data, mock_sa3_control_aliases, tmp_path):
+    aliases_path = tmp_path / 'aliases.yaml'
+    aliases_path.write_text('''
+sa3-xgm: SA3_XTD10_XGM/XGM/DOOCS
+
+SA3_XTD10_XGM/XGM/DOOCS:
+  hv: pulseEnergy.wavelengthUsed
+  beam-x: beamPosition.ixPos
+  beam-y: beamPosition.iyPos
+
+imgfel-frames: [SA3_XTD10_IMGFEL/CAM/BEAMVIEW:daqOutput, data.image.pixels]
+imgfel-frames2: [SA3_XTD10_IMGFEL/CAM/BEAMVIEW2:daqOutput, data.image.pixels]
+imgfel-screen-pos: [SA3_XTD10_IMGFEL/MOTOR/SCREEN, actualPosition]
+imgfel-filter-pos: [SA3_XTD10_IMGFEL/MOTOR/FILTER, actualPosition]
+
+mcp-adc: SA3_XTD10_MCP/ADC/1
+mcp-mpod: SA3_XTD10_MCP/MCPS/MPOD
+mcp-voltage: [SA3_XTD10_MCP/MCPS/MPOD, channels.U3.voltage]
+mcp-trace: [SA3_XTD10_MCP/ADC/1:channel_5.output, data.rawData]
+
+bogus-source: SA4_XTD20_XGM/DOOCS/MAIN
+bogus-key: [SA1_XTD2_XGM/DOOCS/MAIN, foo]
+    ''')
+
+    run = H5File(mock_sa3_control_data).with_aliases(mock_sa3_control_aliases)
+    assert run._aliases == mock_sa3_control_aliases
+
+
+def test_toml_alias_file(mock_sa3_control_data, mock_sa3_control_aliases, tmp_path):
+    aliases_path = tmp_path / 'aliases.toml'
+    aliases_path.write_text('''
+sa3-xgm = "SA3_XTD10_XGM/XGM/DOOCS"
+
+imgfel-frames = ["SA3_XTD10_IMGFEL/CAM/BEAMVIEW:daqOutput", "data.image.pixels"]
+imgfel-frames2 = ["SA3_XTD10_IMGFEL/CAM/BEAMVIEW2:daqOutput", "data.image.pixels"]
+imgfel-screen-pos = ["SA3_XTD10_IMGFEL/MOTOR/SCREEN", "actualPosition"]
+imgfel-filter-pos = ["SA3_XTD10_IMGFEL/MOTOR/FILTER", "actualPosition"]
+
+mcp-adc = "SA3_XTD10_MCP/ADC/1"
+mcp-mpod = "SA3_XTD10_MCP/MCPS/MPOD"
+mcp-voltage = ["SA3_XTD10_MCP/MCPS/MPOD", "channels.U3.voltage"]
+mcp-trace = ["SA3_XTD10_MCP/ADC/1:channel_5.output", "data.rawData"]
+
+bogus-source = "SA4_XTD20_XGM/DOOCS/MAIN"
+bogus-key = ["SA1_XTD2_XGM/DOOCS/MAIN", "foo"]
+
+["SA3_XTD10_XGM/XGM/DOOCS"]
+hv = "pulseEnergy.wavelengthUsed"
+beam-x = "beamPosition.ixPos"
+beam-y = "beamPosition.iyPos"
+    ''')
+
+    run = H5File(mock_sa3_control_data).with_aliases(mock_sa3_control_aliases)
+    assert run._aliases == mock_sa3_control_aliases
+
+
+def test_only_aliases(mock_sa3_control_data, mock_sa3_control_aliases):
+    run = H5File(mock_sa3_control_data).with_aliases(mock_sa3_control_aliases)
+    subrun = H5File(mock_sa3_control_data).only_aliases(mock_sa3_control_aliases)
+
+    # Assume that aliases work when the _aliases property is equal.
+    assert run._aliases == subrun._aliases
+
+    # Test whether only the sources used in aliases are present.
+    assert subrun.all_sources == {
+        'SA3_XTD10_XGM/XGM/DOOCS',
+        'SA3_XTD10_IMGFEL/CAM/BEAMVIEW:daqOutput',
+        'SA3_XTD10_IMGFEL/CAM/BEAMVIEW2:daqOutput',
+        'SA3_XTD10_IMGFEL/MOTOR/SCREEN',
+        'SA3_XTD10_IMGFEL/MOTOR/FILTER',
+        'SA3_XTD10_MCP/ADC/1',
+        'SA3_XTD10_MCP/MCPS/MPOD',
+        'SA3_XTD10_MCP/ADC/1:channel_5.output',
+    }
+
+    # Test whether all keys are present for an aliased source.
+    assert subrun['SA3_XTD10_XGM/XGM/DOOCS'].keys() == run['SA3_XTD10_XGM/XGM/DOOCS'].keys()
+
+    # Test whether all keys are present for an aliased source, even if
+    # there are key aliases for it as well.
+    assert subrun['SA3_XTD10_MCP/MCPS/MPOD'].keys() == run['SA3_XTD10_MCP/MCPS/MPOD'].keys()
+
+    # Test whether only aliased keys are present for unaliased sources.
+    assert subrun['SA3_XTD10_IMGFEL/MOTOR/SCREEN'].keys() == {'actualPosition.value'}
+
+    # Test strict selection.
+    with pytest.raises(ValueError):
+        H5File(mock_sa3_control_data).only_aliases(
+            mock_sa3_control_aliases, strict=True)
+
+    # Remove bogus aliases and test strict selection again.
+    strict_aliases = mock_sa3_control_aliases.copy()
+    del strict_aliases['bogus-source']
+    del strict_aliases['bogus-key']
+    H5File(mock_sa3_control_data).only_aliases(strict_aliases, strict=True)
+
+    # Prepare a run with less trains for a single source
+    # (SA3_XTD10_IMGFEL/CAM/BEAMVIEW2:daqOutput) by removing all sources
+    # without any trains.
+    run = H5File(mock_sa3_control_data) \
+        .deselect([('SA3_XTD10_MCP/ADC/1:*', '*'),
+                   ('SA3_XTD10_IMGFEL/CAM/BEAMVIEW:*', '*')])
+    del strict_aliases['mcp-trace']
+    del strict_aliases['imgfel-frames']
+
+    # Without strict alias selection and a bogus alias.
+    subrun = run.only_aliases(mock_sa3_control_aliases,
+                              require_all=True, strict=False)
+    np.testing.assert_array_equal(subrun.train_ids, run.train_ids[1::2])
+
+    # With strict alias selection.
+    subrun = run.only_aliases(strict_aliases, require_all=True, strict=True)
+    np.testing.assert_array_equal(subrun.train_ids, run.train_ids[1::2])
+
+
+def test_preserve_aliases(mock_sa3_control_data, mock_sa3_control_aliases):
+    run = H5File(mock_sa3_control_data).with_aliases(mock_sa3_control_aliases)
+
+    # Test whether selection operations preserve aliases.
+    assert run.select_trains(by_index[:5])._aliases == run._aliases
+    assert run.select_trains(by_id[run.train_ids[:5]])._aliases == run._aliases
+    assert run.select('*')._aliases == run._aliases
+    assert run.deselect('*XGM*')._aliases == run._aliases
+    assert all([subrun._aliases == run._aliases
+                for subrun in run.split_trains(parts=5)])
+
+
+def test_aliases_union(mock_sa3_control_data, mock_sa3_control_aliases):
+    run = H5File(mock_sa3_control_data).with_aliases(mock_sa3_control_aliases)
+
+    # Split the aliases into two halves and test the union.
+    run1 = run.with_aliases(dict(islice(mock_sa3_control_aliases.items(), 0, None, 2)))
+    run2 = run.with_aliases(dict(islice(mock_sa3_control_aliases.items(), 1, None, 2)))
+    assert run1.union(run2)._aliases == mock_sa3_control_aliases
+
+    # Split the run into two.
+    even_run = run.select_trains(by_id[run.train_ids[0::2]])
+    odd_run = run.select_trains(by_id[run.train_ids[1::2]])
+
+    # Test overlapping aliases with no conflict.
+    even_run.union(odd_run)
+
+    # Test conflicting aliases.
+    conflicting_aliases = mock_sa3_control_aliases.copy()
+    conflicting_aliases['hv'] = ('SA3_XTD10_XGM/XGM/DOOCS', 'pressure.pressure1')
+    with pytest.raises(ValueError):
+        even_run.union(odd_run.with_aliases(conflicting_aliases))
+
+
+def test_alias_select(mock_sa3_control_data, mock_sa3_control_aliases):
+    run = H5File(mock_sa3_control_data).with_aliases(mock_sa3_control_aliases)
+
+    # Only source alias.
+    subrun = run.alias.select('sa3-xgm')
+    assert subrun.all_sources == {'SA3_XTD10_XGM/XGM/DOOCS'}
+    assert subrun.alias['sa3-xgm'].keys() == run.alias['sa3-xgm'].keys()
+
+    # Source alias and key glob.
+    subrun = run.alias.select('sa3-xgm', 'pressure.pressure*.value')
+    assert subrun.all_sources == {'SA3_XTD10_XGM/XGM/DOOCS'}
+    assert subrun.alias['sa3-xgm'].keys() == {
+        'pressure.pressure1.value', 'pressure.pressureFiltered.value'}
+
+    # Iterable of aliases and/or with key globs.
+    subrun = run.alias.select([('sa3-xgm', 'pressure.pressure*.value'),
+                               'beam-x', 'mcp-voltage'])
+    assert subrun.all_sources == {'SA3_XTD10_XGM/XGM/DOOCS', 'SA3_XTD10_MCP/MCPS/MPOD'}
+    assert subrun.alias['sa3-xgm'].keys() == {
+        'pressure.pressure1.value', 'pressure.pressureFiltered.value',
+        'beamPosition.ixPos.value'}
+    assert subrun.alias['mcp-mpod'].keys() == {'channels.U3.voltage.value'}
+
+    # Dictionary
+    subrun = run.alias.select({'sa3-xgm': None, 'mcp-mpod': {'channels.U1.voltage'}})
+    assert subrun.all_sources == {'SA3_XTD10_XGM/XGM/DOOCS', 'SA3_XTD10_MCP/MCPS/MPOD'}
+    assert subrun.alias['sa3-xgm'].keys() == run.alias['sa3-xgm'].keys()
+    assert subrun.alias['mcp-mpod'].keys() == {'channels.U1.voltage.value'}
+
+
+def test_alias_deselect(mock_sa3_control_data, mock_sa3_control_aliases):
+    run = H5File(mock_sa3_control_data).with_aliases(mock_sa3_control_aliases)
+
+    # De-select via alias.
+    subrun = run.alias.deselect([
+        ('sa3-xgm', 'pressure.*'), ('sa3-xgm', 'current.*'),
+        ('sa3-xgm', 'gasDosing.*'), ('sa3-xgm', 'gasSupply.*'),
+        ('sa3-xgm', 'pressure.*'), ('sa3-xgm', 'pulseEnergy.*'),
+        ('sa3-xgm', 'signalAdaption.*')
+    ])
+    assert subrun.all_sources == run.all_sources
+    assert subrun.alias['sa3-xgm'].keys() == {
+        'beamPosition.ixPos.value', 'beamPosition.ixPos.timestamp',
+        'beamPosition.iyPos.value', 'beamPosition.iyPos.timestamp',
+        'pollingInterval.value', 'pollingInterval.timestamp'}

--- a/extra_data/tests/test_aliases.py
+++ b/extra_data/tests/test_aliases.py
@@ -89,8 +89,8 @@ def test_json_alias_file(mock_sa3_control_data, mock_sa3_control_aliases, tmp_pa
     "mcp-voltage": ["SA3_XTD10_MCP/MCPS/MPOD", "channels.U3.voltage"],
     "mcp-trace": ["SA3_XTD10_MCP/ADC/1:channel_5.output", "data.rawData"],
 
-    "bogus-source": "SA4_XTD20_XGM/DOOCS/MAIN",
-    "bogus-key": ["SA1_XTD2_XGM/DOOCS/MAIN", "foo"]
+    "bogus-source": "SA4_XTD20_XGM/XGM/DOOCS",
+    "bogus-key": ["SA3_XTD10_XGM/XGM/DOOCS", "foo"]
 }
     ''')
 
@@ -118,8 +118,8 @@ mcp-mpod: SA3_XTD10_MCP/MCPS/MPOD
 mcp-voltage: [SA3_XTD10_MCP/MCPS/MPOD, channels.U3.voltage]
 mcp-trace: [SA3_XTD10_MCP/ADC/1:channel_5.output, data.rawData]
 
-bogus-source: SA4_XTD20_XGM/DOOCS/MAIN
-bogus-key: [SA1_XTD2_XGM/DOOCS/MAIN, foo]
+bogus-source: SA4_XTD20_XGM/XGM/DOOCS
+bogus-key: [SA3_XTD10_XGM/XGM/DOOCS, foo]
     ''')
 
     run = H5File(mock_sa3_control_data).with_aliases(aliases_path)
@@ -141,8 +141,8 @@ mcp-mpod = "SA3_XTD10_MCP/MCPS/MPOD"
 mcp-voltage = ["SA3_XTD10_MCP/MCPS/MPOD", "channels.U3.voltage"]
 mcp-trace = ["SA3_XTD10_MCP/ADC/1:channel_5.output", "data.rawData"]
 
-bogus-source = "SA4_XTD20_XGM/DOOCS/MAIN"
-bogus-key = ["SA1_XTD2_XGM/DOOCS/MAIN", "foo"]
+bogus-source = "SA4_XTD20_XGM/XGM/DOOCS"
+bogus-key = ["SA3_XTD10_XGM/XGM/DOOCS", "foo"]
 
 ["SA3_XTD10_XGM/XGM/DOOCS"]
 hv = "pulseEnergy.wavelengthUsed"

--- a/extra_data/tests/test_aliases.py
+++ b/extra_data/tests/test_aliases.py
@@ -50,6 +50,23 @@ def test_with_aliases(mock_sa3_control_data, mock_sa3_control_aliases):
     with pytest.raises(PropertyNameError):
         run.alias['bogus-key']
 
+    # Test re-applying the same aliases.
+    run2 = run.with_aliases(mock_sa3_control_aliases)
+    assert run._aliases == run2._aliases
+
+    # Test adding additional aliases.
+    run3 = run.with_aliases({'foo': 'bar'})
+    assert set(run._aliases.keys()) < set(run3._aliases.keys())
+    assert 'foo' in run3._aliases
+
+    # Test adding conflicting aliases
+    with pytest.raises(ValueError):
+        run.with_aliases({'sa3-xgm': 'x'})
+
+    # Test dropping aliases again.
+    run4 = run.drop_aliases()
+    assert not run4._aliases
+
 
 def test_json_alias_file(mock_sa3_control_data, mock_sa3_control_aliases, tmp_path):
     aliases_path = tmp_path / 'aliases.json'

--- a/extra_data/tests/test_aliases.py
+++ b/extra_data/tests/test_aliases.py
@@ -94,7 +94,7 @@ def test_json_alias_file(mock_sa3_control_data, mock_sa3_control_aliases, tmp_pa
 }
     ''')
 
-    run = H5File(mock_sa3_control_data).with_aliases(mock_sa3_control_aliases)
+    run = H5File(mock_sa3_control_data).with_aliases(aliases_path)
     assert run._aliases == mock_sa3_control_aliases
 
 
@@ -122,7 +122,7 @@ bogus-source: SA4_XTD20_XGM/DOOCS/MAIN
 bogus-key: [SA1_XTD2_XGM/DOOCS/MAIN, foo]
     ''')
 
-    run = H5File(mock_sa3_control_data).with_aliases(mock_sa3_control_aliases)
+    run = H5File(mock_sa3_control_data).with_aliases(aliases_path)
     assert run._aliases == mock_sa3_control_aliases
 
 
@@ -150,7 +150,7 @@ beam-x = "beamPosition.ixPos"
 beam-y = "beamPosition.iyPos"
     ''')
 
-    run = H5File(mock_sa3_control_data).with_aliases(mock_sa3_control_aliases)
+    run = H5File(mock_sa3_control_data).with_aliases(aliases_path)
     assert run._aliases == mock_sa3_control_aliases
 
 

--- a/extra_data/tests/test_reader_mockdata.py
+++ b/extra_data/tests/test_reader_mockdata.py
@@ -985,6 +985,7 @@ def test_run_metadata(mock_spb_raw_run):
         }
         assert isinstance(md['creationDate'], str)
 
+
 def test_run_metadata_no_trains(mock_scs_run):
     run = RunDirectory(mock_scs_run)
     sel = run.select_trains(np.s_[:0])

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,8 @@ setup(name="EXtra-data",
               'pytest-cov',
               'testpath',
               'psutil',
+              'pyyaml',
+              'tomli; python_version < "3.11"'
           ]
       },
       python_requires='>=3.6',


### PR DESCRIPTION
It's been requested frequently to somehow allow easier access to sources and keys without the need to deal with Karabo device names and their properties. This PR adds support for this via an alias mechanism. As discussed towards the end of last year, it is mostly separate from the existing code using literal sources and keys via an index property `run.alias[...]` inspired by the likes of `pandas` and `xarray`.

Aliases may refer to a **source** or a **source-key** or equivalently to a  `SourceData` or a `KeyData` object. There are **no** pure key aliases that may be used with different sources. They can be attached to a `DataCollection` object via two methods:

* `DataCollection.with_aliases(*alias_defs)`
* `DataCollection.only_aliases(*alias_defs, strict=False, require_all=False)`

They may be passed any number of alias definitions, which may be

* A `dict` mapping the alias to a `str` (for sources) or 2-`tuple` of `str` (for source-keys).
* A `str` pointing to a JSON, YAML or TOML file with alias definitions. These should define a `dict` in the same way, with the additional option of using nested dictionaries for multiple keys per source. (See docstring)

With the returned `DataCollection`, aliases may **only** be used through the `DataCollection.alias` property.

```
run = open_run(proposal=1, run=2).with_aliases('aliases.yaml')
run.alias['my-source']  # Returns SourceData
run.alias['my-source', 'a-key']  # Returns KeyData
run.alias['my-source-key']  # Returns KeyData
run.alias['my-alias-to-a-missing-source']  # Raises SourceNameError
run.alias['my-bogus-alias']  # Raises AliasError
run.alias['my-source-key', 'another-key']  # Raises ValueError
run.alias.select('my-source')  # returns DataCollection
run.alias.deselect('my-source')  # returns DataCollection
```

Once attached, aliases are handed down to any `DataCollection` created from this, e.g. by selection. The aliases are merged as well when using `DataCollection.union()` as long as there is no conflict - in that case a `ValueError` is raised.

Aliases are shown in `DataCollection.info()` in tags `<` `>` for both sources and keys, even if a source is not shown in detail.

Documentation follows after the initial discussion 😃 
