### PR TITLE
Add require_any keyword argument to source selection

### DIFF
--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -909,7 +909,8 @@ class DataCollection:
                              .format((source_glob, key_glob)))
         return matched
 
-    def select(self, seln_or_source_glob, key_glob='*', require_all=False):
+    def select(self, seln_or_source_glob, key_glob='*', require_all=False,
+               require_any=False):
         """Select a subset of sources and keys from this data.
 
         There are four possible ways to select data:
@@ -945,9 +946,9 @@ class DataCollection:
              # Select the same data contained in another DataCollection
              prev_run.select(sel)
 
-        The optional `require_all` argument restricts the trains to those for
-        which all selected sources and keys have at least one data entry. By
-        default, all trains remain selected.
+        The optional `require_all` and `require_any` arguments restrict the
+        trains to those for which all or at least one selected sources and
+        keys have at least one data entry. By default, all trains remain selected.
 
         Returns a new :class:`DataCollection` object for the selected data.
 
@@ -969,17 +970,21 @@ class DataCollection:
             seln_or_source_glob = [(seln_or_source_glob, key_glob)]
         sources_data = self._expand_selection(seln_or_source_glob)
 
-        if require_all:
-            # Select only those trains for which all selected sources
-            # and keys have data, i.e. have a count > 0 in their
-            # respective INDEX section.
+        if require_all or require_any:
+            # Select only those trains for which all (require_all) or at
+            # least one (require_any) selected sources and keys have
+            # data, i.e. have a count > 0 in their respective INDEX
+            # section.
 
-            train_ids = self.train_ids
+            if require_all:
+                train_ids = self.train_ids
+            else:  # require_any
+                # Empty list would be converted to np.float64 array.
+                train_ids = np.empty(0, dtype=np.uint64)
 
             for source, srcdata in sources_data.items():
 
                 for group in srcdata._index_group_names():
-                    # Empty list would be converted to np.float64 array.
                     source_tids = np.empty(0, dtype=np.uint64)
 
                     for f in self._sources_data[source].files:
@@ -992,7 +997,11 @@ class DataCollection:
 
                     # Remove any trains previously selected, for which this
                     # selected source and key group has no data.
-                    train_ids = np.intersect1d(train_ids, source_tids)
+
+                    if require_all:
+                        train_ids = np.intersect1d(train_ids, source_tids)
+                    else:  # require_any
+                        train_ids = np.union1d(train_ids, source_tids)
 
             sources_data = {
                 src: srcdata._only_tids(train_ids)
@@ -1640,7 +1649,8 @@ class AliasIndexer:
 
         return res
 
-    def select(self, seln_or_alias, key_glob='*', require_all=False):
+    def select(self, seln_or_alias, key_glob='*', require_all=False,
+               require_any=False):
         """Select a subset of sources and keys from this using aliases.
 
         In contrast to :method:`DataCollection.select`, only a subset of
@@ -1670,9 +1680,9 @@ class AliasIndexer:
                 # from an aliased XGM.
                 sel = run.select({'agipd': {'image.data'}, 'sa1-xgm': set()})
 
-        The optional `require_all` argument restricts the trains to those for
-        which all selected sources and keys have at least one data entry. By
-        default, all trains remain selected.
+        The optional `require_all` and `require_any` arguments restrict the
+        trains to those for which all or at least one selected sources and
+        keys have at least one data entry. By default, all trains remain selected.
 
         Returns a new :class:`DataCollection` object for the selected data.
         """
@@ -1681,7 +1691,7 @@ class AliasIndexer:
             seln_or_alias = [(seln_or_alias, key_glob)]
 
         return self.data.select(self._resolve_aliased_selection(
-            seln_or_alias))
+            seln_or_alias), require_all=require_all, require_any=require_any)
 
     def deselect(self, seln_or_alias, key_glob='*'):
         """Select everything except the specified sources and keys using aliases.

--- a/extra_data/tests/make_examples.py
+++ b/extra_data/tests/make_examples.py
@@ -190,6 +190,7 @@ def make_sa3_da_file(path, ntrains=500, format_version='0.5'):
         XGM('SA3_XTD10_XGM/XGM/DOOCS'),
         IMGFELCamera('SA3_XTD10_IMGFEL/CAM/BEAMVIEW', nsamples=0),
         IMGFELCamera('SA3_XTD10_IMGFEL/CAM/BEAMVIEW2', nsamples=250),
+        IMGFELCamera('SA3_XTD10_IMGFEL/CAM/BEAMVIEW3', nsamples=200),
         IMGFELMotor('SA3_XTD10_IMGFEL/MOTOR/FILTER'),
         IMGFELMotor('SA3_XTD10_IMGFEL/MOTOR/SCREEN'),
         MPOD('SA3_XTD10_MCP/MCPS/MPOD'),

--- a/extra_data/tests/test_reader_mockdata.py
+++ b/extra_data/tests/test_reader_mockdata.py
@@ -21,6 +21,7 @@ from extra_data import (
     MultiRunError
 )
 
