### PR TITLE
Add SourceData.drop_empty_trains()

### DIFF
--- a/extra_data/sourcedata.py
+++ b/extra_data/sourcedata.py
@@ -221,6 +221,16 @@ class SourceData:
             inc_suspect_trains=self.inc_suspect_trains
         )
 
+    def drop_empty_trains(self, index_group=None):
+        """Select only trains with data as a new :class:`SourceData` object.
+
+        If *index_group* is omitted, those trains with data for any of this
+        source's index groups are selected.
+        """
+        counts = self.data_counts(labelled=False, index_group=index_group)
+        tids = np.array(self.train_ids)[counts > 0]
+        return self._only_tids(list(tids))
+
     def split_trains(self, parts=None, trains_per_part=None):
         """Split this data into chunks with a fraction of the trains each.
 

--- a/extra_data/tests/test_sourcedata.py
+++ b/extra_data/tests/test_sourcedata.py
@@ -187,3 +187,21 @@ def test_data_counts_values(mock_reduced_spb_proc_run):
 
     with pytest.raises(ValueError):
         am0.data_counts(index_group='preamble')
+
+
+def test_drop_empty_trains(mock_reduced_spb_proc_run):
+    run = RunDirectory(mock_reduced_spb_proc_run)
+    am0 = run['SPB_DET_AGIPD1M-1/DET/0CH0:xtdf']
+
+    # Compare all index groups with `require_any`.
+    np.testing.assert_equal(
+        am0.drop_empty_trains().train_ids,
+        run.select(am0.source, '*', require_any=True).train_ids)
+
+    # Compare one specific index group with `require_all`.
+    np.testing.assert_equal(
+        am0.drop_empty_trains(index_group='image').train_ids,
+        run.select(am0.source, 'image.*', require_all=True).train_ids)
+
+    with pytest.raises(ValueError):
+        am0.drop_empty_trains(index_group='preamble')


### PR DESCRIPTION
A natural and small addition building on top of https://github.com/European-XFEL/EXtra-data/pull/405, and the code is even almost identical to `KeyData.drop_empty_trains`.