### PR TITLE
Validation: clearer info on filesystem errors

### DIFF
--- a/extra_data/tests/test_validation.py
+++ b/extra_data/tests/test_validation.py
@@ -6,7 +6,7 @@ import numpy as np
 from pytest import fixture, raises
 from tempfile import TemporaryDirectory
 
-from extra_data.validation import FileAccess, FileValidator, RunValidator, ValidationError
+from extra_data.validation import FileAccess, FileValidator, RunValidator, ValidationError, main
 from . import make_examples
 
 
@@ -170,3 +170,12 @@ def test_control_data_timestamps(data_aggregator_file):
     assert problem['msg'] == 'Timestamp is decreasing, e.g. at 10 (5 < 10)'
     assert problem['dataset'] == 'CONTROL/SA1_XTD2_XGM/DOOCS/MAIN/pulseEnergy/photonFlux/timestamp'
     assert 'RAW-R0450-DA01-S00001.h5' in problem['file']
+
+
+def test_main_file_non_h5(tmp_path, capsys):
+    not_h5 = tmp_path / 'notHDF5.h5'
+    not_h5.write_text("Accessible file, not HDF5")
+
+    status = main([str(not_h5)])
+    assert status == 1
+    assert 'Could not open HDF5 file' in capsys.readouterr().out

--- a/extra_data/tests/test_validation.py
+++ b/extra_data/tests/test_validation.py
@@ -39,7 +39,7 @@ def test_file_error(mock_fxe_raw_run):
 
     problems = RunValidator(mock_fxe_raw_run).run_checks()
     assert len(problems) == 1
-    assert problems[0]['msg'] == 'Could not open file'
+    assert problems[0]['msg'] == 'Could not access file'
     assert problems[0]['file'] == str(not_readable)
 
 


### PR DESCRIPTION
If opening an HDF5 file fails, see if we can read from it at all. If not, present the OS error in place of the HDF5 error, as HDF5's error messages obscure what's really going wrong.

```
$ python -m extra_data.validation /gpfs/exfel/exp/SPB/202302/p004511/raw/r0011/RAW-R0011-AGIPD02-S00010.h5
Checking file: /gpfs/exfel/exp/SPB/202302/p004511/raw/r0011/RAW-R0011-AGIPD02-S00010.h5

Could not access file
  error: [Errno 5] Input/output error
  file: /gpfs/exfel/exp/SPB/202302/p004511/raw/r0011/RAW-R0011-AGIPD02-S00010.h5
```