### PR TITLE
Return a copy of the array for detector_key.train_id_coordinates()

### DIFF
--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -752,7 +752,7 @@ class MultimodKeyData:
         return self.det.train_ids
 
     def train_id_coordinates(self):
-        return self.det.train_ids
+        return np.array(self.det.train_ids)
 
     @property
     def modules(self):
@@ -768,7 +768,7 @@ class MultimodKeyData:
 
     @property
     def shape(self):
-        return ((len(self.modno_to_keydata), len(self.train_id_coordinates()))
+        return ((len(self.modno_to_keydata), len(self.det.train_ids))
                 + self._eg_keydata.entry_shape)
 
     @property
@@ -889,6 +889,8 @@ class XtdfImageMultimodKeyData(MultimodKeyData):
         # Only allocate sel_frames array if we need it:
         if not self._all_pulses():
             a = a[self._sel_frames]
+        else:
+            a = a.copy()  # So you can't accidentally modify the internal array
         return a
 
     @property


### PR DESCRIPTION
So that modifying the returned array doesn't affect the internals of the detector data objects.

This also means the `.train_id_coordinates()` method will consistently return a NumPy array - previously for JUNGFRAU it would have been a list. That's technically an API break, but I think the consistency is worth it.

cc @turkot - I spotted this while looking at the code to answer your question.