### PR TITLE
allow caching "open" run folders to scratch

### DIFF
--- a/extra_data/run_files_map.py
+++ b/extra_data/run_files_map.py
@@ -60,12 +60,12 @@ class RunFilesMap:
         #   /gpfs/exfel/exp/inst/cycle/prop/(raw|proc)/run
         maxwell_match = re.match(
             #     raw/proc  instr  cycle prop   run
-            r'.+/(raw|proc|red)/(\w+)/(\w+)/(p\d+)/(r\d+)/?$',
+            r'.+/(raw|proc|red|open)/(\w+)/(\w+)/(p\d+)/(r\d+)/?$',
             os.path.realpath(directory)
         )
         online_match = re.match(
             #     instr cycle prop   raw/proc   run
-            r'^.+/(\w+)/(\w+)/(p\d+)/(raw|proc|red)/(r\d+)/?$',
+            r'^.+/(\w+)/(\w+)/(p\d+)/(raw|proc)/(r\d+)/?$',
             os.path.realpath(directory)
         )
 


### PR DESCRIPTION
@philsmt pointed out that `open` should be there as well.