### PR TITLE
Require Python >= 3.8

### DIFF
--- a/.github/dependabot/constraints.txt
+++ b/.github/dependabot/constraints.txt
@@ -1,5 +1,5 @@
 cloudpickle<=3.0.0
-coverage==6.2
+coverage==6.5
 h5py<3.12.0
 karabo-bridge==0.7.0
 msgpack<=1.0.8

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - name: Checkout

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,8 @@ jobs:
         MPLBACKEND: agg
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+      # This specific version uses Node 20 - see codecov-action#1293
+      uses: codecov/codecov-action@v3.1.5
 
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
 
     - name: Test with pytest
       run: |
-        python3 -m pytest -v --nbval-lax --current-env --cov=extra_data --cov-report=xml
+        python3 -m pytest -v --nbval-lax --nbval-current-env --cov=extra_data --cov-report=xml
       env:
         MPLBACKEND: agg
 

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ setup(name="EXtra-data",
               'testpath',
           ]
       },
-      python_requires='>=3.6',
+      python_requires='>=3.8',
       classifiers=[
           'Development Status :: 5 - Production/Stable',
           'Environment :: Console',


### PR DESCRIPTION
This is still fairly conservative, but we're still using 3.8 for offline calibration at present, so I don't want to make extra work for ourselves if updating that gets held up.