### PR TITLE
Move components to their own package

### DIFF
--- a/extra_data/components/__init__.py
+++ b/extra_data/components/__init__.py
@@ -1,0 +1,2 @@
+
+from .multimod_det import *

--- a/extra_data/components/multimod_det.py
+++ b/extra_data/components/multimod_det.py
@@ -1,4 +1,4 @@
-"""Interfaces to data from specific instruments
+"""High-level interfaces for multi-module frame-based detectors
 """
 import logging
 import re
@@ -8,13 +8,14 @@ from warnings import warn
 import numpy as np
 import pandas as pd
 
-from .exceptions import SourceNameError
-from .reader import DataCollection, by_id, by_index
-from .read_machinery import DataChunk, roi_shape, split_trains
-from .writer import FileWriter
-from .write_cxi import XtdfCXIWriter, JUNGFRAUCXIWriter
+from ..exceptions import SourceNameError
+from ..reader import DataCollection, by_id, by_index
+from ..read_machinery import DataChunk, roi_shape, split_trains
+from ..writer import FileWriter
+from ..write_cxi import XtdfCXIWriter, JUNGFRAUCXIWriter
 
 __all__ = [
+    'XtdfDetectorBase',
     'AGIPD1M',
     'AGIPD500K',
     'DSSC1M',


### PR DESCRIPTION
The current components module is already quite heavy at more than 1700 lines and we plan to add more components in the near future covering more than multi-modular frame-based detectors. This PR turns `extra_data.components` from a module into a package and moves the existing components into a module `extra_data.components.multimod_det`.

To preserve the existing public API, the package initializer star imports this module (and I would suggest to add any future components modules in the same way). It is technically possible for code to break that imported some not in `extra_data.components.multimod_det.__all__`. We could work around that with a `__getitem__` handler if you feel strongly about it.