### PR TITLE
Fix handling of empty string as index group for control sources

### DIFF
--- a/extra_data/file_access.py
+++ b/extra_data/file_access.py
@@ -471,7 +471,7 @@ class FileAccess(metaclass=MetaFileAccess):
         """Similar to get_keys(), except it returns only a single key for performance"""
 
         # Use empty prefix if no index group filter is active.
-        prefix = index_group + '.' if index_group is not None else ''
+        prefix = index_group + '.' if index_group else ''
 
         if source in self._keys_cache:
             for key in self._keys_cache[source]:
@@ -497,7 +497,7 @@ class FileAccess(metaclass=MetaFileAccess):
 
         group = f'/{root}/{source}'
 
-        if index_group is not None:
+        if index_group:
             group += '/' + index_group
 
         def get_key(subkey, value):

--- a/extra_data/tests/test_file_access.py
+++ b/extra_data/tests/test_file_access.py
@@ -121,9 +121,10 @@ def test_no_metadata(mock_no_metadata_file):
 @pytest.mark.parametrize(
     ['source', 'index_group'],
     [('SPB_XTD9_XGM/DOOCS/MAIN', None),
+     ('SPB_XTD9_XGM/DOOCS/MAIN', ''),
      ('SPB_DET_AGIPD1M-1/DET/4CH0:xtdf', None),
      ('SPB_DET_AGIPD1M-1/DET/4CH0:xtdf', 'image')],
-    ids=['control', 'instrument-*', 'instrument-image'])
+    ids=['control-None', 'control-empty', 'instrument-*', 'instrument-image'])
 def test_one_key(mock_spb_raw_run, source, index_group):
     # Get first file of the chosen source.
     fa = RunDirectory(mock_spb_raw_run)[source].files[0]


### PR DESCRIPTION
I introduced a bug in https://github.com/European-XFEL/EXtra-data/pull/526 when one calls `fa.get_one_key(<ctrl-src>, '')`, which is actually done by `SourceData.data_counts()`. As the test is only done for `index_group is not None`, an empty string causes `prefix` to be `.`.

I'm still slightly confused why the `test_sourcedata.test_data_counts_values()` does not trigger it, yet I can consistently trigger it by the added test case for `FileAccess`.