### PR TITLE
Add support for a default aliases file

### DIFF
--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -645,7 +645,7 @@ class DataCollection:
             with open(aliases_path, 'r') as f:
                 data = json.load(f)
 
-        elif aliases_path.suffix == '.yaml':
+        elif aliases_path.suffix in ['.yaml', '.yml']:
             import yaml
 
             with open(aliases_path, 'r') as f:

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -1617,6 +1617,13 @@ class AliasIndexer:
 
         raise TypeError('expected alias or (source alias, key) tuple')
 
+    def __contains__(self, aliased_item):
+        try:
+            self[aliased_item]
+            return True
+        except KeyError:
+            return False
+
     def _resolve_aliased_selection(self, selection):
         if isinstance(selection, dict):
             res = {self._resolve_source_alias(alias): keys

--- a/extra_data/tests/test_aliases.py
+++ b/extra_data/tests/test_aliases.py
@@ -23,6 +23,12 @@ def test_with_aliases(mock_sa3_control_data, mock_sa3_control_aliases):
     # Test whether source alias yields identical SourceData.
     assert run.alias['sa3-xgm'] is run['SA3_XTD10_XGM/XGM/DOOCS']
 
+    # Test __contains__()
+    assert "sa3-xgm" in run.alias
+    assert not "sa42-xgm" in run.alias
+    with pytest.raises(TypeError):
+        42 in run.alias
+
     # Test whether source alias plus literal key yields equal KeyData.
     assert_equal_keydata(
         run.alias['sa3-xgm', 'pulseEnergy.wavelengthUsed'],


### PR DESCRIPTION
Following up on https://github.com/European-XFEL/EXtra-data/pull/367#issuecomment-1385418097, I've added support for an `aliases` argument to `open_run()` that defaults to looking for a file named `usr/extra-data-aliases.yml` in the proposal. So as long as that file exists, you get aliases by default. Let the bikeshedding begin! :grinning: 

Things to mention:
- I figured that it only made sense to add an `aliases` argument to `open_run()` and not `RunDirectory` because this automatic-aliases-finding thing is specifically for opening runs *by proposal*. By that argument you could say that the `aliases` argument should only support paths and not `dict` objects, but I figured it could be useful. I have no objection to removing support for `dict` arguments though.
- One of `.with_aliases()` possible inputs is an `*arg` of tuples, but I didn't think that API made sense for `open_run()` so I left it out.

b29ad11 and b10e82c are smaller fixes that I found useful.