### PR TITLE
Prefer newer JSON cache files to older

### DIFF
--- a/extra_data/run_files_map.py
+++ b/extra_data/run_files_map.py
@@ -94,7 +94,17 @@ class RunFilesMap:
         loaded_data = []
         t0 = time.monotonic()
 
+        paths_mtimes = []
+
         for path in self.candidate_paths:
+            try:
+                st = os.stat(path)
+                paths_mtimes.append((path, st.st_mtime))
+            except (FileNotFoundError, PermissionError):
+                pass
+
+        # Try the newest found file (greatest mtime) first
+        for path, _ in sorted(paths_mtimes, key=lambda x: x[1], reverse=True):
             try:
                 with open(path) as f:
                     loaded_data = json.load(f)


### PR DESCRIPTION
The 'run map' JSON cache is used to speed up opening a run when possible, by listing the sources & trains to be found in each file. There are a couple of possible locations for this: it can be inside the run folder, where only privileged processes can write, or in a hidden world-writable folder under proposal scratch. In master, a cache in the run folder is preferred both for reading & writing.

In some cases, the calibration pipeline creates a partial cache file in the run folder, by opening a subset of files with the `include=` parameter. When someone later opens the whole run folder, a complete cache file is written in scratch, but then this is never used, because the one in the run folder takes priority.

This change looks for the newest available run map file when reading.

-----

**Testing**: I was pointed to p5733 r120 as an example. Using the script below, I get a minimum of about 0.4 s to open the run on master, and around 0.1 s on this branch.

Using `strace`, I can also see that it opens 320 `.h5` files on master, and 0 on this branch, because the information is all cached.

```python
import time

from extra_data import open_run

t0 = time.perf_counter()
run = open_run(5733, 120, data='proc')
t1 = time.perf_counter()

print(f"{len(run.train_ids)} trains")
print(f"{t1 - t0:.3f} s to open")
```