### PR TITLE
API to load detector data with mask

### DIFF
--- a/docs/agipd_lpd_data.rst
+++ b/docs/agipd_lpd_data.rst
@@ -31,6 +31,8 @@ DSSC and JUNGFRAU, pulling together the separate modules into a single array.
    arranged along the first axis. So ``det['image.data'].ndarray()`` will
    load all the selected data as a NumPy array.
 
+   .. automethod:: masked_data
+
    .. automethod:: get_array
 
    .. automethod:: get_dask_array
@@ -57,6 +59,8 @@ DSSC and JUNGFRAU, pulling together the separate modules into a single array.
    object similar to a single-source :class:`KeyData`, but with the modules
    arranged along the first axis. So ``jf['data.adc'].ndarray()`` will
    load all the selected data as a NumPy array.
+
+   .. automethod:: masked_data
 
    .. automethod:: get_array
 

--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -196,6 +196,7 @@ class MultimodDetectorBase:
           The replacement value to use for masked data. By default this is NaN.
         """
         key = key or self._main_data_key
+        self[self._mask_data_key]  # Check that the mask is there
         return DetectorMaskedKeyData(
             self, key, mask_key=self._mask_data_key,
             mask_bits=mask_bits, masked_value=masked_value
@@ -527,6 +528,7 @@ class XtdfDetectorBase(MultimodDetectorBase):
         """
         key = key or self._main_data_key
         assert key.startswith('image.')
+        self[self._mask_data_key]  # Check that the mask is there
         return XtdfMaskedKeyData(
             self, key, mask_key=self._mask_data_key,
             mask_bits=mask_bits, masked_value=masked_value

--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -968,6 +968,7 @@ class DetectorMaskedKeyData(MultimodKeyData):
         # Load mask first: it shrinks from 4 bytes/px to 1, so peak memory use
         # is lower than loading it after the data
         mask = self._load_mask(module_gaps=module_gaps)
+        print(mask[0, 0, 0, :35])
 
         data = super().ndarray(module_gaps=module_gaps, **kwargs)
         data[mask] = self._masked_value

--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -982,7 +982,6 @@ class DetectorMaskedKeyData(MultimodKeyData):
         # Load mask first: it shrinks from 4 bytes/px to 1, so peak memory use
         # is lower than loading it after the data
         mask = self._load_mask(module_gaps=module_gaps)
-        print(mask[0, 0, 0, :35])
 
         data = super().ndarray(module_gaps=module_gaps, **kwargs)
         data[mask] = self._masked_value

--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -178,6 +178,23 @@ class MultimodDetectorBase:
         return MultimodKeyData(self, item)
 
     def masked_data(self, key=None, *, mask_bits=None, masked_value=np.nan):
+        """Combine corrected data with the mask in the files
+
+        This provides an interface similar to ``det['data.adc']``, but masking
+        out pixels with the mask from the correction pipeline.
+
+        Parameters
+        ----------
+
+        key: str
+          The data key to look at, by default the main data key of the detector
+          (e.g. 'data.adc').
+        mask_bits: int
+          Bitmask of reasons to exclude pixels. By default, all types of bad
+          pixel are masked out.
+        masked_value: int, float
+          The replacement value to use for masked data. By default this is NaN.
+        """
         key = key or self._main_data_key
         return DetectorMaskedKeyData(
             self, key, mask_key=self._mask_data_key,
@@ -491,6 +508,23 @@ class XtdfDetectorBase(MultimodDetectorBase):
         return super().__getitem__(item)
 
     def masked_data(self, key=None, *, mask_bits=None, masked_value=np.nan):
+        """Combine corrected data with the mask in the files
+
+        This provides an interface similar to ``det['image.data']``, but masking
+        out pixels with the mask from the correction pipeline.
+
+        Parameters
+        ----------
+
+        key: str
+          The data key to look at, by default the main data key of the detector
+          (e.g. 'image.data').
+        mask_bits: int
+          Bitmask of reasons to exclude pixels. By default, all types of bad
+          pixel are masked out.
+        masked_value: int, float
+          The replacement value to use for masked data. By default this is NaN.
+        """
         key = key or self._main_data_key
         assert key.startswith('image.')
         return XtdfMaskedKeyData(
@@ -928,6 +962,7 @@ class DetectorMaskedKeyData(MultimodKeyData):
         )
 
     def ndarray(self, *, module_gaps=False, **kwargs):
+        """Load data into a NumPy array & apply the mask"""
         # Load mask first: it shrinks from 4 bytes/px to 1, so peak memory use
         # is lower than loading it after the data
         mask = _load_mask(self.det[self._mask_key], module_gaps, self._mask_bits)

--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -854,7 +854,8 @@ class MultimodKeyData:
 
     # For select_trains() & split_trains() to work correctly with subclasses
     def _with_selected_det(self, det_selected):
-        kw = self._init_kwargs() | {'det': det_selected}
+        kw = self._init_kwargs()
+        kw.update(det=det_selected)
         return type(self)(**kw)
 
     def select_trains(self, trains):
@@ -946,11 +947,13 @@ class DetectorMaskedKeyData(MultimodKeyData):
         return f"<Masked {self.key!r} detector data for {len(self.modules)} modules>"
 
     def _init_kwargs(self):
-        return super()._init_kwargs() | dict(
+        kw = super()._init_kwargs()
+        kw.update(
             mask_key=self._mask_key,
             mask_bits=self._mask_bits,
             masked_value=self._masked_value,
         )
+        return kw
 
     def _load_mask(self, module_gaps):
         """Load the mask & convert to boolean (True for bad pixels)"""
@@ -982,7 +985,9 @@ class XtdfImageMultimodKeyData(MultimodKeyData):
         self._extraneous_dim = (len(entry_shape) >= 1) and (entry_shape[0] == 1)
 
     def _init_kwargs(self):
-        return super()._init_kwargs() | dict(pulse_sel=self._pulse_sel)
+        kw = super()._init_kwargs()
+        kw.update(pulse_sel=self._pulse_sel)
+        return kw
 
     @property
     def ndim(self):
@@ -1053,7 +1058,8 @@ class XtdfImageMultimodKeyData(MultimodKeyData):
         return ['module', 'train_pulse'] + entry_dims
 
     def select_pulses(self, pulses):
-        kw = self._init_kwargs() | {'pulse_sel': _check_pulse_selection(pulses)}
+        kw = self._init_kwargs()
+        kw.update(pulse_sel=_check_pulse_selection(pulses))
         return type(self)(**kw)
 
     @property

--- a/extra_data/tests/make_examples.py
+++ b/extra_data/tests/make_examples.py
@@ -326,6 +326,12 @@ def make_reduced_spb_run(dir_path, raw=True, rng=None, format_version='0.5'):
                          frames_per_train=frame_counts)
             ], ntrains=64, chunksize=32, format_version=format_version)
 
