### PR TITLE
Expand JUNGFRAU components to accept SCS_HRIXS_JUNGF and DET_LAB_JF

### DIFF
--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -1571,7 +1571,7 @@ class JUNGFRAU(MultimodDetectorBase):
     # HED_IA1_JF500K1/DET/JNGFR01:daqOutput    (e.g. in p 2656, r 230)
     # FXE_XAD_JF1M/DET/RECEIVER-1
     _source_re = re.compile(
-        r'(?P<detname>.+_(JNGFR|JF[14]M|JF500K\d?))/DET/'
+        r'(?P<detname>.+_(JNGFR|JF[14]M|JUNGF|JF|JF500K\d?))/DET/'
         r'(MODULE_|RECEIVER-|JNGFR)(?P<modno>\d+)'
     )
     _main_data_key = 'data.adc'


### PR DESCRIPTION
This addresses the mentioned bug in this issue: https://github.com/European-XFEL/EXtra-data/issues/463

This is the first and fast step to fix the issue faced by pycalibration when correcting data for SCS_HRIXS_JUNGF and DET_LAB_JF.

The error at Jungfrau correction notebook
```
SourceNameError: This data has no source named 'DET_LAB_JF/DET/...'.
See data.all_sources for available sources.
```

I will try to propose a solution to avoid such issues later with new detector names.