### PR TITLE
Fix log to stderr when skipping files due to locality

### DIFF
--- a/extra_data/locality.py
+++ b/extra_data/locality.py
@@ -72,7 +72,7 @@ def lc_match(files, accept=ONDISK):
             filtered.append(path)
         else:
             print(f"Skipping file {path}", file=sys.stderr)
-            print(f"  ({LOCMSG[loc]})", file=sys.stderr)
+            print(f"  ({LOCMSG[code]})", file=sys.stderr)
             
     return filtered
         


### PR DESCRIPTION
Frankly I'm still not sure how we ended up here, but the fix seems fairly straightforward.