### PR TITLE
Allow selecting raw/proc data in components layer

### DIFF
--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -139,7 +139,7 @@ class MultimodDetectorBase:
             raise ValueError("min_modules must be a positive integer, not "
                              f"{min_modules!r}")
 
-        source_to_modno = self._identify_sources(data, detector_name, modules)
+        source_to_modno = self._identify_sources(data, detector_name, modules, raw=raw)
 
         data = data.select([(src, '*') for src in source_to_modno])
         self.detector_name = detector_name

--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -239,7 +239,7 @@ class MultimodDetectorBase:
         detector_names = cls._find_detector_names(data)
         # We want exactly 1 source
         if not detector_names:
-            raise SourceNameError(source_re.pattern)
+            raise SourceNameError(f'{cls._det_name_pat}({cls._source_raw_pat}|{cls._source_corr_pat})')
         elif len(detector_names) > 1:
             names_s = ', '.join(repr(n) for n in sorted(detector_names))
             raise ValueError(

--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -1807,12 +1807,12 @@ class JUNGFRAU(MultimodDetectorBase):
                  *, min_modules=1, n_modules=None, first_modno=1):
         super().__init__(data, detector_name, modules, min_modules=min_modules)
 
-        self.modno_to_source = {}
         # Overwrite modno based on given starting module number and update
         # source_to_modno and modno_to_source.
         # JUNGFRAU modno is expected (e.g. extra_geom) to start with 1.
         self.source_to_modno = {s: (m - first_modno + 1)
                                 for (s, m) in self.source_to_modno.items()}
+        self.modno_to_source = {m: s for (s, m) in self.source_to_modno.items()}
 
         if n_modules is not None:
             self.n_modules = int(n_modules)

--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -269,7 +269,10 @@ class MultimodDetectorBase:
             source_to_modno = dict(cls._source_matches(data, pat))
             if not all(cls._data_is_raw(data, s) for s in source_to_modno):
                 # Older corrected data used the same names as raw
-                raise Exception("Raw data was requested, but only proc data was found")
+                raise ValueError(
+                    f"Raw data was not found: {detector_name}/DET/... sources "
+                    f"are from corrected data"
+                )
 
         else:
             # Prefer corrected data
@@ -282,7 +285,7 @@ class MultimodDetectorBase:
                 source_to_modno = dict(cls._source_matches(data, pat))
 
                 if (raw is False) and any(cls._data_is_raw(data, s) for s in source_to_modno):
-                    raise Exception("Corrected data was requested, but only raw data was found")
+                    raise SourceNameError(f'{detector_name}/CORR/...')
                 # raw=None -> legacy behaviour: prefer corrected but allow raw
 
         if modules is not None:
@@ -290,7 +293,8 @@ class MultimodDetectorBase:
                                if n in modules}
 
         if not source_to_modno:
-            raise SourceNameError(f'{detector_name}/DET/...')
+            dc = '(DET|CORR)' if raw is None else 'DET' if raw else 'CORR'
+            raise SourceNameError(f'{detector_name}/{dc}/...')
 
         return source_to_modno
 

--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -226,7 +226,7 @@ class MultimodDetectorBase:
     def _find_detector_names(cls, data):
         # Find sources matching the pattern for this detector type
         source_re = re.compile(
-            f'({cls._det_name_pat})(?{cls._source_raw_pat}|{cls._source_corr_pat})'
+            f'({cls._det_name_pat})({cls._source_raw_pat}|{cls._source_corr_pat})'
         )
         detector_names = set()
         for source in data.instrument_sources:

--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -224,13 +224,12 @@ class MultimodDetectorBase:
 
     @classmethod
     def _find_detector_names(cls, data):
-        # Find sources matching the pattern for this detector type
-        source_re = re.compile(
-            f'({cls._det_name_pat})({cls._source_raw_pat}|{cls._source_corr_pat})'
-        )
+        # Find sources matching the pattern (raw or proc) for this detector type
+        raw_re  = re.compile(f'({cls._det_name_pat}){cls._source_raw_pat}')
+        corr_re = re.compile(f'({cls._det_name_pat}){cls._source_corr_pat}')
         detector_names = set()
         for source in data.instrument_sources:
