### PR TITLE
Update RTD Sphinx search-as-you-type plugin

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,6 +34,7 @@ extensions = [
     'sphinx.ext.napoleon',
     'nbsphinx',
     'sphinxcontrib_github_alt',
+    'sphinx_search.extension',
     # Workaround for sphinx-rtd-theme issue
     # https://github.com/readthedocs/sphinx_rtd_theme/issues/1452
     'sphinxcontrib.jquery',

--- a/docs/requirements-rtd.txt
+++ b/docs/requirements-rtd.txt
@@ -1,3 +1,3 @@
 sphinx==6.1.3
 sphinx_rtd_theme==1.2.0
-readthedocs-sphinx-search==0.2.0
+readthedocs-sphinx-search==0.3.2


### PR DESCRIPTION
RTD sent me an email about a [security issue](https://github.com/readthedocs/readthedocs-sphinx-search/security/advisories/GHSA-xgfm-fjx6-62mj) with the Sphinx search-as-you-type plugin. I don't think it's a big deal in our static docs pages, but may as well update.

I've also added it to the plugins in config, which will hopefully mean we actually get search-as-you-type. :confused: 