### PR TITLE
Ignore incomplete entries in JSON 'run files map' caches

### DIFF
--- a/extra_data/file_access.py
+++ b/extra_data/file_access.py
@@ -146,8 +146,8 @@ class FileAccess(metaclass=MetaFileAccess):
             self.train_ids = _cache_info['train_ids']
             self.control_sources = _cache_info['control_sources']
             self.instrument_sources = _cache_info['instrument_sources']
-            self.legacy_sources = _cache_info.get('legacy_sources', {})
-            self.validity_flag = _cache_info.get('flag', None)
+            self.legacy_sources = _cache_info['legacy_sources']
+            self.validity_flag = _cache_info['flag']
         else:
             try:
                 tid_data = self.file['INDEX/trainId'][:]

--- a/extra_data/run_files_map.py
+++ b/extra_data/run_files_map.py
@@ -136,14 +136,13 @@ class RunFilesMap:
             dt = time.monotonic() - t0
             log.debug("Loaded cached files map in %.2g s", dt)
 
-    @staticmethod
-    def _cache_info_valid(info, file_stat: os.stat_result):
+    @classmethod
+    def _cache_info_valid(cls, info, file_stat: os.stat_result):
         # Ignore the cached info if the file size or mtime have changed, or
-        # if it is missing expected keys (likely
-        added_keys = {'suspect_train_indices', 'legacy_sources'}
+        # if it is missing expected keys (likely keys added more recently).
         return ((file_stat.st_mtime == info['mtime'])
                 and (file_stat.st_size == info['size'])
-                and added_keys.issubset(info.keys()))
+                and cls.expected_cache_keys.issubset(info.keys()))
 
     def is_my_directory(self, dir_path):
         return osp.samestat(os.stat(dir_path), self.dir_stat)

--- a/extra_data/tests/test_file_access.py
+++ b/extra_data/tests/test_file_access.py
@@ -69,7 +69,8 @@ _empty_cache_info = dict(
     train_ids= np.zeros(0, dtype=np.uint64),
     control_sources=frozenset(),
     instrument_sources=frozenset(),
-    flag=np.zeros(0, dtype=np.int32)
+    flag=np.zeros(0, dtype=np.int32),
+    legacy_sources={},
 )
 
 


### PR DESCRIPTION
There was a bug in `FileAccess` where if we read a valid run files map without `legacy_sources`, it wouldn't look at the files to identify legacy_sources.

We have tried to be clever, by using the available information from the cache in such cases and getting the new information from the files. This has some performance benefit, because you read less from the files, but it means more complexity, creating bugs like this one. And we still have to open every file to read something from it.

So I think we should go with the simpler option, ignoring incomplete cache entries entirely, even if that is a bit slower.

[We should also extend it to allow caching runs from the `red` folder into scratch, but that's a separate question]

cc @turkot @philsmt 