-            m = source_re.match(source)
+            m = raw_re.match(source) or corr_re.match(source)
             if m:
                 detector_names.add(m.group(0))
         return detector_names

--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -1804,8 +1804,8 @@ class JUNGFRAU(MultimodDetectorBase):
     module_shape = (512, 1024)
 
     def __init__(self, data: DataCollection, detector_name=None, modules=None,
-                 *, min_modules=1, n_modules=None, first_modno=1):
-        super().__init__(data, detector_name, modules, min_modules=min_modules)
+                 *, min_modules=1, n_modules=None, first_modno=1, raw=None):
+        super().__init__(data, detector_name, modules, min_modules=min_modules, raw=raw)
 
         # Overwrite modno based on given starting module number and update
         # source_to_modno and modno_to_source.
@@ -1817,7 +1817,10 @@ class JUNGFRAU(MultimodDetectorBase):
         if n_modules is not None:
             self.n_modules = int(n_modules)
         else:
-            self.n_modules = max(self.modno_to_source)
+            # Re-scan sources without modules= selection to find largest number
+            self.n_modules = max(
+                self._identify_sources(data, self.detector_name, raw=raw).values()
+            ) - first_modno + 1
 
         # In burst mode, JUNGFRAU can have 16 frames per train
         src = next(iter(self.source_to_modno))

--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -231,7 +231,7 @@ class MultimodDetectorBase:
         for source in data.instrument_sources:
             m = raw_re.match(source) or corr_re.match(source)
             if m:
-                detector_names.add(m.group(0))
+                detector_names.add(m.group(1))
         return detector_names
 
     @classmethod

--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -225,13 +225,12 @@ class MultimodDetectorBase:
     @classmethod
     def _find_detector_names(cls, data):
         # Find sources matching the pattern (raw or proc) for this detector type
-        raw_re  = re.compile(f'({cls._det_name_pat}){cls._source_raw_pat}')
-        corr_re = re.compile(f'({cls._det_name_pat}){cls._source_corr_pat}')
+        raw_re  = re.compile(f'(?P<detname>{cls._det_name_pat}){cls._source_raw_pat}')
+        corr_re = re.compile(f'(?P<detname>{cls._det_name_pat}){cls._source_corr_pat}')
         detector_names = set()
         for source in data.instrument_sources:
-            m = raw_re.match(source) or corr_re.match(source)
-            if m:
-                detector_names.add(m.group(1))
+            if m := raw_re.match(source) or corr_re.match(source):
+                detector_names.add(m['detname'])
         return detector_names
 
     @classmethod

--- a/extra_data/tests/conftest.py
+++ b/extra_data/tests/conftest.py
@@ -159,10 +159,9 @@ def mock_spb_raw_and_proc_run():
 
 
 @pytest.fixture(scope='session')
-def mock_modern_spb_proc_run(format_version):
+def mock_modern_spb_proc_run():
     with TemporaryDirectory() as td:
-        make_examples.make_modern_spb_proc_run(
-            td, format_version=format_version)
+        make_examples.make_modern_spb_proc_run(td)
         yield td
 
 

--- a/extra_data/tests/conftest.py
+++ b/extra_data/tests/conftest.py
@@ -157,6 +157,11 @@ def mock_spb_raw_and_proc_run():
 
         yield td, raw_run_dir, proc_run_dir
 
+@pytest.fixture(scope='session')
+def mock_spb_raw_run_fmt1():
+    with TemporaryDirectory() as td:
+        make_examples.make_spb_run(td, format_version="1.2")
+        yield td
 
 @pytest.fixture(scope='session')
 def mock_modern_spb_proc_run():

--- a/extra_data/tests/make_examples.py
+++ b/extra_data/tests/make_examples.py
@@ -346,13 +346,13 @@ def make_reduced_spb_run(dir_path, raw=True, rng=None, format_version='0.5'):
                format_version=format_version)
 
 
