### PR TITLE
Prevent iteration over a KeyData object

### DIFF
--- a/extra_data/keydata.py
+++ b/extra_data/keydata.py
@@ -209,6 +209,8 @@ class KeyData:
     def __getitem__(self, item):
         return self.select_trains(item)
 
+    __iter__ = None  # Disable iteration
+
     def _only_tids(self, tids, files=None):
         tids_arr = np.array(tids)
         if files is None:

--- a/extra_data/tests/test_keydata.py
+++ b/extra_data/tests/test_keydata.py
@@ -39,6 +39,10 @@ def test_get_keydata(mock_spb_raw_run):
     data = xgm_beam_x.ndarray()
     assert xgm_beam_x.nbytes == data.nbytes
 
+    # Ensure KeyData is not accidentally iterable
+    with pytest.raises(TypeError):
+        iter(xgm_beam_x)
+
 def test_select_trains(mock_spb_raw_run):
     run = RunDirectory(mock_spb_raw_run)
     xgm_beam_x = run['SPB_XTD9_XGM/DOOCS/MAIN', 'beamPosition.ixPos.value']


### PR DESCRIPTION
By adding `__getitem__` we accidentally made KeyData iterable. And in fact it behaved as an infinite iterable, so simply calling `list(kd)` could go into an infinite loop. I ran into this by making a mistake in a DAMNIT context file.

I can imagine we might want it to be iterable at some point, maybe yielding train IDs or data like `.trains()`. But for now, avoiding the infinite loop seems like a useful step.