### PR TITLE
Implement .nbytes, .size_mb, and .size_gb for KeyData

### DIFF
--- a/docs/reading_files.rst
+++ b/docs/reading_files.rst
@@ -177,6 +177,12 @@ below, e.g.::
 
    .. automethod:: data_counts
 
+   .. autoattribute:: nbytes
+
+   .. autoattribute:: size_mb
+
+   .. autoattribute:: size_gb
+
    .. automethod:: ndarray
 
    .. automethod:: series

--- a/extra_data/keydata.py
+++ b/extra_data/keydata.py
@@ -92,6 +92,21 @@ class KeyData:
         return (sum(c.total_count for c in self._data_chunks),) + self.entry_shape
 
     @property
+    def nbytes(self):
+        """The number of bytes this data would take up in memory."""
+        return self.dtype.itemsize * np.prod(self.shape)
+
+    @property
+    def size_mb(self):
+        """The size of the data in memory in megabytes."""
+        return self.nbytes / 1e6
+
+    @property
+    def size_gb(self):
+        """The size of the data in memory in gigabytes."""
+        return self.nbytes / 1e9
+
+    @property
     def source_file_paths(self):
         paths = []
         for chunk in self._data_chunks:

--- a/extra_data/tests/test_keydata.py
+++ b/extra_data/tests/test_keydata.py
@@ -34,6 +34,9 @@ def test_get_keydata(mock_spb_raw_run):
         'RAW-R0238-DA01-S00000.h5', 'RAW-R0238-DA01-S00001.h5'
     }
 
+    data = xgm_beam_x.ndarray()
+    assert xgm_beam_x.nbytes == data.nbytes
+
 def test_select_trains(mock_spb_raw_run):
     run = RunDirectory(mock_spb_raw_run)
     xgm_beam_x = run['SPB_XTD9_XGM/DOOCS/MAIN', 'beamPosition.ixPos.value']


### PR DESCRIPTION
Added because it can be useful to see how large a dataset will be in memory without actually loading it.

`.size_mb` and `.size_gb` are there because I wanted a way to quickly check what the size of a dataset is in human-readable units. I could also implement a `.size()` function that takes in a unit, but I'd like to keep `.size_mb` and `.size_gb` anyway for ease-of-use.