### PR TITLE
Add data_availability method for multi-module detectors

### DIFF
--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -452,6 +452,14 @@ class MultimodDetectorBase:
         """
         return MPxDetectorTrainIterator(self, require_all=require_all)
 
+    def data_availability(self, module_gaps=False):
+        """Get an array indicating what data is available
+
+        Returns a boolean array (modules, entries), True where a module has data
+        for a given train, False for missing data.
+        """
+        return self[self._main_data_key].data_availability(module_gaps)
+
 
 class XtdfDetectorBase(MultimodDetectorBase):
     """Common machinery for a group of detectors with similar data format

--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -844,6 +844,25 @@ class MultimodKeyData:
 
         return arr
 
+    def data_availability(self, module_gaps=False):
+        """Get an array indicating what data is available
+
+        Returns a boolean array (modules, entries), True where a module has data
+        for a given train, False for missing data.
+        """
+        train_ids = self.train_id_coordinates()
+
+        module_dim = self.det.n_modules if module_gaps else len(self.modno_to_keydata)
+        out = np.zeros((module_dim, len(train_ids)), dtype=np.bool_)
+
+        for i, (modno, kd) in enumerate(sorted(self.modno_to_keydata.items())):
+            mod_ix = (modno - self.det._modnos_start_at) if module_gaps else i
+            for chunk in kd._data_chunks:
+                for tgt_slice, _ in self.det._split_align_chunk(chunk, train_ids):
+                    out[mod_ix, tgt_slice] = True
+
+        return out
+
 
 class XtdfImageMultimodKeyData(MultimodKeyData):
     _sel_frames_cached = None

--- a/extra_data/tests/test_components.py
+++ b/extra_data/tests/test_components.py
@@ -302,6 +302,21 @@ def test_get_dask_array_jungfrau(mock_jungfrau_run):
     np.testing.assert_array_equal(arr.coords['train'], np.arange(10000, 10100))
 
 
+def test_data_availability_lpd_gap(mock_lpd_mini_gap_run):
+    run = RunDirectory(mock_lpd_mini_gap_run)
+    det = LPD1M(run, modules=[0, 1])  # This example just contains 2 modules
+
+    av = det.data_availability()
+    assert av.shape == (2, 50)
+    np.testing.assert_array_equal(av[1, 20:30], False)
+    assert av.sum() == 2 * 50 - 10
+
+    av_gaps = det.data_availability(module_gaps=True)
+    assert av_gaps.shape == (16, 50)
+    np.testing.assert_array_equal(av_gaps[2:], False)
+    assert av_gaps.sum() == 2 * 50 - 10
+
+
 def test_select_trains(mock_fxe_raw_run):
     run = RunDirectory(mock_fxe_raw_run)
     det = LPD1M(run.select_trains(np.s_[:20]))


### PR DESCRIPTION
@turkot this is something we were discussing yesterday.

If you have 200 trains of data with 40 frames per train recorded by an AGIPD-1M detector (for instance), this would give you a (16, 8000) array, with True for frames that are present, and False for any that are missing.

Open questions:

1. It could be the opposite, telling you where data is missing, if we think we'll want that more often. Flipping it with the `~` operator is easy in either case.
2. It could give you results by train (16, 200) with either booleans for present/absent, or counts of how many frames are in the train (the count should be the same across modules, except where it's 0).
3. We could also expose it on the detector object so `agipd.data_availability()` is the same as `agipd['image.data'].data_availability()` (using the `_main_data_key`).