### PR TITLE
Add concept of legacy source names

### DIFF
--- a/extra_data/read_machinery.py
+++ b/extra_data/read_machinery.py
@@ -16,7 +16,7 @@ import numpy as np
 log = logging.getLogger(__name__)
 
 DETECTOR_NAMES = {'AGIPD', 'DSSC', 'LPD'}
-DETECTOR_SOURCE_RE = re.compile(r'(.+(?:DET|CORR))/(\d+)CH')
+DETECTOR_SOURCE_RE = re.compile(r'(.+\/(?:DET|CORR))\/(\d+)CH')
 
 DATA_ROOT_DIR = os.environ.get('EXTRA_DATA_DATA_ROOT', '/gpfs/exfel/exp')
 

--- a/extra_data/read_machinery.py
+++ b/extra_data/read_machinery.py
@@ -16,7 +16,7 @@ import numpy as np
 log = logging.getLogger(__name__)
 
 DETECTOR_NAMES = {'AGIPD', 'DSSC', 'LPD'}
-DETECTOR_SOURCE_RE = re.compile(r'(.+)/DET/(\d+)CH')
+DETECTOR_SOURCE_RE = re.compile(r'(.+(?:DET|CORR))/(\d+)CH')
 
 DATA_ROOT_DIR = os.environ.get('EXTRA_DATA_DATA_ROOT', '/gpfs/exfel/exp')
 

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -1394,9 +1394,26 @@ class DataCollection:
         print()
 
         if self.legacy_sources:
+            # Collect legacy souces matching DETECTOR_SOURCE_RE
+            # separately for a condensed view.
+            detector_legacy_sources = defaultdict(set)
+
             print(len(self.legacy_sources), 'legacy source names:')
             for s in sorted(self.legacy_sources.keys()):
-                print(' -', s, '->', self.legacy_sources[s])
+                m = DETECTOR_SOURCE_RE.match(s)
+
+                if m is not None:
+                    detector_legacy_sources[m[1]].add(s)
+                else:
+                    # Only print non-XTDF legacy sources.
+                    print(' -', s, '->', self.legacy_sources[s])
+
+            for legacy_det, legacy_sources in detector_legacy_sources.items():
+                canonical_mod = self.legacy_sources[next(iter(legacy_sources))]
+                canonical_det = DETECTOR_SOURCE_RE.match(canonical_mod)[1]
+
+                print(' -', f'{legacy_det}/*', '->', f'{canonical_det}/*',
+                      f'({len(legacy_sources)})')
             print()
 
     def plot_missing_data(self, min_saved_pct=95, expand_instrument=False):

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -1249,30 +1249,30 @@ class DataCollection:
             # Include summary section for multi-module detectors unless
             # source details are enabled.
 
-            detector_modules = {}
+            sources_by_detector = {}
             for source in self.detector_sources:
                 name, modno = DETECTOR_SOURCE_RE.match(source).groups((1, 2))
-                detector_modules[(name, modno)] = source
+                sources_by_detector.setdefault(name, {})[modno] = source
 
-            # A run should only have one detector, but if that changes, don't hide it
-            detector_name = ','.join(sorted(set(k[0] for k in detector_modules)))
+            for detector_name in sorted(sources_by_detector.keys()):
+                detector_modules = sources_by_detector[detector_name]
 
