### PR TITLE
Add optional index group filter to SourceData.one_key()

### DIFF
--- a/extra_data/sourcedata.py
+++ b/extra_data/sourcedata.py
@@ -96,17 +96,6 @@ class SourceData:
 
         return FileAccess(sample_path)
 
-    def _get_index_group_sample(self, index_group):
-        if self.is_control and not index_group:
-            # Shortcut for CONTROL data.
-            return self.one_key()
-
-        for key in self.keys():
-            if self[key].index_group == index_group:
-                return key
-
-        raise ValueError(f'{index_group} not an index group of this source')
-
     @property
     def storage_class(self):
         if self._first_source_file is ...:
@@ -354,9 +343,8 @@ class SourceData:
         if index_group is None:
             # Collect data counts for a sample key per index group.
             data_counts = {
-                index_group: self[
-                    self._get_index_group_sample(index_group)
-                ].data_counts(labelled=labelled)
+                index_group: self[self.one_key(index_group)].data_counts(
+                    labelled=labelled)
                 for index_group in self.index_groups
             }
 
@@ -367,8 +355,8 @@ class SourceData:
                 return np.stack(list(data_counts.values())).max(axis=0)
 
         else:
-            return self[self._get_index_group_sample(index_group)] \
-                .data_counts(labelled=labelled)
+            return self[self.one_key(index_group)].data_counts(
+                labelled=labelled)
 
     def train_id_coordinates(self, index_group=None):
         """Make an array of train IDs to use alongside data this source.
@@ -395,8 +383,7 @@ class SourceData:
 
             index_group = self.index_groups.pop()
 
-        return self[self._get_index_group_sample(index_group)] \
-            .train_id_coordinates()
+        return self[self.one_key(index_group)].train_id_coordinates()
 
     def run_metadata(self) -> Dict:
         """Get a dictionary of metadata about the run

--- a/extra_data/sourcedata.py
+++ b/extra_data/sourcedata.py
@@ -155,17 +155,28 @@ class SourceData:
         for f in self.files:
             return f.get_keys(self.source)
 
-    def one_key(self):
+    def one_key(self, index_group=None):
         """Get a single (random) key for this source
 
         If you only need a single key, this can be much faster than calling
-        :meth:`keys`.
+        :meth:`keys`. If *index_group* is omitted, the key may be part of
+        any index group.
         """
         if self.sel_keys is not None:
-            return next(iter(self.sel_keys))
+            if index_group is None:
+                return next(iter(self.sel_keys))
+
+            prefix = f'{index_group}.'
+
+            for key in self.sel_keys:
+                if key.startswith(prefix):
+                    return key
+
+            raise ValueError(f'none of the selected keys is part of '
+                             f'`{index_group}`')
 
         for f in self.files:
-            return f.get_one_key(self.source)
+            return f.get_one_key(self.source, index_group)
 
     @property
     def index_groups(self) -> set:

--- a/extra_data/tests/test_sourcedata.py
+++ b/extra_data/tests/test_sourcedata.py
@@ -51,6 +51,18 @@ def test_keys(mock_spb_raw_run):
     xgm_output = run['SPB_XTD9_XGM/DOOCS/MAIN:output']
     assert xgm_output.one_key() in xgm_output.keys()
 
+    # Test one_key() with index group.
+    am0 = run['SPB_DET_AGIPD1M-1/DET/0CH0:xtdf']
+    assert am0.one_key('image').startswith('image.')
+
+    with pytest.raises(ValueError):
+        # Asking for a de-selected index group.
+        assert am0.select_keys('header.*').one_key('image')
+
+    with pytest.raises(ValueError):
+        # Not an index group of this source.
+        assert am0.one_key('data')
+
 
 def test_select_keys(mock_spb_raw_run):
     run = RunDirectory(mock_spb_raw_run)


### PR DESCRIPTION
During the offline data reduction trials, calls to `SourceData._get_index_group_sample()` ended up being a significant performance problem, as the [current implementation](https://github.com/European-XFEL/EXtra-data/blob/1.17.0/extra_data/sourcedata.py#L101) triggers a call to the fairly expensive `SourceData.keys()`.

Initially this was fixed by overwriting this method only within [`exdf-tools`](https://git.xfel.eu/dataAnalysis/exdf-tools/-/commit/0509da5e3fb66965d470186cd189cc54cdd13e01), this MR means to upstream these changes now.

Since the improved implementation is based on `SourceData.one_key()`, I decided to augment this method by an optional keyword argument `index_group` and entirely replace the usage of `_get_index_group_sample()`.

Something I noticed in the implementation is that `FileAccess.get_one_key()` (and in extension `SourceData.one_key()`) may technically return `None` if a source has no keys. While the selection mechanism prevents no keys to be selected, it does not seem to prevent files with key-less sources. I would not expect the current DAQ or calibration to create such files, but it's not impossible for someone external to prepare them. For now I decided to not change any behaviour, but preserve the one from `_get_index_group_sample()` and raise an exception if asking for a non-existing index group. 