### PR TITLE
Add source, key & alias completions for IPython

### DIFF
--- a/extra_data/aliases.py
+++ b/extra_data/aliases.py
@@ -36,6 +36,9 @@ class AliasIndexer:
 
         raise TypeError('expected alias or (source alias, key) tuple')
 
+    def _ipython_key_completions_(self):
+        return list(self.data._aliases.keys())
+
     def __contains__(self, aliased_item):
         try:
             self[aliased_item]

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -265,6 +265,9 @@ class DataCollection:
 
         raise TypeError("Expected data[source] or data[source, key]")
 
+    def _ipython_key_completions_(self):
+        return list(self.all_sources)
+
     def get_entry_shape(self, source, key):
         """Get the shape of a single data entry for the given source & key"""
         return self._get_key_data(source, key).entry_shape

--- a/extra_data/sourcedata.py
+++ b/extra_data/sourcedata.py
@@ -82,6 +82,9 @@ class SourceData:
             inc_suspect_trains=self.inc_suspect_trains,
         )
 
+    def _ipython_key_completions_(self):
+        return list(self.keys(inc_timestamps=False))
+
     def _get_first_source_file(self):
         first_kd = self[self.one_key()]
 


### PR DESCRIPTION
A picture is worth a thousand words:

![image](https://github.com/European-XFEL/EXtra-data/assets/327925/3b5a55d3-6856-4785-81e6-0a2dcb3d8e78)

I've tested all three interactively.

Thanks to @JamesWrigley for reminding me of this hook. It was actually [something](https://github.com/ipython/ipython/pull/9289) that I implemented in IPython. :grin: 