-            print("{} XTDF detector modules ({})".format(
-                len(self.detector_sources), detector_name
-            ))
-            if len(detector_modules) > 0:
-                # Show detail on the first module (the others should be similar)
-                mod_key = sorted(detector_modules)[0]
-                mod_source = detector_modules[mod_key]
-                dinfo = self.detector_info(mod_source)
-                module = ' '.join(mod_key)
-                dims = ' x '.join(str(d) for d in dinfo['dims'])
-                print("  e.g. module {} : {} pixels".format(module, dims))
-                print("  {}".format(mod_source))
-                print("  {} frames per train, up to {} frames total".format(
-                    dinfo['frames_per_train'], dinfo['total_frames']
+                print("{} XTDF detector modules of {}/*".format(
+                    len(detector_modules), detector_name
                 ))
-            print()
+                if len(detector_modules) > 0:
+                    # Show detail on the first module (the others should be similar)
+                    mod_key = sorted(detector_modules)[0]
+                    mod_source = detector_modules[mod_key]
+                    dinfo = self.detector_info(mod_source)
+                    module = ' '.join(mod_key)
+                    dims = ' x '.join(str(d) for d in dinfo['dims'])
+                    print("  e.g. module {} : {} pixels".format(module, dims))
+                    print("  {}".format(mod_source))
+                    print("  {} frames per train, up to {} frames total".format(
+                        dinfo['frames_per_train'], dinfo['total_frames']
+                    ))
+                print()
 
         # Invert aliases for faster lookup.
         src_aliases = defaultdict(set)

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -109,7 +109,7 @@ class DataCollection:
                     train_ids=train_ids,
                     files=files,
                     section=section,
-                    legacy=legacy_sources.get(src, None),
+                    canonical_name=legacy_sources.get(src, src),
                     is_single_run=self.is_single_run,
                     inc_suspect_trains=self.inc_suspect_trains
                 )
@@ -131,8 +131,8 @@ class DataCollection:
             if sd.section == 'INSTRUMENT'
         })
         self.legacy_sources = {
-            name: sd.legacy for (name, sd) in self._sources_data.items()
-            if sd.legacy is not None
+            name: sd.canonical_name for (name, sd)
+            in self._sources_data.items() if sd.is_legacy
         }
 
     @staticmethod

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -267,7 +267,7 @@ class DataCollection:
 
         if sd.is_legacy:
             warn(f"{source} is a legacy name for {self.legacy_sources[source]}. "
-                 f"Access via this name will be removed at a future data.",
+                 f"Access via this name will be removed for future data.",
                  DeprecationWarning,
                  stacklevel=3)
 

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -299,7 +299,8 @@ class DataCollection:
             if file is None:
                 return True
 
-        for source in self.instrument_sources:
+        # No need to evaluate this for legacy sources as well.
+        for source in self.instrument_sources - self.legacy_sources.keys():
             file, pos = self._find_data(source, tid)
             if file is None:
                 return True

--- a/extra_data/sourcedata.py
+++ b/extra_data/sourcedata.py
@@ -22,14 +22,15 @@ class SourceData:
     _first_source_file = ...
 
     def __init__(
-            self, source, *, sel_keys, train_ids, files, section,
-            is_single_run, inc_suspect_trains=True
+            self, source, *, sel_keys, train_ids, files, section, legacy,
+            is_single_run, inc_suspect_trains=True,
     ):
         self.source = source
         self.sel_keys = sel_keys
         self.train_ids = train_ids
         self.files: List[FileAccess] = files
         self.section = section
+        self.legacy = legacy
         self.is_single_run = is_single_run
         self.inc_suspect_trains = inc_suspect_trains
 
@@ -46,6 +47,11 @@ class SourceData:
     def is_instrument(self):
         """Whether this source is an instrument source."""
         return self.section == 'INSTRUMENT'
+
+    @property
+    def is_legacy(self):
+        """Whether this source is a legacy name for another source."""
+        return self.legacy is not None
 
     def _has_exact_key(self, key):
         if self.sel_keys is not None:
@@ -258,6 +264,7 @@ class SourceData:
             train_ids=self.train_ids,
             files=self.files,
             section=self.section,
+            legacy=self.legacy,
             is_single_run=self.is_single_run,
             inc_suspect_trains=self.inc_suspect_trains
         )
@@ -283,6 +290,7 @@ class SourceData:
             train_ids=tids,
             files=files,
             section=self.section,
+            legacy=self.legacy,
             is_single_run=self.is_single_run,
             inc_suspect_trains=self.inc_suspect_trains
         )
