### PR TITLE
Add DataCollection.plot_missing_data() to visualize missing data

### DIFF
--- a/extra_data/file_access.py
+++ b/extra_data/file_access.py
@@ -471,7 +471,7 @@ class FileAccess(metaclass=MetaFileAccess):
         """Similar to get_keys(), except it returns only a single key for performance"""
         if source in self._keys_cache:
             return next(iter(self._keys_cache[source]))
-        elif source in self._known_keys:
+        elif self._known_keys[source]:
             return next(iter(self._known_keys[source]))
 
         if source in self.control_sources:

--- a/extra_data/file_access.py
+++ b/extra_data/file_access.py
@@ -469,6 +469,11 @@ class FileAccess(metaclass=MetaFileAccess):
 
     def get_one_key(self, source):
         """Similar to get_keys(), except it returns only a single key for performance"""
+        if source in self._keys_cache:
+            return next(iter(self._keys_cache[source]))
+        elif source in self._known_keys:
+            return next(iter(self._known_keys[source]))
+
         if source in self.control_sources:
             group = '/CONTROL/' + source
         elif source in self.instrument_sources:

--- a/extra_data/file_access.py
+++ b/extra_data/file_access.py
@@ -467,6 +467,21 @@ class FileAccess(metaclass=MetaFileAccess):
         self._keys_cache[source] = res
         return res
 
