### PR TITLE
Return train timestamps in local (i.e., EuXFEL) time not just UTC

### DIFF
--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -1605,7 +1605,7 @@ class DataCollection:
         print('\tControls')
         [print('\t-', d) for d in sorted(ctrl)] or print('\t-')
 
-    def train_timestamps(self, local_time=True, labelled=False):
+    def train_timestamps(self, local_time=False, labelled=False):
         """Get approximate timestamps for each train
 
         Timestamps are stored and returned in UTC (not local time).
@@ -1613,8 +1613,9 @@ class DataCollection:
         and the returned data in those cases will have the special value NaT
         (Not a Time).
 
-        If *local_time* is True (default), the timestamps are converted from
-        the UTC timezone to Europe/Berlin (XFEL) timezone.
+        If *local_time* is True, the timestamps are converted from
+        the UTC timezone to Europe/Berlin (XFEL) timezone. By default,
+        *local_time* is set to False.
 
         If *labelled* is True, they are returned in a pandas series, labelled
         with train IDs. If False (default), they are returned in a NumPy array

--- a/extra_data/tests/test_reader_mockdata.py
+++ b/extra_data/tests/test_reader_mockdata.py
@@ -764,6 +764,21 @@ def test_train_timestamps_nat(mock_fxe_control_data):
         assert not np.any(np.isnat(tss))
 
 
+def test_train_timestamps_local_time(mock_scs_run):
+    run = RunDirectory(mock_scs_run)
+    tss_loc = run.train_timestamps(local_time=True, labelled=False)
+    tss_utc = run.train_timestamps(local_time=False, labelled=False)
+    mask = np.logical_not(np.isnat(tss_utc))
+    # Same tests as above to check that nothing strange happens during
+    # the conversion since it involves numpy -> pandas -> numpy
+    assert isinstance(tss_loc, np.ndarray)
+    assert tss_loc.shape == (len(run.train_ids),)
+    assert tss_loc.dtype == np.dtype('datetime64[ns]')
+    # Now check that the conversion was successful
+    delta_t = (tss_loc[mask] - tss_utc[mask]) / np.timedelta64(1, 'h')
+    assert np.all(delta_t == 2)
+
+
 def test_union(mock_fxe_raw_run):
     run = RunDirectory(mock_fxe_raw_run)
 


### PR DESCRIPTION
Added a non-positional boolean argument `local_time=False/True` that returns the time in the `Europe/Berlin` timezone.