### PR TITLE
Improve AliasIndexer.__repr__() when there are no aliases loaded

### DIFF
--- a/extra_data/aliases.py
+++ b/extra_data/aliases.py
@@ -84,6 +84,9 @@ class AliasIndexer:
             elif isinstance(alias_ident, str):
                 source_key_aliases[(alias, alias_ident)].extend([])
 
+        if len(source_key_aliases) == 0:
+            return "No aliases have been loaded."
+
         # Print the aliases
         output_lines = ["Loaded aliases:"]
         for source, alias_keys in source_key_aliases.items():

--- a/extra_data/tests/test_aliases.py
+++ b/extra_data/tests/test_aliases.py
@@ -11,7 +11,8 @@ from extra_data import (
 
 
 def test_with_aliases(mock_sa3_control_data, mock_sa3_control_aliases):
-    run = H5File(mock_sa3_control_data).with_aliases(mock_sa3_control_aliases)
+    run_without_aliases = H5File(mock_sa3_control_data)
+    run = run_without_aliases.with_aliases(mock_sa3_control_aliases)
 
     def assert_equal_keydata(kd1, kd2):
         assert isinstance(kd1, KeyData)
@@ -73,8 +74,9 @@ def test_with_aliases(mock_sa3_control_data, mock_sa3_control_aliases):
     run4 = run.drop_aliases()
     assert not run4._aliases
 
-    # Smoke test for __str__() and __repr__()
-    repr(run.alias)
+    # Smoke tests for __str__() and __repr__()
+    assert "Loaded aliases" in repr(run.alias)
+    assert "No aliases" in repr(run_without_aliases.alias)
     str(run.alias)
 
 


### PR DESCRIPTION
Another silly bug, previously it would just print out 'Loaded aliases:'.