### PR TITLE
Make aliases case-insensitive, and allow - & _ interchangeably

### DIFF
--- a/extra_data/aliases.py
+++ b/extra_data/aliases.py
@@ -10,6 +10,7 @@ class AliasIndexer:
         self.data = data
 
     def _resolve_any_alias(self, alias):
+        alias = alias.lower().replace('_', '-')
         try:
             literal = self.data._aliases[alias]
         except KeyError:

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -575,6 +575,7 @@ class DataCollection:
 
         for aliases in alias_dicts:
             for alias, literal in aliases.items():
+                alias = alias.lower().replace('_', '-')
                 if new_aliases.setdefault(alias, literal) != literal:
                     raise ValueError(f'conflicting alias definition '
                                      f'for {alias}')

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -578,7 +578,8 @@ class DataCollection:
                 alias = alias.lower().replace('_', '-')
                 if new_aliases.setdefault(alias, literal) != literal:
                     raise ValueError(f'conflicting alias definition '
-                                     f'for {alias}')
+                                     f'for {alias} (or {alias.upper()}, '
+                                     f'{alias.replace("-", "_")}, etc.)')
 
         return new_aliases
 

--- a/extra_data/tests/test_aliases.py
+++ b/extra_data/tests/test_aliases.py
@@ -24,6 +24,9 @@ def test_with_aliases(mock_sa3_control_data, mock_sa3_control_aliases):
     # Test whether source alias yields identical SourceData.
     assert run.alias['sa3-xgm'] is run['SA3_XTD10_XGM/XGM/DOOCS']
 
+    # Test alternative capitalisation and _ instead of -
+    assert run.alias['SA3_XGM'] is run['SA3_XTD10_XGM/XGM/DOOCS']
+
     # Test __contains__()
     assert "sa3-xgm" in run.alias
     assert not "sa42-xgm" in run.alias
@@ -80,6 +83,16 @@ def test_with_aliases(mock_sa3_control_data, mock_sa3_control_aliases):
     str(run.alias)
 
 
+def test_alias_clash(mock_sa3_control_data, mock_sa3_control_aliases):
+    run_without_aliases = H5File(mock_sa3_control_data)
+    # The aliases include 'mcp-adc' - test with an equivalent name
+    with pytest.raises(ValueError, match='conflicting alias'):
+        run = run_without_aliases.with_aliases(
+            mock_sa3_control_aliases | {'MCP_ADC': 'SA3_XTD10_MCP/ADC/2'}
+        )
+
+
+
 def test_json_alias_file(mock_sa3_control_data, mock_sa3_control_aliases, tmp_path):
     aliases_path = tmp_path / 'aliases.json'
     aliases_path.write_text('''
@@ -125,7 +138,8 @@ imgfel-frames2: [SA3_XTD10_IMGFEL/CAM/BEAMVIEW2:daqOutput, data.image.pixels]
 imgfel-screen-pos: [SA3_XTD10_IMGFEL/MOTOR/SCREEN, actualPosition]
 imgfel-filter-pos: [SA3_XTD10_IMGFEL/MOTOR/FILTER, actualPosition]
 
-mcp-adc: SA3_XTD10_MCP/ADC/1
+# Will be normalised to mcp-adc
+MCP_ADC: SA3_XTD10_MCP/ADC/1
 mcp-mpod: SA3_XTD10_MCP/MCPS/MPOD
 mcp-voltage: [SA3_XTD10_MCP/MCPS/MPOD, channels.U3.voltage]
 mcp-trace: [SA3_XTD10_MCP/ADC/1:channel_5.output, data.rawData]

--- a/extra_data/tests/test_aliases.py
+++ b/extra_data/tests/test_aliases.py
@@ -87,10 +87,8 @@ def test_alias_clash(mock_sa3_control_data, mock_sa3_control_aliases):
     run_without_aliases = H5File(mock_sa3_control_data)
     # The aliases include 'mcp-adc' - test with an equivalent name
     with pytest.raises(ValueError, match='conflicting alias'):
-        run = run_without_aliases.with_aliases(
-            mock_sa3_control_aliases | {'MCP_ADC': 'SA3_XTD10_MCP/ADC/2'}
-        )
-
+        mock_sa3_control_aliases.update({'MCP_ADC': 'SA3_XTD10_MCP/ADC/2'})
+        run_without_aliases.with_aliases(mock_sa3_control_aliases)
 
 
 def test_json_alias_file(mock_sa3_control_data, mock_sa3_control_aliases, tmp_path):


### PR DESCRIPTION
From the discussion in chat. I'm still open to people saying it's better not to do this, but it was easy enough to implement so we've got a concrete proposal to consider. :slightly_smiling_face: 

The normalised form is lowercase with dashes, e.g. `sa3-xgm`. The tests were already based on this pattern,  so this required fewest changes, and it's also the easiest to type, at least on UK & US keyboards, not requiring the shift key.