### PR TITLE
Set ctx_closes when opening run using voview

### DIFF
--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -1398,7 +1398,9 @@ def RunDirectory(
     if _use_voview and (sel_files == files):
         voview_file_acc = voview.find_file_valid(path)
         if voview_file_acc is not None:
-            return DataCollection([voview_file_acc], is_single_run=True)
+            return DataCollection([voview_file_acc],
+                                  is_single_run=True,
+                                  ctx_closes=True)
 
     files_map = RunFilesMap(path)
     t0 = time.monotonic()

--- a/extra_data/tests/test_voview.py
+++ b/extra_data/tests/test_voview.py
@@ -35,6 +35,10 @@ def test_use_voview(mock_spb_raw_run, tmp_path):
     assert 'SPB_DET_AGIPD1M-1/DET/0CH0:xtdf' in run.instrument_sources
     assert 'SA1_XTD2_XGM/DOOCS/MAIN' in run.control_sources
 
+    with RunDirectory(str(new_run_dir)) as run:
+        assert 'SPB_DET_AGIPD1M-1/DET/0CH0:xtdf' in run.instrument_sources
+        assert 'SA1_XTD2_XGM/DOOCS/MAIN' in run.control_sources
+
 
 def open_run_with_voview(run_src, new_run_dir):
     copytree(run_src, new_run_dir)

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,7 @@ setup(name="EXtra-data",
               'pytest',
               'pytest-cov',
               'testpath',
+              'psutil',
           ]
       },
       python_requires='>=3.6',


### PR DESCRIPTION
This MR aims to close #374 in which it's shown how the context manager is not set correctly when using voview files.

The changes can be tested with the example shown in the ticket:  
```python
from extra_data import RunDirectory

with RunDirectory("/gpfs/exfel/exp/HED/202330/p900338/raw/r0052", "*S00000*") as fd:
    print(fd)
```

I updated the tests accordingly.  

On an unrelated note, I found that `psutil` is required to run tests, but is not in the `test` requirements, which I suppose was not noticed because most have the `docs` requirements.  


Thanks,   
Cyril