### PR TITLE
Add SourceData.data_counts()

### DIFF
--- a/extra_data/file_access.py
+++ b/extra_data/file_access.py
@@ -342,7 +342,7 @@ class FileAccess(metaclass=MetaFileAccess):
             counts = np.uint64((ix_group['last'][:ntrains] - firsts + 1) * status)
         return firsts, counts
 
-    def index_group_names(self, source):
+    def index_groups(self, source):
         """Get group names for index data, to use with .get_index()"""
         if source in self.control_sources:
             return {''}

--- a/extra_data/keydata.py
+++ b/extra_data/keydata.py
@@ -33,7 +33,7 @@ class KeyData:
             if len(file.train_ids) == 0:
                 continue
 
-            firsts, counts = file.get_index(self.source, self._key_group)
+            firsts, counts = file.get_index(self.source, self.index_group)
 
             # Of trains in this file, which are in selection
             include = np.isin(file.train_ids, self.train_ids)
@@ -69,7 +69,7 @@ class KeyData:
                f"for {len(self.train_ids)} trains>"
 
     @property
-    def _key_group(self):
+    def index_group(self):
         """The part of the key needed to look up index data"""
         if self.section == 'INSTRUMENT':
             return self.key.partition('.')[0]
@@ -458,7 +458,7 @@ class KeyData:
         if fa is None:
             return np.empty((0,) + self.entry_shape, dtype=self.dtype)
 
-        firsts, counts = fa.get_index(self.source, self._key_group)
+        firsts, counts = fa.get_index(self.source, self.index_group)
         first, count = firsts[ix], counts[ix]
         if count == 1 and not keep_dims:
             return tid, fa.file[self.hdf5_data_path][first]

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -983,8 +983,7 @@ class DataCollection:
                 train_ids = np.empty(0, dtype=np.uint64)
 
             for source, srcdata in sources_data.items():
-
-                for group in srcdata._index_group_names():
+                for group in srcdata.index_groups:
                     source_tids = np.empty(0, dtype=np.uint64)
 
                     for f in self._sources_data[source].files:

--- a/extra_data/sourcedata.py
+++ b/extra_data/sourcedata.py
@@ -2,6 +2,7 @@ import fnmatch
 import re
 from typing import Dict, List, Optional
 
+import numpy as np
 import h5py
 
 from .exceptions import MultiRunError, PropertyNameError
@@ -244,6 +245,41 @@ class SourceData:
         """
         for s in split_trains(len(self.train_ids), parts, trains_per_part):
             yield self.select_trains(s)
+
+    def data_counts(self, labelled=True, index_group=None):
+        """Get a count of data entries in each train.
+
+        if *index_group* is omitted, the largest count across all index
+        groups is returned for each train.
+
+        If *labelled* is True, returns a pandas series with an index of train
+        IDs. Otherwise, returns a NumPy array of counts to match ``.train_ids``.
+        """
+
+        if index_group is None:
+            sample_keys = dict(zip(
+                [self[key].index_group for key in self.keys()], self.keys()))
+
+            data_counts = {
+                prefix: self[key].data_counts(labelled=labelled)
+                for prefix, key in sample_keys.items()
+            }
+
+            if labelled:
+                import pandas as pd
+                return pd.DataFrame(data_counts).max(axis=1)
+            else:
+                return np.stack(list(data_counts.values())).max(axis=0)
+
+        else:
+            for key in self.keys():
+                if self[key].index_group == index_group:
+                    break
+            else:
+                raise ValueError(f'{index_group} not an index group of this '
+                                 f'source')
+
+            return self[key].data_counts(labelled=labelled)
 
     def run_metadata(self) -> Dict:
         """Get a dictionary of metadata about the run

--- a/extra_data/sourcedata.py
+++ b/extra_data/sourcedata.py
@@ -105,14 +105,16 @@ class SourceData:
         for f in self.files:
             return f.get_keys(self.source)
 
