### PR TITLE
Support selecting down DataCollection by SourceData objects

### DIFF
--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -872,6 +872,8 @@ class DataCollection:
                     for src, src_datas in sources_data_multi.items()}
         elif isinstance(selection, DataCollection):
             return self._expand_selection(selection.selection)
+        elif isinstance(selection, SourceData):
+            return {selection.source: selection}
         elif isinstance(selection, KeyData):
             src = selection.source
             return {src: self._sources_data[src].select_keys({selection.key})}
@@ -952,7 +954,7 @@ class DataCollection:
            It's a more precise but less convenient option for code that knows
            exactly what sources and keys it needs.
 
-        4. With an existing DataCollection or KeyData object::
+        4. With an existing DataCollection, SourceData or KeyData object::
 
              # Select the same data contained in another DataCollection
              prev_run.select(sel)

--- a/extra_data/tests/test_reader_mockdata.py
+++ b/extra_data/tests/test_reader_mockdata.py
@@ -595,6 +595,18 @@ def test_select(mock_fxe_raw_run):
     assert sel_by_dc.instrument_sources == sel.instrument_sources
     assert sel_by_dc.train_ids == sel.train_ids
 
+    # Select by SourceData.
+    sd = run['SPB_XTD9_XGM/DOOCS/MAIN'].select_keys('beamPosition.*')
+    sel_by_sd = run.select(sd)
+    assert sel_by_sd.control_sources == {sd.source}
+    assert sel_by_sd.keys_for_source(sd.source) == sd.keys()
+
+    # Select by KeyData.
+    kd = run['SPB_XTD9_XGM/DOOCS/MAIN', 'beamPosition.ixPos']
+    sel_by_kd = run.select(kd)
+    assert sel_by_kd.control_sources == {kd.source}
+    assert sel_by_kd.keys_for_source(kd.source) == {kd.key}
+
 
 @pytest.mark.parametrize(
     'select_str',


### PR DESCRIPTION
Seems like an obvious addition after `SourceData` became a public interface 🤷 

Also adds missing tests for using `KeyData` in this place.