+    def get_one_key(self, source):
+        """Similar to get_keys(), except it returns only a single key for performance"""
+        if source in self.control_sources:
+            group = '/CONTROL/' + source
+        elif source in self.instrument_sources:
+            group = '/INSTRUMENT/' + source
+        else:
+            raise SourceNameError(source)
+
+        def get_key(key, value):
+            if isinstance(value, h5py.Dataset):
+                return key.replace('/', '.')
+
+        return self.file[group].visititems(get_key)
+
     def get_run_keys(self, source):
         """Get the keys in the RUN section for a given control source name
 

--- a/extra_data/keydata.py
+++ b/extra_data/keydata.py
@@ -187,14 +187,15 @@ class KeyData:
             import pandas as pd
             return pd.Series(counts, index=train_ids)
         else:
+            all_tids_arr = np.array(self.train_ids)
+            res = np.zeros(len(all_tids_arr), dtype=np.uint64)
+            tid_to_ix = np.intersect1d(all_tids_arr, train_ids, return_indices=True)[1]
+
             # We may be missing some train IDs, if they're not in any file
             # for this source, and they're sometimes out of order within chunks
             # (they shouldn't be, but we try not to fail too badly if they are).
-            assert np.isin(train_ids, self.train_ids).all()
-            tid_to_ix = {t: i for (i, t) in enumerate(self.train_ids)}
-            res = np.zeros(len(self.train_ids), dtype=np.uint64)
-            for tid, ct in zip(train_ids, counts):
-                res[tid_to_ix[tid]] = ct
+            assert len(tid_to_ix) == len(train_ids)
+            res[tid_to_ix] = counts
 
             return res
 

--- a/extra_data/keydata.py
+++ b/extra_data/keydata.py
@@ -29,6 +29,8 @@ class KeyData:
 
     def _find_chunks(self):
         """Find contiguous chunks of data for this key, in any order."""
+        all_tids_arr = np.array(self.train_ids)
+
         for file in self.files:
             if len(file.train_ids) == 0:
                 continue
@@ -36,7 +38,7 @@ class KeyData:
             firsts, counts = file.get_index(self.source, self.index_group)
 
             # Of trains in this file, which are in selection
-            include = np.isin(file.train_ids, self.train_ids)
+            include = np.isin(file.train_ids, all_tids_arr)
             if not self.inc_suspect_trains:
                 include &= file.validity_flag
 
@@ -126,8 +128,9 @@ class KeyData:
         return self.select_trains(item)
 
     def _only_tids(self, tids):
+        tids_arr = np.array(tids)
         files = [f for f in self.files
-                 if f.has_train_ids(tids, self.inc_suspect_trains)]
+                 if f.has_train_ids(tids_arr, self.inc_suspect_trains)]
 
         return KeyData(
             self.source,

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -1428,7 +1428,7 @@ class DataCollection:
                                   markerfacecolor=c, markersize=6)
                            for c, label in [("k", "Missing"), ("r", "Present")]]
         ax.legend(handles=legend_elements, bbox_to_anchor=(0, 1.02, 1, 0.1), loc='lower center',
-                  ncols=2, borderaxespad=0)
+                  ncol=2, borderaxespad=0)
 
         fig.tight_layout()
 

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -1385,7 +1385,7 @@ class DataCollection:
         # Plot missing data
         import matplotlib.pyplot as plt
         from matplotlib.lines import Line2D
-        fig, ax = plt.subplots(figsize=(9, max(2, len(flaky_sources) / 4)))
+        fig, ax = plt.subplots(figsize=(9, max(3, len(flaky_sources) / 3.5)))
 
         bar_height = 0.5
         for i, src in enumerate(flaky_sources):
@@ -1411,7 +1411,7 @@ class DataCollection:
             # Plot all the blocks
             ax.broken_barh(bars.keys(),
                            (i, bar_height),
-                           color=["r" if x else "k" for x in bars.values()])
+                           color=["deeppink" if x else "k" for x in bars.values()])
 
         # Set labels and ticks
         tick_labels = [f"{src} ({save_pcts[src]:.2f}%)"
@@ -1430,8 +1430,17 @@ class DataCollection:
         # Create legend
         legend_elements = [Line2D([0], [0], marker='o', color='w', label=label,
                                   markerfacecolor=c, markersize=6)
-                           for c, label in [("k", "Missing"), ("r", "Present")]]
-        ax.legend(handles=legend_elements, bbox_to_anchor=(0, 1.02, 1, 0.1), loc='lower center',
+                           for c, label in [("k", "Missing"), ("deeppink", "Present")]]
+
+        # bbox_factor is a variable that tries to scale down the bounding box of
+        # the legend as the height of the plot grows with more sources. It's
+        # necessary because the bounding box coordinates are relative to the
+        # plot size, so with a tall plot the figure/legend padding will be
+        # massive. 7000 is a magic number that seems to give good results.
+        bbox_factor = 1 - len(flaky_sources) / 7000
+        ax.legend(handles=legend_elements,
+                  bbox_to_anchor=(0, 1.02 * bbox_factor, 1, 0.1 * bbox_factor),
+                  loc='lower center',
                   ncol=2, borderaxespad=0)
 
         fig.tight_layout()

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -1346,6 +1346,9 @@ class DataCollection:
         for src in self.all_sources:
             kds = { }
             if src.endswith(":xtdf"):
+                # If it's an XTDF source we need to check all the subsections
+                # (prioritizing image.* if the user doesn't want to check all of
+                # them) because each subsection has its own index.
                 keys = self[src].keys()
                 subsections = set(k.split(".")[0] for k in keys) if all_xtdf_subsections else { "image" }
                 keys_for_subsections = { sec: next(iter(k for k in keys if k.startswith(f"{sec}.")))
@@ -1355,6 +1358,7 @@ class DataCollection:
                 for subsection, key in keys_for_subsections.items():
                     kds[f"{src_name}, {subsection}.*"] = self[src, key]
             else:
+                # If it's a regular source then we pick a random key to look at
                 key = self[src].one_key()
                 kds[best_src_name(src)] = self[src, key]
 

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -1391,7 +1391,7 @@ class DataCollection:
 
         # Plot missing data
         import matplotlib.pyplot as plt
-        fig, ax = plt.subplots()
+        fig, ax = plt.subplots(figsize=(9, max(2, len(flaky_sources) / 4)))
 
         bar_height = 0.5
         for i, src in enumerate(flaky_sources):

--- a/extra_data/sourcedata.py
+++ b/extra_data/sourcedata.py
@@ -139,6 +139,18 @@ class SourceData:
         for f in self.files:
             return f.get_keys(self.source)
 
+    def one_key(self):
+        """Get a single (random) key for this source
+
+        If you only need a single key, this can be much faster than calling
+        :meth:`keys`.
+        """
+        if self.sel_keys is not None:
+            return next(iter(self.sel_keys))
+
+        for f in self.files:
+            return f.get_one_key(self.source)
+
     @property
     def index_groups(self) -> set:
         """The part of keys needed to look up index data."""

--- a/extra_data/sourcedata.py
+++ b/extra_data/sourcedata.py
@@ -81,7 +81,7 @@ class SourceData:
         )
 
     def _get_first_source_file(self):
-        first_kd = self[next(iter(self.keys()))]
+        first_kd = self[self.one_key()]
 
         try:
             # This property is an empty list if no trains are selected.

--- a/extra_data/tests/test_reader_mockdata.py
+++ b/extra_data/tests/test_reader_mockdata.py
@@ -190,6 +190,7 @@ def test_read_spb_proc_run(mock_spb_proc_run):
     assert 'u4' == data[device]['image.mask'].dtype
     assert 'f4' == data[device]['image.data'].dtype
     run.info() # Smoke test
+    run.plot_missing_data() # Smoke test
 
 
 def test_iterate_spb_raw_run(mock_spb_raw_run):

--- a/extra_data/tests/test_sourcedata.py
+++ b/extra_data/tests/test_sourcedata.py
@@ -40,6 +40,11 @@ def test_keys(mock_spb_raw_run):
     assert 'beamPosition.ixPos.timestamp' not in xgm.keys(inc_timestamps=False)
     assert 'beamPosition.ixPos' in xgm.keys(inc_timestamps=False)
 
+    # Make sure that one_key() does indeed return a valid key for
+    # control/instrument sources.
+    assert xgm.one_key() in xgm.keys()
+    xgm_output = run['SPB_XTD9_XGM/DOOCS/MAIN:output']
+    assert xgm_output.one_key() in xgm_output.keys()
 
 def test_select_keys(mock_spb_raw_run):
     run = RunDirectory(mock_spb_raw_run)

--- a/extra_data/tests/test_sourcedata.py
+++ b/extra_data/tests/test_sourcedata.py
@@ -40,11 +40,17 @@ def test_keys(mock_spb_raw_run):
     assert 'beamPosition.ixPos.timestamp' not in xgm.keys(inc_timestamps=False)
     assert 'beamPosition.ixPos' in xgm.keys(inc_timestamps=False)
 
+    # Recreate the run and xgm objects so we can test one_key() when the
+    # FileAccess caches are empty.
+    run = RunDirectory(mock_spb_raw_run)
+    xgm = run["SPB_XTD9_XGM/DOOCS/MAIN"]
+
     # Make sure that one_key() does indeed return a valid key for
     # control/instrument sources.
     assert xgm.one_key() in xgm.keys()
     xgm_output = run['SPB_XTD9_XGM/DOOCS/MAIN:output']
     assert xgm_output.one_key() in xgm_output.keys()
+
 
 def test_select_keys(mock_spb_raw_run):
     run = RunDirectory(mock_spb_raw_run)

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(name="EXtra-data",
           'packaging',
           'pandas',
           'xarray',
+          'matplotlib'
       ],
       extras_require={
           'bridge': [


### PR DESCRIPTION
I've recently started making DAMNIT variables to plot the missing data for various sources in a run, and I figured it'd be useful to have something like that in extra-data considering how frequently it comes up. Originally I did this with line and scatter plots, but those get completely unreadable with lots of sources, so I opted for horizontal broken bar plots instead.

The downside of the bar plots is that if the plot is too small then it's impossible to see infrequent missing/present trains, but I think that's ok (you can see an example in the GIF below when `min_saved_pct=100`). One way around that would be to have a tiny scatter plot above the bars showing where the missing/present trains are.

Things I'm unsure about:
- The check for missing trains might not be robust, it's basically doing this: `set(source_tids) != set(run_tids)`. But that'll kinda break if train IDs repeat, does that ever happen?
- The code doesn't check the trains for each source-key pair individually, only the first key for the source. Is that ok? I think it is because if I remember correctly the DAQ drops entire hashes at a time if any data in the hash is missing.
- I called the method `plot_missing_data()` because technically it's the data for a source that's missing, not entire trains from the run. But I think everyone calls this problem 'missing trains' so maybe it should be named `plot_missing_trains()` instead? I don't have a strong opinion about that.

Examples:
![plot-missing-data](https://github.com/European-XFEL/EXtra-data/assets/5361518/9b03f0eb-335b-43d5-a932-38f5bec6c89d)

![image](https://github.com/European-XFEL/EXtra-data/assets/5361518/517c1785-f58e-4dd8-b1e8-d7766746002f)

![image](https://github.com/European-XFEL/EXtra-data/assets/5361518/89c6bdd5-8888-446e-88f9-3d00ad9fec08)