### PR TITLE
Clearer name for former path traits

### DIFF
--- a/extra_data/tests/test_file_access.py
+++ b/extra_data/tests/test_file_access.py
@@ -72,7 +72,7 @@ _empty_cache_info = dict(
 )
 
 
-def test_path_traits(mock_sa3_control_data, monkeypatch):
+def test_euxfel_path_infos(mock_sa3_control_data, monkeypatch):
     fa = FileAccess(mock_sa3_control_data)
 
     # Default path is not a EuXFEL storage location.
@@ -94,7 +94,7 @@ def test_path_traits(mock_sa3_control_data, monkeypatch):
         assert fa.cycle == '202301'
 
 
-def test_filename_traits(mock_sa3_control_data, monkeypatch):
+def test_euxfel_filename_infos(mock_sa3_control_data, monkeypatch):
     fa = FileAccess(mock_sa3_control_data)
 
     assert fa.data_category == 'RAW'

--- a/extra_data/tests/test_sourcedata.py
+++ b/extra_data/tests/test_sourcedata.py
@@ -140,7 +140,7 @@ def test_device_class(mock_spb_raw_run):
     assert xgm_inst.device_class is None
 
 
-def test_path_traits(mock_spb_raw_run):
+def test_euxfel_path_infos(mock_spb_raw_run):
     run = RunDirectory(mock_spb_raw_run)
     xgm = run['SPB_XTD9_XGM/DOOCS/MAIN']
 


### PR DESCRIPTION
Sorry for having the idea after merging https://github.com/European-XFEL/EXtra-data/pull/399, but I did find a clearer (internal!) name for this feature to avoid using the debatable word _trait_. Incidentally I'd also like to change the regexp name to indicate it's about files saved at EuXFEL, not strictly in the EXDF format.