### PR TITLE
Add publishing to PyPI from Github actions on tag

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,3 +40,27 @@ jobs:
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
+
+  publish:
+    runs-on: ubuntu-latest
+    if: ${{ startsWith(github.ref, 'refs/tags/') }}
+    needs: tests
+    permissions:
+      id-token: write  # OIDC for uploading to PyPI
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.10
+
+      - name: Build packages
+        run: |
+          python3 -m pip install build
+          python3 -m build
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Trying the new ['Trusted publisher'](https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/) support to automatically upload packages when we push a tag to Github.