### PR TITLE
Add warning when select with require_all discards most trains

### DIFF
--- a/extra_data/tests/test_reader_mockdata.py
+++ b/extra_data/tests/test_reader_mockdata.py
@@ -617,6 +617,17 @@ def test_select_require_all(mock_sa3_control_data, select_str):
     assert all([isinstance(x, np.uint64) for x in subrun.train_ids])
 
 
+def test_select_require_all_empty(mock_fxe_raw_run):
+    run = RunDirectory(mock_fxe_raw_run)
+    with pytest.warns(match=r"(\d+)/\1 \(100%\) trains dropped"):
+        sel = run.select([
+            "*_XGM/DOOCS/MAIN:output",
+            "FXE_XAD_GEC/CAM/CAMERA_NODATA:daqOutput"
+        ], require_all=True)
+
+    assert sel.train_ids == []
+
+
 def test_select_require_any(mock_sa3_control_data):
     run = H5File(mock_sa3_control_data)
 


### PR DESCRIPTION
We sometimes see an instrument source which is in the run but has no data for any train. If you `run.select(..., require_all=True)` including such a source, you get a valid selection with 0 trains, which is surprising, and you then have to work out which source cause it.

With this change, the selection will come with a warning like:

```
480/480 trains lost when filtering by FXE_XAD_GEC/CAM/CAMERA_NODATA:daqOutput
```

I've currently made this appear when filtering by a single source drops more than half the trains we had just before. IDK if that's right, e.g. with HED-style experiments where only a very few pulses are important. Another option is to show the warning only if we're deselecting *all* trains.

Naturally we could also make it configurable, but I hope we can have a default that works for 99% of use cases without config.