+        if modno == 9 and not raw:
+            # For testing masked_data
+            with h5py.File(path, 'a') as f:
+                mask_ds = f['INSTRUMENT/SPB_DET_AGIPD1M-1/DET/9CH0:xtdf/image/mask']
+                mask_ds[0, 0, :32] = np.arange(32)
+
     write_file(osp.join(dir_path, '{}-R0238-DA01-S00000.h5'.format(prefix)),
                [ XGM('SA1_XTD2_XGM/DOOCS/MAIN'),
                  XGM('SPB_XTD9_XGM/DOOCS/MAIN'),
@@ -408,6 +414,10 @@ def make_fxe_jungfrau_run(dir_path):
     write_file(path, [
         JUNGFRAUModule(f'FXE_XAD_JF500K/DET/JNGFR03')
     ], ntrains=100, chunksize=1, format_version='1.0')
+    with h5py.File(path, 'a') as f:
+        # For testing masked_data
+        mask_ds = f['INSTRUMENT/FXE_XAD_JF500K/DET/JNGFR03:daqOutput/data/mask']
+        mask_ds[0, 0, 0, :32] = np.arange(32)
 
     write_file(osp.join(dir_path, f'RAW-R0052-JNGFRCTRL00-S00000.h5'), [
         JUNGFRAUControl('FXE_XAD_JF1M/DET/CONTROL'),

--- a/extra_data/tests/test_components.py
+++ b/extra_data/tests/test_components.py
@@ -301,10 +301,10 @@ def test_xtdf_masked_data(mock_reduced_spb_proc_run):
     line0_2mod[1, 1:32] = np.nan
     np.testing.assert_array_equal(arr[:, 0, 0, :], line0_2mod)
 
-    kd = agipd.masked_data(mask_bits=1, masked_value=-1).select_trains(np.s_[:1])
+    kd = agipd.masked_data(mask_bits=[1, 4], masked_value=-1).select_trains(np.s_[:1])
     arr = kd.ndarray()
     line0_2mod = np.zeros((2, 128), dtype=np.float32)
-    line0_2mod[1, 1:32:2] = -1
+    line0_2mod[1, np.nonzero(np.arange(32) & 5)] = -1
     np.testing.assert_array_equal(arr[:, 0, 0, :], line0_2mod)
 
 

--- a/extra_data/tests/test_components.py
+++ b/extra_data/tests/test_components.py
@@ -308,6 +308,14 @@ def test_xtdf_masked_data(mock_reduced_spb_proc_run):
     np.testing.assert_array_equal(arr[:, 0, 0, :], line0_2mod)
 
 
+def test_masked_data_raw_error(mock_fxe_raw_run):
+    run = RunDirectory(mock_fxe_raw_run)
+    lpd = LPD1M(run)
+
+    with pytest.raises(RuntimeError, match="image.mask"):
+        lpd.masked_data()
+
+
 def test_get_dask_array(mock_fxe_raw_run):
     run = RunDirectory(mock_fxe_raw_run)
     det = LPD1M(run)


### PR DESCRIPTION
This continues the KeyData pattern, so you can do:

```python
jf_det.masked_data().select_trains(np.s_[2000:2500]).ndarray()
```

Which is equivalent to:

```python
mask = jf_det['data.mask'].select_trains(np.s_[2000:2500]).ndarray() != 0
imgs = jf_det['data.adc'].select_trains(np.s_[2000:2500]).ndarray()
imgs[mask] = np.nan
```

- [x] Add tests