### PR TITLE
Add pulse_id_coordinates() & train_id_coordinates() for XTDF image data

### DIFF
--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -933,6 +933,14 @@ class XtdfImageMultimodKeyData(MultimodKeyData):
             a = a.copy()  # So you can't accidentally modify the internal array
         return a
 
+    def pulse_id_coordinates(self):
+        """Get an array of pulse IDs per-frame for this data"""
+        return self.det._collect_inner_ids('pulseId')
+
+    def cell_id_coordinates(self):
+        """Get an array of memory cell IDs per-frame for this data"""
+        return self.det._collect_inner_ids('cellId')
+
     @property
     def dimensions(self):
         ndim_inner = self.ndim - 2

--- a/extra_data/tests/test_components.py
+++ b/extra_data/tests/test_components.py
@@ -322,6 +322,30 @@ def test_data_availability_lpd_gap(mock_lpd_mini_gap_run):
     assert av_gaps.sum() == 2 * 50 - 10
 
 
+def test_pulse_id_cell_id(mock_lpd_mini_gap_run):
+    run = RunDirectory(mock_lpd_mini_gap_run)
+    det = LPD1M(run, modules=[0, 1])  # This example just contains 2 modules
+    kd = det['image.data']
+
+    np.testing.assert_array_equal(
+        kd.pulse_id_coordinates(), np.tile(np.arange(10), 5)
+    )
+    np.testing.assert_array_equal(
+        kd.cell_id_coordinates(), np.tile(np.arange(10), 5)
+    )
+
+def test_pulse_id_cell_id_reduced(mock_reduced_spb_proc_run):
+    run = RunDirectory(mock_reduced_spb_proc_run)
+    det = AGIPD1M(run)
+    kd = det['image.data']
+    nframes = kd.shape[1]
+
+    # The selected frames are random, so we don't know precisely the pattern
+    assert kd.train_id_coordinates().shape == (nframes,)
+    assert kd.pulse_id_coordinates().shape == (nframes,)
+    assert kd.cell_id_coordinates().shape == (nframes,)
+
+
 def test_select_trains(mock_fxe_raw_run):
     run = RunDirectory(mock_fxe_raw_run)
     det = LPD1M(run.select_trains(np.s_[:20]))


### PR DESCRIPTION
@turkot I think this was another thing that you requested. I've gone for an API matching the existing `.train_id_coordinates()` method.