-    def _index_group_names(self) -> set:
-        if self.section == 'INSTRUMENT':
+    @property
+    def index_groups(self) -> set:
+        """The part of keys needed to look up index data."""
+        if self.is_instrument:
             # For INSTRUMENT sources, the INDEX is saved by
             # key group, which is the first hash component. In
             # many cases this is 'data', but not always.
             if self.sel_keys is None:
                 # All keys are selected.
-                return self.files[0].index_group_names(self.source)
+                return self.files[0].index_groups(self.source)
             else:
                 return {key.partition('.')[0] for key in self.sel_keys}
         else:

--- a/extra_data/tests/test_sourcedata.py
+++ b/extra_data/tests/test_sourcedata.py
@@ -12,12 +12,14 @@ def test_get_sourcedata(mock_spb_raw_run):
     assert am0.section == 'INSTRUMENT'
     assert am0.is_instrument
     assert not am0.is_control
+    assert am0.index_groups == {'header', 'detector', 'image', 'trailer'}
 
     xgm = run['SPB_XTD9_XGM/DOOCS/MAIN']
     assert len(xgm.files) == 2
     assert xgm.section == 'CONTROL'
     assert xgm.is_control
     assert not xgm.is_instrument
+    assert xgm.index_groups == {''}
 
 
 def test_keys(mock_spb_raw_run):

--- a/extra_data/tests/test_sourcedata.py
+++ b/extra_data/tests/test_sourcedata.py
@@ -138,3 +138,52 @@ def test_device_class(mock_spb_raw_run):
 
     xgm_inst = run['SPB_XTD9_XGM/DOOCS/MAIN:output']
     assert xgm_inst.device_class is None
+
+
+@pytest.mark.parametrize('source', [
+    'SPB_XTD9_XGM/DOOCS/MAIN',  # Control data.
+    'SPB_IRU_CAM/CAM/SIDEMIC:daqOutput',  # Pipeline data.
+    'SPB_DET_AGIPD1M-1/DET/0CH0:xtdf'  # XTDF data.
+])
+def test_data_counts_modes(mock_reduced_spb_proc_run, source):
+    run = RunDirectory(mock_reduced_spb_proc_run)
+    sd = run[source]
+
+    import pandas as pd
+
+    for index_group in [None, *sd.index_groups]:
+        count1 = sd.data_counts(index_group=index_group)
+        assert isinstance(count1, pd.Series)
+        assert count1.index.tolist() == sd.train_ids
+
+        count2 = sd.data_counts(labelled=False, index_group=index_group)
+        assert isinstance(count2, np.ndarray)
+        assert len(count2) == len(sd.train_ids)
+
+        np.testing.assert_equal(count1, count2)
+
+
+def test_data_counts_values(mock_reduced_spb_proc_run):
+    run = RunDirectory(mock_reduced_spb_proc_run)
+
+    # control data
+    xgm = run['SPB_XTD9_XGM/DOOCS/MAIN']
+    assert (xgm.data_counts().values == 1).all()
+
+    with pytest.raises(ValueError):
+        xgm.data_counts(index_group='data')
+
+    # instrument data
+    camera = run['SPB_IRU_CAM/CAM/SIDEMIC:daqOutput']
+    assert (camera.data_counts().values == 1).all()
+
+    with pytest.raises(ValueError):
+        camera.data_counts(index_group='not-data')
+
+    am0 = run['SPB_DET_AGIPD1M-1/DET/0CH0:xtdf']
+    num_images = am0['image.data'].shape[0]
+    assert am0.data_counts().values.sum() >= num_images
+    assert am0.data_counts(index_group='image').values.sum() == num_images
+
+    with pytest.raises(ValueError):
+        am0.data_counts(index_group='preamble')


### PR DESCRIPTION
(targeting `feat/sd-is-control` for now for a cleaner diff and to avoid a merge conflict in the making)

Another API extension to `SourceData` in the form of an analogue to `KeyData.data_counts(labelled=True)`. The behaviour of this method depends on whether it's a `CONTROL` or `INSTRUMENT` source. For the former, it's identical to the data counts of a _random_ of its keys. For the latter, a _random_ key is chosen for each of its key group and returned as a data frame or dictionary.