@@ -481,6 +489,7 @@ class SourceData:
             train_ids=sorted(train_ids),
             files=sorted(files, key=lambda f: f.filename),
             section=self.section,
+            legacy=self.legacy,
             is_single_run=same_run(self, *others),
             inc_suspect_trains=self.inc_suspect_trains
         )

--- a/extra_data/sourcedata.py
+++ b/extra_data/sourcedata.py
@@ -22,15 +22,15 @@ class SourceData:
     _first_source_file = ...
 
     def __init__(
-            self, source, *, sel_keys, train_ids, files, section, legacy,
-            is_single_run, inc_suspect_trains=True,
+            self, source, *, sel_keys, train_ids, files, section,
+            canonical_name, is_single_run, inc_suspect_trains=True,
     ):
         self.source = source
         self.sel_keys = sel_keys
         self.train_ids = train_ids
         self.files: List[FileAccess] = files
         self.section = section
-        self.legacy = legacy
+        self.canonical_name = canonical_name
         self.is_single_run = is_single_run
         self.inc_suspect_trains = inc_suspect_trains
 
@@ -51,7 +51,7 @@ class SourceData:
     @property
     def is_legacy(self):
         """Whether this source is a legacy name for another source."""
-        return self.legacy is not None
+        return self.canonical_name != self.source
 
     def _has_exact_key(self, key):
         if self.sel_keys is not None:
@@ -264,7 +264,7 @@ class SourceData:
             train_ids=self.train_ids,
             files=self.files,
             section=self.section,
-            legacy=self.legacy,
+            canonical_name=self.canonical_name,
             is_single_run=self.is_single_run,
             inc_suspect_trains=self.inc_suspect_trains
         )
@@ -290,7 +290,7 @@ class SourceData:
             train_ids=tids,
             files=files,
             section=self.section,
-            legacy=self.legacy,
+            canonical_name=self.canonical_name,
             is_single_run=self.is_single_run,
             inc_suspect_trains=self.inc_suspect_trains
         )
@@ -489,7 +489,7 @@ class SourceData:
             train_ids=sorted(train_ids),
             files=sorted(files, key=lambda f: f.filename),
             section=self.section,
-            legacy=self.legacy,
+            canonical_name=self.canonical_name,
             is_single_run=same_run(self, *others),
             inc_suspect_trains=self.inc_suspect_trains
         )

--- a/extra_data/tests/conftest.py
+++ b/extra_data/tests/conftest.py
@@ -159,6 +159,14 @@ def mock_spb_raw_and_proc_run():
 
 
 @pytest.fixture(scope='session')
+def mock_modern_spb_proc_run(format_version):
+    with TemporaryDirectory() as td:
+        make_examples.make_modern_spb_proc_run(
+            td, format_version=format_version)
+        yield td
+
+
+@pytest.fixture(scope='session')
 def mock_jungfrau_run():
     with TemporaryDirectory() as td:
         make_examples.make_jungfrau_run(td)

--- a/extra_data/tests/make_examples.py
+++ b/extra_data/tests/make_examples.py
@@ -346,6 +346,16 @@ def make_reduced_spb_run(dir_path, raw=True, rng=None, format_version='0.5'):
                format_version=format_version)
 
 