-def make_modern_spb_proc_run(dir_path, format_version='0.5'):
+def make_modern_spb_proc_run(dir_path, format_version='1.2'):
     for modno in range(16):
         path = osp.join(dir_path, f'CORR-R0142-AGIPD{modno:0>2}-S00000.h5')
         write_file(path, [
-            AGIPDModule(f'SPB_DET_AGIPD1M-1/CORR/{modno}CH0', raw=False,
-                         frames_per_train=32,
-                         legacy_name=f'SPB_DET_AGIPD1M-1/DET/{modno}CH0')
+            AGIPDModule(f'SPB_DET_AGIPD1M-1/CORR/{modno}CH0', channel_name='output',
+                        raw=False, frames_per_train=32,
+                        legacy_name=f'SPB_DET_AGIPD1M-1/DET/{modno}CH0')
             ], ntrains=64, chunksize=32, format_version=format_version)
 
 

--- a/extra_data/tests/test_file_access.py
+++ b/extra_data/tests/test_file_access.py
@@ -166,8 +166,8 @@ def test_legacy_sources(mock_modern_spb_proc_run):
 
     # Instrument sources should be a set of both canonical and legacy name.
     assert fa.instrument_sources == {
-        'SPB_DET_AGIPD1M-1/DET/0CH0:xtdf', 'SPB_DET_AGIPD1M-1/CORR/0CH0:xtdf'}
+        'SPB_DET_AGIPD1M-1/DET/0CH0:xtdf', 'SPB_DET_AGIPD1M-1/CORR/0CH0:output'}
 
     # Legacy sources should be a dict mapping to the canonical name.
     assert fa.legacy_sources == {
-        'SPB_DET_AGIPD1M-1/DET/0CH0:xtdf': 'SPB_DET_AGIPD1M-1/CORR/0CH0:xtdf'}
+        'SPB_DET_AGIPD1M-1/DET/0CH0:xtdf': 'SPB_DET_AGIPD1M-1/CORR/0CH0:output'}

--- a/extra_data/tests/test_reader_mockdata.py
+++ b/extra_data/tests/test_reader_mockdata.py
@@ -1153,9 +1153,9 @@ def test_run_metadata_no_trains(mock_scs_run):
 def test_proc_legacy_sources(mock_modern_spb_proc_run):
     run = RunDirectory(mock_modern_spb_proc_run)
 
-    src_pattern = 'SPB_DET_AGIPD1M-1/{}/{}CH0:xtdf'
-    corr_sources = {src_pattern.format('CORR', i) for i in range(16)}
-    det_sources = {src_pattern.format('DET', i) for i in range(16)}
+    src_pattern = 'SPB_DET_AGIPD1M-1/{}/{}CH0:{}'
+    corr_sources = {src_pattern.format('CORR', i, 'output') for i in range(16)}
+    det_sources = {src_pattern.format('DET', i, 'xtdf') for i in range(16)}
 
     # Should contain both canonical and legacy names.
     assert run.all_sources == corr_sources | det_sources
@@ -1169,7 +1169,7 @@ def test_proc_legacy_sources(mock_modern_spb_proc_run):
     assert run.legacy_sources == dict(zip(
         sorted(det_sources), sorted(corr_sources)))
 
-    det_mod0 = src_pattern.format('DET', 0)
+    det_mod0 = src_pattern.format('DET', 0, 'xtdf')
 
     # Classic APIs continue to work as normal, but raise warnings
     # whenever data is accessed through creation of SourceData object.

--- a/extra_data/tests/test_sourcedata.py
+++ b/extra_data/tests/test_sourcedata.py
@@ -297,7 +297,7 @@ def test_legacy_sourcedata(mock_modern_spb_proc_run):
     run = RunDirectory(mock_modern_spb_proc_run)
 
     det_mod0 = 'SPB_DET_AGIPD1M-1/DET/0CH0:xtdf'
-    corr_mod0 = 'SPB_DET_AGIPD1M-1/CORR/0CH0:xtdf'
+    corr_mod0 = 'SPB_DET_AGIPD1M-1/CORR/0CH0:output'
 
     # True (canonical) source works as normal
     sd = run[corr_mod0]


### PR DESCRIPTION
Preparing for the future when raw & proc data has different names.

You can pass `raw=True`, `False` or `None`. The default is `None`, which tries to preserve the legacy behaviour of using proc if possible and raw if not.

Opening a draft PR to try the CI.