### PR TITLE
Faster split_trains for long runs

### DIFF
--- a/extra_data/keydata.py
+++ b/extra_data/keydata.py
@@ -188,11 +188,13 @@ class KeyData:
     def _only_tids(self, tids, files=None):
         tids_arr = np.array(tids)
         if files is None:
-            # Keep 1 file, even if 0 trains selected.
             files = [
                 f for f in self.files
                 if f.has_train_ids(tids_arr, self.inc_suspect_trains)
-            ] or [self.files[0]]
+            ]
+        if not files:
+            # Keep 1 file, even if 0 trains selected.
+            files = [self.files[0]]
 
         return KeyData(
             self.source,

--- a/extra_data/keydata.py
+++ b/extra_data/keydata.py
@@ -185,13 +185,14 @@ class KeyData:
     def __getitem__(self, item):
         return self.select_trains(item)
 
-    def _only_tids(self, tids):
+    def _only_tids(self, tids, files=None):
         tids_arr = np.array(tids)
-        # Keep 1 file, even if 0 trains selected.
-        files = [
-            f for f in self.files
-            if f.has_train_ids(tids_arr, self.inc_suspect_trains)
-        ] or [self.files[0]]
+        if files is None:
+            # Keep 1 file, even if 0 trains selected.
+            files = [
+                f for f in self.files
+                if f.has_train_ids(tids_arr, self.inc_suspect_trains)
+            ] or [self.files[0]]
 
         return KeyData(
             self.source,
@@ -232,8 +233,22 @@ class KeyData:
             A maximum number of trains in each part. Parts will often have
             fewer trains than this.
         """
-        for s in split_trains(len(self.train_ids), parts, trains_per_part):
-            yield self.select_trains(s)
+        # tids_files points to the file for each train.
+        # This avoids checking all files for each chunk, which can be slow.
+        tids_files = [None] * len(self.train_ids)
+        tid_to_ix = {t: i for i, t in enumerate(self.train_ids)}
+        for file in self.files:
+            f_tids = file.train_ids if self.inc_suspect_trains else file.valid_train_ids
+            for tid in f_tids:
+                ix = tid_to_ix.get(tid, None)
+                if ix is not None:
+                    tids_files[ix] = file
+
+        for sl in split_trains(len(self.train_ids), parts, trains_per_part):
+            tids = self.train_ids[sl]
+            files = set(tids_files[sl]) - {None}
+            files = sorted(files, key=lambda f: f.filename)
+            yield self._only_tids(tids, files=files)
 
     def data_counts(self, labelled=True):
         """Get a count of data entries in each train.

--- a/extra_data/keydata.py
+++ b/extra_data/keydata.py
@@ -6,7 +6,8 @@ import numpy as np
 from .exceptions import TrainIDError, NoDataError
 from .file_access import FileAccess
 from .read_machinery import (
-    contiguous_regions, DataChunk, select_train_ids, split_trains, roi_shape
+    contiguous_regions, DataChunk, select_train_ids, split_trains, roi_shape,
+    trains_files_index,
 )
 
 class KeyData:
@@ -237,15 +238,9 @@ class KeyData:
         """
         # tids_files points to the file for each train.
         # This avoids checking all files for each chunk, which can be slow.
-        tids_files = [None] * len(self.train_ids)
-        tid_to_ix = {t: i for i, t in enumerate(self.train_ids)}
-        for file in self.files:
-            f_tids = file.train_ids if self.inc_suspect_trains else file.valid_train_ids
-            for tid in f_tids:
-                ix = tid_to_ix.get(tid, None)
-                if ix is not None:
-                    tids_files[ix] = file
-
+        tids_files = trains_files_index(
+            self.train_ids, self.files, self.inc_suspect_trains
+        )
         for sl in split_trains(len(self.train_ids), parts, trains_per_part):
             tids = self.train_ids[sl]
             files = set(tids_files[sl]) - {None}

--- a/extra_data/read_machinery.py
+++ b/extra_data/read_machinery.py
@@ -152,6 +152,18 @@ def split_trains(n_trains, parts=None, trains_per_part=None) -> [slice]:
         for i in range(n_parts)
     ]
 
+def trains_files_index(train_ids, files, inc_suspect_trains=True) -> list:
+    """Make a list of which FileAccess contains each train, used in splitting"""
+    tids_files = [None] * len(train_ids)
+    tid_to_ix = {t: i for i, t in enumerate(train_ids)}
+    for file in files:
+        f_tids = file.train_ids if inc_suspect_trains else file.valid_train_ids
+        for tid in f_tids:
+            ix = tid_to_ix.get(tid, None)
+            if ix is not None:
+                tids_files[ix] = file
+    return tids_files
+
 class DataChunk:
     """Reference to a contiguous chunk of data for one or more trains."""
     def __init__(self, file, dataset_path, first, train_ids, counts):

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -1123,8 +1123,28 @@ class DataCollection:
             A maximum number of trains in each part. Parts will often have
             fewer trains than this.
         """
-        for s in split_trains(len(self.train_ids), parts, trains_per_part):
-            yield self.select_trains(s)
+        for source in self._sources_data.values():
+            assert source.train_ids == self.train_ids
+
+        def dict_zip(iter_d):
+            while True:
+                try:
+                    yield {k: next(v) for (k, v) in iter_d.items()}
+                except StopIteration:
+                    return
+
+        for sources_data_part in dict_zip({
+            n: s.split_trains(parts=parts, trains_per_part=trains_per_part)
+            for (n, s) in self._sources_data.items()
+        }):
+            files = set().union(*[sd.files for sd in sources_data_part.values()])
+            train_ids = list(sources_data_part.values())[0].train_ids
+
+            yield DataCollection(
+                files, sources_data=sources_data_part, train_ids=train_ids,
+                aliases=self._aliases, inc_suspect_trains=self.inc_suspect_trains,
+                is_single_run=self.is_single_run,
+            )
 
     def _check_source_conflicts(self):
         """Check for data with the same source and train ID in different files.

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -1013,12 +1013,11 @@ class DataCollection:
                     else:  # require_any
                         train_ids = np.union1d(train_ids, source_tids)
 
+            train_ids = list(train_ids)  # Convert back to a list.
             sources_data = {
                 src: srcdata._only_tids(train_ids)
                 for src, srcdata in sources_data.items()
             }
-
-            train_ids = list(train_ids)  # Convert back to a list.
 
         else:
             train_ids = self.train_ids

--- a/extra_data/sourcedata.py
+++ b/extra_data/sourcedata.py
@@ -267,8 +267,10 @@ class SourceData:
             files = [
                 f for f in self.files
                 if f.has_train_ids(tids, self.inc_suspect_trains)
-            ] or [self.files[0]]
+            ]
+        if not files:
             # Keep 1 file, even if 0 trains selected, to get keys, dtypes, etc.
+            files = [self.files[0]]
 
         return SourceData(
             self.source,

--- a/extra_data/sourcedata.py
+++ b/extra_data/sourcedata.py
@@ -8,7 +8,9 @@ import h5py
 from .exceptions import MultiRunError, PropertyNameError, NoDataError
 from .file_access import FileAccess
 from .keydata import KeyData
-from .read_machinery import glob_wildcards_re, same_run, select_train_ids, split_trains
+from .read_machinery import (
+    glob_wildcards_re, same_run, select_train_ids, split_trains, trains_files_index
+)
 
 
 class SourceData:
@@ -316,15 +318,9 @@ class SourceData:
         """
         # tids_files points to the file for each train.
         # This avoids checking all files for each chunk, which can be slow.
-        tids_files = [None] * len(self.train_ids)
-        tid_to_ix = {t: i for i, t in enumerate(self.train_ids)}
-        for file in self.files:
-            f_tids = file.train_ids if self.inc_suspect_trains else file.valid_train_ids
-            for tid in f_tids:
-                ix = tid_to_ix.get(tid, None)
-                if ix is not None:
-                    tids_files[ix] = file
-
+        tids_files = trains_files_index(
+            self.train_ids, self.files, self.inc_suspect_trains
+        )
         for sl in split_trains(len(self.train_ids), parts, trains_per_part):
             tids = self.train_ids[sl]
             files = set(tids_files[sl]) - {None}

--- a/extra_data/tests/test_reader_mockdata.py
+++ b/extra_data/tests/test_reader_mockdata.py
@@ -702,6 +702,8 @@ def test_split_trains(mock_fxe_raw_run):
     chunks = list(run.split_trains(3))
     assert len(chunks) == 3
     assert {len(c.train_ids) for c in chunks} == {160}
+    arr = chunks[0]['FXE_XAD_GEC/CAM/CAMERA:daqOutput', 'data.image.dims'].ndarray()
+    assert arr.shape == (160, 2)
 
     chunks = list(run.split_trains(4, trains_per_part=100))
     assert len(chunks) == 5

--- a/extra_data/tests/test_sourcedata.py
+++ b/extra_data/tests/test_sourcedata.py
@@ -111,6 +111,8 @@ def test_split_trains(mock_spb_raw_run):
     chunks = list(xgm.split_trains(3))
     assert len(chunks) == 3
     assert {len(c.train_ids) for c in chunks} == {21, 22}
+    # The middle chunk spans across 2 files
+    assert [len(c.files) for c in chunks] == [1, 2, 1]
 
     chunks = list(xgm.split_trains(3, trains_per_part=20))
     assert len(chunks) == 4


### PR DESCRIPTION
While watching DAMNIT run on p4507, I noticed that `run.split_trains()` was pathologically slow when splitting a long run into many small pieces. Splitting 10k trains into 5k chunks took 8 seconds for a single source, and the 16 LPD modules in a run of 27k trains (45 minutes) took over *7 minutes* to split into 2-train chunks. I took a screenshot to prove to myself I'm not imagining it:

![Screenshot from 2023-10-26 17-18-15](https://github.com/European-XFEL/EXtra-data/assets/327925/634eedcb-f97d-45de-98fe-a5becda41a54)

Profiling revealed the culprit was finding the files that belong to each chunk. For each chunk we were checking for an overlap in each file relevant to that source. For a given chunk size, a longer run means both more files and more chunks, so it's $\mathcal{O}(N^2)$ on the number of trains.

<details>
<summary>Stack dump from py-spy</summary>

```
Thread 67309 (active+gil): "MainThread"
    _unique1d (numpy/lib/arraysetops.py:352)
    unique (numpy/lib/arraysetops.py:274)
    unique (<__array_function__ internals>:200)
    intersect1d (numpy/lib/arraysetops.py:445)
    intersect1d (<__array_function__ internals>:200)
    has_train_ids (extra_data/file_access.py:270)
    <listcomp> (extra_data/sourcedata.py:273)
    _only_tids (extra_data/sourcedata.py:271)
    <dictcomp> (extra_data/reader.py:1094)
    select_trains (extra_data/reader.py:1093)
    split_trains (extra_data/reader.py:1127)
    <listcomp> (analysis_helpers.py:105)
    integrate_run (analysis_helpers.py:105)
    lpd_ai (<string>:126)
    get_default_inputs (damnit_ctx.py:246)
    create (ctxrunner.py:337)
    main (ctxrunner.py:579)
    <module> (ctxrunner.py:603)
    _run_code (runpy.py:87)
    _run_module_as_main (runpy.py:197)
```
</details>

This change creates a temporary index of which file each train belongs to, and uses that to select the relevant files, which is $\mathcal{O}(N)$. This now takes about 16ms for the single source 10k trains example, and about 4 seconds for the 27k trains of LPD data. That's still slower than I might like, but it's much better than it was.

I played around a bit with making the index using NumPy arrays and set operations (e.g. `intersect1d`), but at least for the cases I was testing, the pure-Python approach was somewhat faster, and I find it more readable.

The index obviously uses some extra memory. [`sys.getsizeof`](https://docs.python.org/3/library/sys.html#sys.getsizeof) tells me that for 27k trains, the `tid_to_ix` dict is ~1.3 MiB per source, and `tids_files` about 200 KiB. This seems like an acceptable trade-off.