### PR TITLE
Try to improve coverage measurement

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,8 @@
 [run]
 omit = */tests/*
 concurrency = multiprocessing
+
+[paths]
+source =
+    extra_data/
+    */site-packages/extra_data/


### PR DESCRIPTION
By telling coverage that installed paths are equivalent to source paths ([docs](https://coverage.readthedocs.io/en/7.3.2/config.html#paths)).