### PR TITLE
Fix typo in iterate_trains documentation

### DIFF
--- a/docs/iterate_trains.ipynb
+++ b/docs/iterate_trains.ipynb
@@ -133,7 +133,7 @@
      "traceback": [
       "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
       "\u001b[0;31mKeyError\u001b[0m                                  Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-3-630f9647c3c0>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;32mfor\u001b[0m \u001b[0mtid\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdata\u001b[0m \u001b[0;32min\u001b[0m \u001b[0msel\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtrains\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      2\u001b[0m     \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"Processing train\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mtid\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 3\u001b[0;31m     \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"Detctor data module 0 shape:\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdata\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'SPB_DET_AGIPD1M-1/DET/0CH0:xtdf'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'image.data'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mshape\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      4\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      5\u001b[0m     \u001b[0;32mbreak\u001b[0m  \u001b[0;31m# Stop after the first train to keep the demo quick\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m<ipython-input-3-630f9647c3c0>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;32mfor\u001b[0m \u001b[0mtid\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdata\u001b[0m \u001b[0;32min\u001b[0m \u001b[0msel\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtrains\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      2\u001b[0m     \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"Processing train\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mtid\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 3\u001b[0;31m     \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"Detector data module 0 shape:\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdata\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'SPB_DET_AGIPD1M-1/DET/0CH0:xtdf'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'image.data'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mshape\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      4\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      5\u001b[0m     \u001b[0;32mbreak\u001b[0m  \u001b[0;31m# Stop after the first train to keep the demo quick\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
       "\u001b[0;31mKeyError\u001b[0m: 'image.data'"
      ]
     }
@@ -141,7 +141,7 @@
    "source": [
     "for tid, data in sel.trains():\n",
     "    print(\"Processing train\", tid)\n",
-    "    print(\"Detctor data module 0 shape:\", data['SPB_DET_AGIPD1M-1/DET/0CH0:xtdf']['image.data'].shape)\n",
+    "    print(\"Detector data module 0 shape:\", data['SPB_DET_AGIPD1M-1/DET/0CH0:xtdf']['image.data'].shape)\n",
     "\n",
     "    break  # Stop after the first train to keep the demo quick"
    ]
@@ -164,14 +164,14 @@
      "output_type": "stream",
      "text": [
       "Processing train 79726787\n",
-      "Detctor data module 0 shape: (64, 2, 512, 128)\n"
+      "Detector data module 0 shape: (64, 2, 512, 128)\n"
      ]
     }
    ],
    "source": [
     "for tid, data in sel.trains(require_all=True):\n",
     "    print(\"Processing train\", tid)\n",
-    "    print(\"Detctor data module 0 shape:\", data['SPB_DET_AGIPD1M-1/DET/0CH0:xtdf']['image.data'].shape)\n",
+    "    print(\"Detector data module 0 shape:\", data['SPB_DET_AGIPD1M-1/DET/0CH0:xtdf']['image.data'].shape)\n",
     "\n",
     "    break  # Stop after the first train to keep the demo quick"
    ]


### PR DESCRIPTION
This is a simple MR to fix a typo I noticed.  


Thanks,
Cyril