### PR TITLE
WIP: Rework LPD Mini components class

### DIFF
--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -178,14 +178,16 @@ class MultimodDetectorBase:
         return MultimodKeyData(self, item)
 
     @classmethod
-    def _find_detector_name(cls, data):
+    def _find_detector_name(cls, data, source_re=None):
         detector_names = set()
+        if source_re is None:
+            source_re = cls._source_re
         for source in data.instrument_sources:
-            m = cls._source_re.match(source)
+            m = source_re.match(source)
             if m:
                 detector_names.add(m.group('detname'))
         if not detector_names:
-            raise SourceNameError(cls._source_re.pattern)
+            raise SourceNameError(source_re.pattern)
         elif len(detector_names) > 1:
             raise ValueError(
                 "Multiple detectors found in the data: {}. "
@@ -1569,6 +1571,8 @@ class LPDMini(XtdfDetectorBase):
                  *, corrected=True):
         self.corrected = corrected
         self._source_re = self._source_re_corr if corrected else self._source_re_raw
+        if detector_name is None:
+            detector_name = self._find_detector_name(data=self._source_re)
         super().__init__(data, detector_name, modules=[0])
 
     def __getitem__(self, item):


### PR DESCRIPTION
This was in need of a rework because we have discovered since adding it that LPD Mini is actually several smaller detectors recorded as a single source in the DAQ, rather than one 256 x 256 detector.

This exposes each module (with 2 tiles) as a 32 x 256 strip, as it is saved, rather than the 64 x 128 arrangement they make physically. The idea is that the geometry will be responsible for putting the data together as an image: https://github.com/European-XFEL/EXtra-geom/pull/187

This is a WIP because I'm still figuring some parts out, and of course it needs tests and docs, but there's something there one can try - see https://max-jhub.desy.de/user-redirect/notebooks/Code/EXtra-data/LPD%20Mini%20test.ipynb

![image](https://user-images.githubusercontent.com/327925/224369952-a027ac46-d5a1-4e20-8ae9-43896900767f.png)
