### PR TITLE
Allow kd[trains] for multi-module KeyData objects

### DIFF
--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -806,6 +806,11 @@ class MultimodKeyData:
     def select_trains(self, trains):
         return self._with_selected_det(self.det.select_trains(trains))
 
+    def __getitem__(self, item):
+        return self.select_trains(item)
+
+    __iter__ = None  # Disable iteration
+
     def split_trains(self, parts=None, trains_per_part=None, frames_per_part=None):
         for det_split in self.det.split_trains(parts, trains_per_part, frames_per_part):
             yield self._with_selected_det(det_split)

--- a/extra_data/tests/test_components.py
+++ b/extra_data/tests/test_components.py
@@ -365,6 +365,20 @@ def test_select_trains(mock_fxe_raw_run):
     assert arr.shape == (16, 2, 128, 256, 256)
 
 
+def test_keydata_select_trains(mock_fxe_raw_run):
+    run = RunDirectory(mock_fxe_raw_run)
+    det = LPD1M(run.select_trains(np.s_[:20]))
+    kd = det['image.data']
+    assert len(kd.train_ids) == 20
+    assert kd.shape == (16, 20 * 128, 256, 256)
+    kd = kd[:3]
+    assert len(kd.train_ids) == 3
+    assert kd.shape == (16, 3 * 128, 256, 256)
+
+    with pytest.raises(TypeError):
+        iter(kd)
+
+
 def test_split_trains(mock_fxe_raw_run):
     run = RunDirectory(mock_fxe_raw_run)
     det = LPD1M(run.select_trains(np.s_[:20]))


### PR DESCRIPTION
Regular KeyData objects allow selecting trains like `xgm_intensity[:100]` . But the objects for multi-module detectors, which generally aim to have a similar API, require something like `lpd_mask.select_trains(np.s_[:100])`. This makes `lpd_mask[:100]` work as well.