### PR TITLE
Miscellaneous improvements to buffer_shape() method

### DIFF
--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -806,8 +806,6 @@ class MultimodKeyData:
         """Get data as a plain NumPy array with no labels"""
         train_ids = np.asarray(self.det.train_ids)
 
-        module_dim = self.det.n_modules if module_gaps else len(self.modno_to_keydata)
-
         out_shape = self.buffer_shape(module_gaps, roi)
 
         if out is None:

--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -766,10 +766,22 @@ class MultimodKeyData:
     def ndim(self):
         return self._eg_keydata.ndim + 1
 
+    def buffer_shape(self, module_gaps=False, roi=()):
+        """Get the array shape for this data
+
+        If *module_gaps* is True, include space for modules which are missing
+        from the data. *roi* may be a tuple of slices defining a region of
+        interest on the inner dimensions of the data.
+        """
+        module_dim = self.det.n_modules if module_gaps else len(self.modno_to_keydata)
+
+        return ((module_dim, len(self.train_ids))
+                # Shape of 1 frame for 1 module with the ROI applied:
+                + roi_shape(self._eg_keydata.entry_shape, roi))
+
     @property
     def shape(self):
-        return ((len(self.modno_to_keydata), len(self.det.train_ids))
-                + self._eg_keydata.entry_shape)
+        return self.buffer_shape()
 
     @property
     def dimensions(self):
@@ -796,9 +808,7 @@ class MultimodKeyData:
 
         module_dim = self.det.n_modules if module_gaps else len(self.modno_to_keydata)
 
-        out_shape = ((module_dim, len(train_ids))
-                     # Shape of 1 frame for 1 module with the ROI applied:
-                     + roi_shape(self._eg_keydata.entry_shape, roi))
+        out_shape = self.buffer_shape(module_gaps, roi)
 
         if out is None:
             dtype = self._eg_keydata.dtype if astype is None else np.dtype(astype)

--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -881,7 +881,12 @@ class XtdfImageMultimodKeyData(MultimodKeyData):
         interest on the inner dimensions of the data.
         """
         module_dim = self.det.n_modules if module_gaps else len(self.modno_to_keydata)
-        nframes_sel = len(self.train_id_coordinates())
+
+        # len(self.train_id_coordinates()), but avoids allocating extra arrays
+        if self._all_pulses():
+            nframes_sel = len(self.det.train_ids_perframe)
+        else:
+            nframes_sel = int(self._sel_frames.sum())
 
         entry_shape = self._eg_keydata.entry_shape
         if self._extraneous_dim:

--- a/extra_data/tests/test_components.py
+++ b/extra_data/tests/test_components.py
@@ -220,6 +220,11 @@ def test_get_array_jungfrau(mock_jungfrau_run):
     arr = jf.get_array('data.adc', astype=np.float32)
     assert arr.dtype == np.float32
 
+    assert jf['data.adc'].shape == (8, 2, 16, 512, 1024)
+    assert jf['data.adc'].buffer_shape(
+        module_gaps=True, roi=np.s_[:, :25, :35]
+    ) == (8, 2, 16, 25, 35)
+
 
 def test_jungfraus_first_modno(mock_jungfrau_run, mock_fxe_jungfrau_run):
 


### PR DESCRIPTION
While working on #504, I noticed a couple of things to fix about the `.buffer_shape()` method.

- It was only there for XTDF image KeyData objects, but it's useful for other multi-module KeyData.
- It was making unnecessary temporary arrays to calculate the shape (especially since #502)