### PR TITLE
Do not check for monotonic increase of timestamps in validation by default

### DIFF
--- a/extra_data/tests/test_validation.py
+++ b/extra_data/tests/test_validation.py
@@ -165,11 +165,16 @@ def test_control_data_timestamps(data_aggregator_file):
         ts[10] = 5
 
     with raises(ValidationError) as excinfo:
-        FileValidator(FileAccess(data_aggregator_file)).validate()
+        FileValidator(FileAccess(data_aggregator_file), timestamps_should_increase=True).validate()
     problem = excinfo.value.problems.pop()
     assert problem['msg'] == 'Timestamp is decreasing, e.g. at 10 (5 < 10)'
     assert problem['dataset'] == 'CONTROL/SA1_XTD2_XGM/DOOCS/MAIN/pulseEnergy/photonFlux/timestamp'
     assert 'RAW-R0450-DA01-S00001.h5' in problem['file']
+
+    # second, and default case, timestamp order doesn't matter
+    validator = FileValidator(FileAccess(data_aggregator_file))
+    validator.validate()
+    assert len(validator.problems) == 0
 
 
 def test_main_file_non_h5(tmp_path, capsys):

--- a/extra_data/validation.py
+++ b/extra_data/validation.py
@@ -286,14 +286,15 @@ class RunValidator:
             # prevent child processes from receiving KeyboardInterrupt
             signal(SIGINT, SIG_IGN)
 
-        filepaths = [(self.run_dir, fn) for fn in sorted(self.filenames)]
+        check_args = [(self.run_dir, fn, self.timestamps_should_increase) 
+                       for fn in sorted(self.filenames)]
         nfiles = len(self.filenames)
         badfiles = []
         self.progress(0, nfiles, 0, badfiles)
 
         with Pool(initializer=initializer) as pool:
             iterator = pool.imap_unordered(
-                _check_file, filepaths, self.timestamps_should_increase)
+                _check_file, check_args)
             for done, (fname, fa, problems) in enumerate(iterator, start=1):
                 if problems:
                     self.problems.extend(problems)


### PR DESCRIPTION
While train ids should always be monotonically increasing, for timestamps there is no such requirement. A device is free to choose any timestamp for a given train id - they are technically not coupled.

The evolved DAQ in fact by design introduces non-monotonically increasing timestamps whenever "late" data, i.e. data that is outside its finite buffer size is applied on a best effort basis. It will then be applied for latest train still in the buffer onwards, which in this case might have a newer timestamp attached to its data than the late data applied. That means that trains that had already left the buffer can have newer timestamps too.

Consider the following scenario, where train id is the train id of the data, and reference train id, when it was registered on the DAQ. The buffer length of the DAQ is 5

idx| train id | reference train id | p1 | p2|  t1 | t2
-- | -------| ------------------| ----- | ---  | --------- | -----
0  |        42 |                         42   |       1 |   a  |   100  |   100
1  |         46 |                        47   |        3|  no update |      500  |  600
2  |         47 |                        51   |        4|  no update |      600|  no update
3 |          48 |                       53 |         5 |  c |     700 | 700
4 |          45 |                        56  |        2 | b |    400 | 400
5 |          49 |                       53 |         5 |  e |     700 | 800

Here, data with idx:=4 occurred "late". In the DAQ it will be applied best effort, i.e. to the first train still within the buffer, , which in this case would be the train idx:=2, since the train with idx:=1 is already outside the buffer at this point. The file data will thus look like this:

idx| train id | reference train id | p1 | p2|  t1 | t2
-- | -------| ------------------| ----- | ---  | --------- | -----
0  |        42 |                         42   |       1 |   a  |   100  |   100
1  |         46 |                        47   |        3|  a |      500  |  600
2  |         47 |                        51   |        4|  b |      600|  400
3 |          48 |                       53 |         5 |  c |     700 | 700
4 |          49 |                       54 |         5 |  e |     700 | 800

Note how the timestamps now do not monotonically increase.