### PR TITLE
Remove LPD Mini component class (pending redesign)

### DIFF
--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -19,7 +19,6 @@ __all__ = [
     'AGIPD500K',
     'DSSC1M',
     'LPD1M',
-    'LPDMini',
     'JUNGFRAU',
     'identify_multimod_detectors',
 ]
@@ -1430,8 +1429,30 @@ class DSSC1M(XtdfDetectorBase):
     module_shape = (128, 512)
 
 
-class LPDBase:
-    """Base LPD class supporting parallel gain mode."""
+@multimod_detectors
+class LPD1M(XtdfDetectorBase):
+    """An interface to LPD-1M data.
+
+    Parameters
+    ----------
+    data: DataCollection
+      A data collection, e.g. from :func:`.RunDirectory`.
+    modules: set of ints, optional
+      Detector module numbers to use. By default, all available modules
+      are used.
+    detector_name: str, optional
+      Name of a detector, e.g. 'FXE_DET_LPD1M-1'. This is only needed
+      if the dataset includes more than one LPD detector.
+    min_modules: int
+      Include trains where at least n modules have data. Default is 1.
+    parallel_gain: bool
+      Set to True to read this data as parallel gain data, where high, medium
+      and low gain data are stored sequentially within each train. This will
+      repeat the pulse & cell IDs from the first 1/3 of each train, and add gain
+      stage labels from 0 (high-gain) to 2 (low-gain).
+    """
+    _source_re = re.compile(r'(?P<detname>.+_LPD1M.*)/DET/(?P<modno>\d+)CH')
+    module_shape = (256, 256)
 
     def __init__(self, data: DataCollection, detector_name=None, modules=None,
                  *, min_modules=1, parallel_gain=False):
@@ -1513,56 +1534,6 @@ class LPDBase:
         return pd.MultiIndex.from_arrays(
             [tids, gain, inner_ids_fixed], names=['train', 'gain', inner_name]
         )
-
-
-@multimod_detectors
-class LPD1M(LPDBase, XtdfDetectorBase):
-    """An interface to LPD-1M data.
-
-    Parameters
-    ----------
-    data: DataCollection
-      A data collection, e.g. from :func:`.RunDirectory`.
-    modules: set of ints, optional
-      Detector module numbers to use. By default, all available modules
-      are used.
-    detector_name: str, optional
-      Name of a detector, e.g. 'FXE_DET_LPD1M-1'. This is only needed
-      if the dataset includes more than one LPD detector.
-    min_modules: int
-      Include trains where at least n modules have data. Default is 1.
-    parallel_gain: bool
-      Set to True to read this data as parallel gain data, where high, medium
-      and low gain data are stored sequentially within each train. This will
-      repeat the pulse & cell IDs from the first 1/3 of each train, and add gain
-      stage labels from 0 (high-gain) to 2 (low-gain).
-    """
-    _source_re = re.compile(r'(?P<detname>.+_LPD1M.*)/DET/(?P<modno>\d+)CH')
-    module_shape = (256, 256)
-
-
-@multimod_detectors
-class LPDMini(LPDBase, XtdfDetectorBase):
-    """An interface to LPD-Mini data.
-
-    Parameters
-    ----------
-    data: DataCollection
-      A data collection, e.g. from :func:`.RunDirectory`.
-    modules: set of ints, optional
-      Detector module numbers to use. By default, all available modules
-      are used.
-    detector_name: str, optional
-      Name of a detector, e.g. 'FXE_DET_LPD_MINI'. This is only needed
-      if the dataset includes more than one LPD detector.
-    parallel_gain: bool
-      Set to True to read this data as parallel gain data, where high, medium
-      and low gain data are stored sequentially within each train. This will
-      repeat the pulse & cell IDs from the first 1/3 of each train, and add gain
-      stage labels from 0 (high-gain) to 2 (low-gain).
-    """
-    _source_re = re.compile(r'(?P<detname>.+_LPD_MINI.*)/DET/(?P<modno>\d+)CH')
-    module_shape = (256, 256)
 
 
 @multimod_detectors

--- a/extra_data/tests/make_examples.py
+++ b/extra_data/tests/make_examples.py
@@ -242,11 +242,6 @@ def make_fxe_run(dir_path, raw=True, format_version='0.5'):
                       frames_per_train=128)
         ], ntrains=480, chunksize=32, format_version=format_version)
 
-    path = osp.join(dir_path, f'{prefix}-R0450-LPDMINI00-S00000.h5')
-    write_file(path, [
-        LPDModule('FXE_DET_LPD_MINI/DET/0CH0', raw=raw, frames_per_train=128)
-        ], ntrains=480, chunksize=32, format_version=format_version)
-
     if not raw:
         return
     write_file(osp.join(dir_path, 'RAW-R0450-DA01-S00000.h5'), [
@@ -273,10 +268,6 @@ def make_lpd_parallelgain_run(dir_path, raw=True, format_version='0.5'):
                       frames_per_train=300)
         ], ntrains=100, chunksize=32, format_version=format_version)
 