+def make_modern_spb_proc_run(dir_path, format_version='0.5'):
+    for modno in range(16):
+        path = osp.join(dir_path, f'CORR-R0142-AGIPD{modno:0>2}-S00000.h5')
+        write_file(path, [
+            AGIPDModule(f'SPB_DET_AGIPD1M-1/CORR/{modno}CH0', raw=False,
+                         frames_per_train=32,
+                         legacy_name=f'SPB_DET_AGIPD1M-1/DET/{modno}CH0')
+            ], ntrains=64, chunksize=32, format_version=format_version)
+
+
 def make_agipd1m_run(
     dir_path,
     rep_rate=True,

--- a/extra_data/tests/test_file_access.py
+++ b/extra_data/tests/test_file_access.py
@@ -152,3 +152,20 @@ def test_one_key(mock_spb_raw_run, source, index_group):
 
     # Test with use of _known_keys.
     assert fa.get_one_key(source, index_group) == single_key
+
+
+def test_legacy_sources(mock_modern_spb_proc_run):
+    # Get FileAccess for first module.
+    fa = sorted(RunDirectory(mock_modern_spb_proc_run).files,
+                key=lambda fa: fa.filename)[0]
+
+    # There should be no control source.
+    assert not fa.control_sources
+
+    # Instrument sources should be a set of both canonical and legacy name.
+    assert fa.instrument_sources == {
+        'SPB_DET_AGIPD1M-1/DET/0CH0:xtdf', 'SPB_DET_AGIPD1M-1/CORR/0CH0:xtdf'}
+
+    # Legacy sources should be a dict mapping to the canonical name.
+    assert fa.legacy_sources == {
+        'SPB_DET_AGIPD1M-1/DET/0CH0:xtdf': 'SPB_DET_AGIPD1M-1/CORR/0CH0:xtdf'}

--- a/extra_data/tests/test_sourcedata.py
+++ b/extra_data/tests/test_sourcedata.py
@@ -291,3 +291,23 @@ def test_train_id_coordinates(mock_reduced_spb_proc_run):
     # Should fail due to multiple index groups with differing counts.
     with pytest.raises(ValueError):
         am0.train_id_coordinates()
+
+
+def test_legacy_sourcedata(mock_modern_spb_proc_run):
+    run = RunDirectory(mock_modern_spb_proc_run)
+
+    det_mod0 = 'SPB_DET_AGIPD1M-1/DET/0CH0:xtdf'
+    corr_mod0 = 'SPB_DET_AGIPD1M-1/CORR/0CH0:xtdf'
+
+    # True (canonical) source works as normal
+    sd = run[corr_mod0]
+    assert sd.canonical_name == corr_mod0
+    assert not sd.is_legacy
+
+    # Obtaining SourceData object via legacy name emits a warning.
+    with pytest.warns(DeprecationWarning):
+        sd = run[det_mod0]
+
+    assert sd.source == det_mod0
+    assert sd.canonical_name == corr_mod0
+    assert sd.is_legacy


### PR DESCRIPTION
The calibration team wants to discontinue the practice of writing corrected data under the same source name as raw data, but instead switch the _type_ part of the source name from `DET` to `CORR`. For limited backwards compatibility, we aim to [insert soft links](https://git.xfel.eu/calibration/pycalibration/-/merge_requests/872/) under the old source name in corrected files. While this would work transparently in EXtra-data, some more support for this concept seems prudent, which I'd like to start with this MR.

It introduces the concept of _legacy sources_ throughout the `FileAccess`, `DataCollection` and `SourceData` APIs. For now I limited this solely to tracking, i.e. it has no impact on any business logic when accessing files or data:

* When reading sources, `FileAccess` will probe the source's leaf object for being a soft link and record its target. The source is counted as a regular source otherwise. For performance reasons, I limited this to `INSTRUMENT` sources for now (simple benchmarking suggests tens of ms for this operation when cold)
* Legacy sources are part of the `run_files_map` and will invalidate any existing cache.
* `SourceData` objects know whether they're a legacy source through a non-`None` value of `SourceData.legacy`, `DataCollection` has a `legacy_sources: dict` property.
* When accessing the `SourceData` object of a legacy source via a `DataCollection`, a `DeprecationWarning` is emitted.
* `DataCollection.info()` tracks legacy sources separately in their own section alongside their target.

For now it does not yet touch `data='all'`, which will still kick out the raw data. I would add tests once we're happy with the design.

As part of some earlier tests, I also added support for multiple XTDF detectors in a single `DataCollection`. I'm happy to remove this, but it seems useful to have for the future (e.g. AGIPD1M and AGIPD4M in a single run).

@takluyver @tmichela @dgoeries 