### PR TITLE
Catch error calculating run duration from corrupted timestamp

### DIFF
--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -1213,8 +1213,12 @@ class DataCollection:
             first_train = self.train_ids[0]
             last_train = self.train_ids[-1]
             seconds, deciseconds = divmod((last_train - first_train + 1), 10)
-            span_txt = '{}.{}'.format(datetime.timedelta(seconds=seconds),
-                                      int(deciseconds))
+            try:
+                td = datetime.timedelta(seconds=seconds)
+            except OverflowError:  # Can occur if a train ID is corrupted
+                span_txt = "OverflowError"
+            else:
+                span_txt = f'{td}.{int(deciseconds)}'
 
         # disp
         print('# of trains:   ', train_count)

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -1216,7 +1216,7 @@ class DataCollection:
             try:
                 td = datetime.timedelta(seconds=seconds)
             except OverflowError:  # Can occur if a train ID is corrupted
-                span_txt = "OverflowError"
+                span_txt = "OverflowError (one or more train IDs are probably wrong)"
             else:
                 span_txt = f'{td}.{int(deciseconds)}'
 


### PR DESCRIPTION
I'm hoping this is rare enough that just not crashing is sufficient. Here's what it displays for the run we found this on (p900438 r1):

```
# of trains:    358
Duration:       OverflowError
First train ID: 1936707599
Last train ID:  9223372040728191546
```