### PR TITLE
Expose origin indices in FileAccess

### DIFF
--- a/extra_data/file_access.py
+++ b/extra_data/file_access.py
@@ -265,6 +265,21 @@ class FileAccess(metaclass=MetaFileAccess):
     def valid_train_ids(self):
         return self.train_ids[self.validity_flag]
 
+    @property
+    def origin_indices(self):
+        if self.format_version in ('0.5', '1.0', '1.1'):
+            # These format versions do not have origin indices yet, so
+            # construct it based on the validity flag.
+            # The origin index refers to the source in METADATA/dataSources
+            # from which a train originates, with "safe" trains indicated
+            # by the time server with virtual index -1.
+            origin_indices = np.zeros(len(self.train_ids), dtype=np.int8)
+            origin_indices[self.validity_flag] = -1
+        else:
+            origin_indices = self.file['INDEX/origin'][:len(self.train_ids)]
+
+        return origin_indices
+
     def has_train_ids(self, tids: np.ndarray, inc_suspect=False):
         f_tids = self.train_ids if inc_suspect else self.valid_train_ids
         return np.intersect1d(tids, f_tids).size > 0

--- a/extra_data/tests/test_file_access.py
+++ b/extra_data/tests/test_file_access.py
@@ -62,13 +62,22 @@ def test_pickle(pickle_mod, mock_sa3_control_data):
     assert len(fa3.train_ids) == 500
 
 
+def test_origin_indices(mock_sa3_control_data):
+    fa = FileAccess(mock_sa3_control_data)
+
+    origins = fa.origin_indices
+    assert isinstance(origins, np.ndarray)
+    assert len(origins) == len(fa.train_ids)
+    np.testing.assert_equal(origins, -1)
+
+
 # Empty FileAccess cache entry to test behaviour without actually trying
 # to read a non-existing file in tests below.
 _empty_cache_info = dict(
     train_ids= np.zeros(0, dtype=np.uint64),
     control_sources=frozenset(),
     instrument_sources=frozenset(),
-    flag=np.zeros(0, dtype=np.int32)
+    flag=np.zeros(0, dtype=bool)
 )
 
 


### PR DESCRIPTION
EXDF-1.2 introduced the `INDEX/origin` dataset, which expands upon `INDEX/flag` by telling from which source a train "originates" through indexing into `METADATA/dataSources`. This PR exposes this information through the `FileAccess` API including a fallback for older files that lack this information.

Since it's not used internally at the moment, I kept it a simple property without caching.