### PR TITLE
Merge attributes of key group and value dataset for CONTROL keys

### DIFF
--- a/extra_data/keydata.py
+++ b/extra_data/keydata.py
@@ -73,6 +73,16 @@ class KeyData:
                f"for {len(self.train_ids)} trains>"
 
     @property
+    def is_control(self):
+        """Whether this key belongs to a control source."""
+        return self.section == 'CONTROL'
+
+    @property
+    def is_instrument(self):
+        """Whether this key belongs to an instrument source."""
+        return self.section == 'INSTRUMENT'
+
+    @property
     def index_group(self):
         """The part of the key needed to look up index data"""
         if self.section == 'INSTRUMENT':

--- a/extra_data/tests/mockdata/xgm.py
+++ b/extra_data/tests/mockdata/xgm.py
@@ -68,3 +68,18 @@ class XGM(DeviceBase):
         ds.attrs['unitEnum'] = np.array([15], dtype=np.int32)
         ds.attrs['unitName'] = b'joule'
         ds.attrs['unitSymbol'] = b'J'
+
+        # Also annotate a CONTROL key, where attributes are split across
+        # the parent key group and the value dataset.
+        # (The timestamp dataset has its own, but distinct attributes)
+        # Specific examples taken from p5696, r32
+        grp = f[f'CONTROL/{self.device_id}/beamPosition/ixPos']
+        grp.attrs['alias'] = b'IX.POS'
+        grp.attrs['description'] = b'Calculated X position [mm]'
+        grp.attrs['daqPolicy'] = np.array([-1], dtype=np.int32)
+
+        # daqPolicy is intentionally different, the correct schema value
+        # is -1 as above!
+        ds = grp['value']
+        ds.attrs['alias'] = b'IX.POS'
+        ds.attrs['daqPolicy'] = np.array([1], dtype=np.int32)

--- a/extra_data/tests/test_keydata.py
+++ b/extra_data/tests/test_keydata.py
@@ -345,12 +345,23 @@ def test_file_no_trains(run_with_file_no_trains):
 
 def test_attributes(mock_sa3_control_data):
     run = H5File(mock_sa3_control_data)
+
+    # INSTRUMENT key.
     xgm_intensity = run['SA3_XTD10_XGM/XGM/DOOCS:output', 'data.intensityTD']
     attrs = xgm_intensity.attributes()
 
     assert isinstance(attrs, dict)
     assert attrs['metricPrefixName'] == 'micro'
     assert attrs['unitSymbol'] == 'J'
+
+    # CONTROL key.
+    xgm_beampos_x = run['SA3_XTD10_XGM/XGM/DOOCS', 'beamPosition.ixPos']
+    attrs = xgm_beampos_x.attributes()
+
+    assert isinstance(attrs, dict)
+    assert attrs['alias'] == 'IX.POS'
+    assert attrs['description'] == 'Calculated X position [mm]'
+    assert attrs['daqPolicy'][0] == -1
 
 
 def test_units(mock_sa3_control_data):

--- a/extra_data/tests/test_keydata.py
+++ b/extra_data/tests/test_keydata.py
@@ -17,6 +17,7 @@ def test_get_keydata(mock_spb_raw_run):
     am0 = run['SPB_DET_AGIPD1M-1/DET/0CH0:xtdf', 'image.data']
     assert len(am0.files) == 1
     assert am0.section == 'INSTRUMENT'
+    assert am0.is_instrument
     assert am0.entry_shape == (2, 512, 128)
     assert am0.ndim == 4
     assert am0.dtype == np.dtype('u2')
@@ -27,6 +28,7 @@ def test_get_keydata(mock_spb_raw_run):
     xgm_beam_x = run['SPB_XTD9_XGM/DOOCS/MAIN', 'beamPosition.ixPos.value']
     assert len(xgm_beam_x.files) == 2
     assert xgm_beam_x.section == 'CONTROL'
+    assert xgm_beam_x.is_control
     assert xgm_beam_x.entry_shape == ()
     assert xgm_beam_x.ndim == 1
     assert xgm_beam_x.dtype == np.dtype('f4')


### PR DESCRIPTION
Unfortunately I noticed that the HDF attributes mapping to Karabo properties at the time of recording are a bit all over the place in the case of `CONTROL` keys. For example, `SA3_XTD10_XGM/XGM/DOOCS.beamposition.ixPos` for a recent run:

```shell
├21 attributes:
│ ├accessMode: [2]
│ ├alias: 'IX.POS'
│ ├assignment: [0]
│ ├daqPolicy: [-1]
│ ├defaultValue: [-1.]
│ ├description: 'Calculated X position [mm]'
│ ├displayedName: 'X'
│ ├frac: [0]
│ ├leafType: [0]
│ ├metricPrefixEnum: [13]
│ ├metricPrefixName: 'milli'
│ ├metricPrefixSymbol: 'm'
│ ├nodeType: [0]
│ ├requiredAccessLevel: [0]
│ ├sec: [0]
│ ├tags: ['doocs' 'poll']
│ ├tid: [0]
│ ├unitEnum: [2]
│ ├unitName: 'meter'
│ ├unitSymbol: 'm'
│ └valueType: 'FLOAT'
├timestamp	[uint64: 500]
│ └4 attributes:
│   ├daqPolicy: [1]
│   ├frac: [0]
│   ├sec: [0]
│   └tid: [0]
└value	[float32: 500]
  └12 attributes:
    ├alias: 'IX.POS'
    ├daqPolicy: [1]
    ├frac: [0]
    ├metricPrefixEnum: [13]
    ├metricPrefixName: 'milli'
    ├metricPrefixSymbol: 'm'
    ├sec: [0]
    ├tags: ['doocs' 'poll']
    ├tid: [0]
    ├unitEnum: [2]
    ├unitName: 'meter'
    └unitSymbol: 'm'
``` 

After scanning through attributes across a large number of sources, I found:
* In all cases except one (`minSize`, not shown here), the keys on `value` are a true subset of the parent
* Duplicate attributes in `value` either have the same value (e.g. `alias` above) or a wrong, likely constant value (e.g. `daqPolicy`)
* `timestamp` always has exactly the four attributes with exactly those values as shown above

Based on that, this PR merges the attributes on the parent group into those returned from `KeyData.attributes()` for the `value` dataset of a key, specifically overwriting any existing key.