### PR TITLE
Expose srcdata.device_class property

### DIFF
--- a/extra_data/tests/mockdata/base.py
+++ b/extra_data/tests/mockdata/base.py
@@ -9,6 +9,7 @@ import numpy as np
 class DeviceBase:
     # Override these in subclasses
     control_keys = []
+    extra_run_values = []
     output_channels = ()
     instrument_keys = []
 
@@ -62,6 +63,14 @@ class DeviceBase:
                              (1,), 'u8', maxshape=(None,))
             f.create_dataset('RUN/%s/%s/value' % (self.device_id, topic),
                              (1,)+dims, datatype, maxshape=((None,)+dims))
+
+        for (topic, datatype, value) in self.extra_run_values:
+            if isinstance(value, str):
+                datatype = h5py.string_dtype('ascii')
+            f.create_dataset('RUN/%s/%s/timestamp' % (self.device_id, topic),
+                             (1,), 'u8', maxshape=(None,))
+            f.create_dataset('RUN/%s/%s/value' % (self.device_id, topic),
+                             (1,) + dims, datatype, data=[value], maxshape=((None,) + dims))
 
     def write_instrument(self, f):
         """Write the INSTRUMENT data, and the relevant parts of INDEX"""

--- a/extra_data/tests/mockdata/xgm.py
+++ b/extra_data/tests/mockdata/xgm.py
@@ -36,6 +36,10 @@ class XGM(DeviceBase):
         ('signalAdaption/dig', 'i4', ()),
     ]
 
+    extra_run_values = [
+        ('classId', None, 'DoocsXGM'),
+    ]
+
     # Technically, only the part before the / is the output channel.
     # But there is a structure associated with the part one level after that,
     # and we don't know what else to call it.

--- a/extra_data/tests/test_sourcedata.py
+++ b/extra_data/tests/test_sourcedata.py
@@ -104,3 +104,12 @@ def test_run_value(mock_spb_raw_run):
     with pytest.raises(ValueError):
         # no run values for instrument sources
         am0.run_values()
+
+
+def test_device_class(mock_spb_raw_run):
+    run = RunDirectory(mock_spb_raw_run)
+    xgm_ctrl = run['SPB_XTD9_XGM/DOOCS/MAIN']
+    assert xgm_ctrl.device_class == 'DoocsXGM'
+
+    xgm_inst = run['SPB_XTD9_XGM/DOOCS/MAIN:output']
+    assert xgm_inst.device_class is None


### PR DESCRIPTION
Make it easier to get the Karabo class name for CONTROL sources. This will allow things like:

```python
xgms = [src for src in run.control_sources if run[src].device_class == 'DoocsXGM']
```

I've added an `allow_multi_run` parameter to `.run_value()` for things that we don't expect to change even between runs, like this. It feels a bit clumsy, though. Another option would be to drop the is_single_run check and trust that people understand that run values on the union of two runs may not be reliable. :thinking: 