+
 def test_iterate_trains(mock_agipd_data, mock_control_data_with_empty_source):
     with H5File(mock_agipd_data) as f:
         for train_id, data in islice(f.trains(), 10):
@@ -33,6 +34,7 @@ def test_iterate_trains(mock_agipd_data, mock_control_data_with_empty_source):
         # smoke test
         tid, data = next(f.trains())
         assert list(data['SA3_XTD10_VAC/GAUGE/G30520C'].keys()) == ['metadata']
+
 
 def test_iterate_trains_flat_keys(mock_agipd_data):
     with H5File(mock_agipd_data) as f:
@@ -160,6 +162,7 @@ def test_read_fxe_raw_run(mock_fxe_raw_run):
     assert run.train_ids == list(range(10000, 10480))
     run.info()  # Smoke test
 
+
 def test_read_fxe_raw_run_selective(mock_fxe_raw_run):
     run = RunDirectory(mock_fxe_raw_run, include='*DA*')
     assert run.train_ids == list(range(10000, 10480))
@@ -169,6 +172,7 @@ def test_read_fxe_raw_run_selective(mock_fxe_raw_run):
     assert run.train_ids == list(range(10000, 10480))
     assert 'SA1_XTD2_XGM/DOOCS/MAIN' not in run.control_sources
     assert 'FXE_DET_LPD1M-1/DET/0CH0:xtdf' in run.detector_sources
+
 
 def test_read_spb_proc_run(mock_spb_proc_run):
     run = RunDirectory(mock_spb_proc_run) #Test for calib data
@@ -183,6 +187,7 @@ def test_read_spb_proc_run(mock_spb_proc_run):
     assert 'u4' == data[device]['image.mask'].dtype
     assert 'f4' == data[device]['image.data'].dtype
     run.info() # Smoke test
+
 
 def test_iterate_spb_raw_run(mock_spb_raw_run):
     run = RunDirectory(mock_spb_raw_run)
@@ -592,12 +597,13 @@ def test_select(mock_fxe_raw_run):
     ['*/BEAMVIEW2:daqOutput', '*/BEAMVIEW2*', '*', [('*/BEAMVIEW2:*', 'data.image.*')]]
 )
 def test_select_require_all(mock_sa3_control_data, select_str):
-    # De-select two sources in this example set, which have no trains
-    # at all, to allow matching trains across all sources with the same
-    # result.
+    # De-select two sources in this example set which have no trains
+    # at all as well as one other with partuial trains, to allow
+    # matching trains across all sources with the same result.
     run = H5File(mock_sa3_control_data) \
         .deselect([('SA3_XTD10_MCP/ADC/1:*', '*'),
-                   ('SA3_XTD10_IMGFEL/CAM/BEAMVIEW:*', '*')])
+                   ('SA3_XTD10_IMGFEL/CAM/BEAMVIEW:*', '*'),
+                   ('SA3_XTD10_IMGFEL/CAM/BEAMVIEW3:*', '*')])
     subrun = run.select(select_str, require_all=True)
     np.testing.assert_array_equal(subrun.train_ids, run.train_ids[1::2])
 
@@ -605,6 +611,23 @@ def test_select_require_all(mock_sa3_control_data, select_str):
     # sure it's a list of np.uint64 again.
     assert isinstance(subrun.train_ids, list)
     assert all([isinstance(x, np.uint64) for x in subrun.train_ids])
+
+
+def test_select_require_any(mock_sa3_control_data):
+    run = H5File(mock_sa3_control_data)
+
+    # BEAMVIEW2 has 250/500 trains, BEAMVIEW3 has 200/500 trains.
+    # Compare the train IDs resulting from a require-any select with the
+    # union of their respective train IDs.
+    np.testing.assert_array_equal(
+        run.select('*/BEAMVIEW*:daqOutput', require_any=True).train_ids,
+        np.union1d(
+            run.select('*/BEAMVIEW2:daqOutput', require_all=True).train_ids,
+            run.select('*/BEAMVIEW3:daqOutput', require_all=True).train_ids
+        ))
+
+    # BEAMVIEW has no trains, should also yield an empty list.
+    assert run.select('*/BEAMVIEW:daqOutput', require_any=True).train_ids == []
 
 
 def test_deselect(mock_fxe_raw_run):


### PR DESCRIPTION
Complementing the [earlier support](https://github.com/European-XFEL/EXtra-data/pull/113)  to match data during a selection, this PR adds a `require_any` keyword argument as a weaker version of `require_all`. Rather than requiring all source to have data for each train, it only requires one source to have data for each train. The use cases for this are definitely smaller, but it seemed trivial to add to the existing `require_all` code by tweaking the logic only slightly.

Also used the opportunity to fix an oversight from https://github.com/European-XFEL/EXtra-data/pull/367 with `require_all` not actually being forwarded from `run.alias.select()` to `run.select()`.

An open question is whether this should be ported to `run.trains()` as well.