-    path = osp.join(dir_path, f'{prefix}-R0450-LPDMINI00-S00000.h5')
-    write_file(path, [
-        LPDModule('FXE_DET_LPD_MINI/DET/0CH0', raw=raw, frames_per_train=300)
-    ], ntrains=100, chunksize=32, format_version=format_version)
 
 def make_lpd_run_mini_missed_train(dir_path):
     write_file(osp.join(dir_path, 'RAW-R0450-LPD00-S00000.h5'), [

--- a/extra_data/tests/test_components.py
+++ b/extra_data/tests/test_components.py
@@ -7,7 +7,7 @@ from testpath import assert_isfile
 
 from extra_data.reader import RunDirectory, H5File, by_id, by_index
 from extra_data.components import (
-    AGIPD1M, DSSC1M, LPD1M, LPDMini, JUNGFRAU, identify_multimod_detectors,
+    AGIPD1M, DSSC1M, LPD1M, JUNGFRAU, identify_multimod_detectors,
 )
 
 
@@ -179,17 +179,6 @@ def test_get_array_lpd_parallelgain(mock_lpd_parallelgain_run):
     np.testing.assert_array_equal(arr.coords['gain'], np.arange(3))
     np.testing.assert_array_equal(arr.coords['pulse'], np.arange(100))
 
-    run = RunDirectory(mock_lpd_parallelgain_run)
-    det = LPDMini(run.select_trains(by_index[:2]), parallel_gain=True)
-    assert det.detector_name == 'FXE_DET_LPD_MINI'
-
-    arr = det.get_array('image.data')
-    assert arr.shape == (1, 2, 3, 100, 256, 256)
-    assert arr.dims == ('module', 'train', 'gain', 'pulse', 'slow_scan', 'fast_scan')
-    np.testing.assert_array_equal(arr.coords['gain'], np.arange(3))
-    np.testing.assert_array_equal(arr.coords['pulse'], np.arange(100))
-
-
 
 def test_get_array_lpd_parallelgain_select_pulses(mock_lpd_parallelgain_run):
     run = RunDirectory(mock_lpd_parallelgain_run)
@@ -204,20 +193,6 @@ def test_get_array_lpd_parallelgain_select_pulses(mock_lpd_parallelgain_run):
 
     arr = det.get_array('image.data', pulses=by_id[:5])
     assert arr.shape == (16, 2, 3, 5, 256, 256)
-    np.testing.assert_array_equal(arr.coords['pulse'], np.arange(5))
-
-    run = RunDirectory(mock_lpd_parallelgain_run)
-    det = LPDMini(run.select_trains(by_index[:2]), parallel_gain=True)
-    assert det.detector_name == 'FXE_DET_LPD_MINI'
-
-    arr = det.get_array('image.data', pulses=np.s_[:5])
-    assert arr.shape == (1, 2, 3, 5, 256, 256)
-    assert arr.dims == ('module', 'train', 'gain', 'pulse', 'slow_scan', 'fast_scan')
-    np.testing.assert_array_equal(arr.coords['gain'], np.arange(3))
-    np.testing.assert_array_equal(arr.coords['pulse'], np.arange(5))
-
-    arr = det.get_array('image.data', pulses=by_id[:5])
-    assert arr.shape == (1, 2, 3, 5, 256, 256)
     np.testing.assert_array_equal(arr.coords['pulse'], np.arange(5))
 
 
@@ -609,7 +584,7 @@ def test_write_selected_frames_proc(mock_spb_proc_run, tmp_path):
     test_file.unlink()
 
 def test_identify_multimod_detectors(mock_fxe_raw_run):
-    run = RunDirectory(mock_fxe_raw_run, include='*LPD[!MINI]*')
+    run = RunDirectory(mock_fxe_raw_run)
     name, cls = identify_multimod_detectors(run, single=True)
     assert name == 'FXE_DET_LPD1M-1'
     assert cls is LPD1M

--- a/extra_data/tests/test_reader_mockdata.py
+++ b/extra_data/tests/test_reader_mockdata.py
@@ -161,7 +161,7 @@ def test_iterate_trains_require_all(mock_sa3_control_data):
 
 def test_read_fxe_raw_run(mock_fxe_raw_run):
     run = RunDirectory(mock_fxe_raw_run)
-    assert len(run.files) == 19  # 16 LPD 1M, 1 LPD Minimodules + 2 control data files
+    assert len(run.files) == 18  # 16 LPD 1M + 2 control data files
     assert run.train_ids == list(range(10000, 10480))
     run.info()  # Smoke test
 

--- a/extra_data/tests/test_streamer.py
+++ b/extra_data/tests/test_streamer.py
@@ -11,7 +11,7 @@ from karabo_bridge import Client
 
 
 def test_merge_detector(mock_fxe_raw_run, mock_fxe_control_data, mock_spb_proc_run):
-    with RunDirectory(mock_fxe_raw_run, include="*LPD[!MINI]*") as run:
+    with RunDirectory(mock_fxe_raw_run) as run:
         for tid, data in _iter_trains(run, merge_detector=True):
             assert 'FXE_DET_LPD1M-1/DET/APPEND' in data
             assert 'FXE_DET_LPD1M-1/DET/0CH0:xtdf' not in data


### PR DESCRIPTION
The current component is wrong, based on when we thought LPD Mini was a single 256 x 256 pixel detector, and we're still working out some issues with the redesign. We don't want to keep delaying the release for this, so it was suggested that we remove the LPD Mini wrapper for now so we can release other improvements and spend more time on it.

See #381 for the work to add it back.