### PR TITLE
Return timezone-aware values from train_timestamps() where possible.

### DIFF
--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -1608,7 +1608,7 @@ class DataCollection:
     def train_timestamps(self, labelled=False, *, pydatetime=False, euxfel_local_time=False):
         """Get approximate timestamps for each train
 
-        Timestamps are stored and returned in UTC (not local time).
+        Timestamps are stored and returned in UTC by default.
         Older files (before format version 1.0) do not have timestamp data,
         and the returned data in those cases will have the special value NaT
         (Not a Time).
@@ -1618,6 +1618,9 @@ class DataCollection:
         objects (truncated to microseconds) is returned, the same length as
         data.train_ids. Otherwise (by default), timestamps are returned as a
         NumPy array with datetime64 dtype.
+
+        *euxfel_local_time* can be True when either *labelled* or *pydatetime* is True.
+        In this case, timestamps are converted to the `Europe/Berlin` timezone.
         """
         arr = np.zeros(len(self.train_ids), dtype=np.uint64)
         id_to_ix = {tid: i for (i, tid) in enumerate(self.train_ids)}
@@ -1661,7 +1664,7 @@ class DataCollection:
         elif euxfel_local_time:
             raise ValueError(
                 'The euxfel_local_time option '
-                + 'can only be invoked if either labelled or pydatetime '
+                + 'can only be used if either labelled or pydatetime '
                 + 'are set to True'
             )
         return arr

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -1642,7 +1642,7 @@ class DataCollection:
         arr[arr == epoch] = 'NaT'  # Not a Time
         if labelled:
             import pandas as pd
-            return pd.Series(arr, index=self.train_ids)
+            return pd.Series(arr, index=self.train_ids).dt.tz_localize('UTC')
         return arr
 
     def run_metadata(self) -> dict:

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -1659,9 +1659,11 @@ class DataCollection:
                 res.append(pydt)
             return res
         elif euxfel_local_time:
-            raise ValueError("The euxfel_local_time option '+\
-                'can only be invoked if either labelled or pydatetime '+\
-                'are set to True")
+            raise ValueError(
+                'The euxfel_local_time option '
+                + 'can only be invoked if either labelled or pydatetime '
+                + 'are set to True'
+            )
         return arr
 
     def run_metadata(self) -> dict:

--- a/extra_data/tests/test_reader_mockdata.py
+++ b/extra_data/tests/test_reader_mockdata.py
@@ -784,8 +784,7 @@ def test_train_timestamps_local_time(mock_scs_run):
     # Finally, check that ValueError is raised if euxfel_local_time is used
     # on its own
     with pytest.raises(ValueError):
-        run.train_timestamps(pydatetime=False, euxfel_local_time=True)
-        run.train_timestamps(labelled=False, euxfel_local_time=True)
+        run.train_timestamps(pydatetime=False, labelled=False, euxfel_local_time=True)
 
 
 def test_train_timestamps_nat(mock_fxe_control_data):

--- a/extra_data/tests/test_reader_mockdata.py
+++ b/extra_data/tests/test_reader_mockdata.py
@@ -761,7 +761,7 @@ def test_train_timestamps_local_time(mock_scs_run):
 
     del1h = timedelta(hours=1)
     del2h = timedelta(hours=2)
-      
+
     # First, the pydatetime case
     tss = run.train_timestamps(pydatetime=True)
     tss_berlin = run.train_timestamps(pydatetime=True, euxfel_local_time=True)
@@ -769,18 +769,17 @@ def test_train_timestamps_local_time(mock_scs_run):
     # The time difference between UTC and Europe/Berlin can only be
     # one or two hours depending on daylight savings
     assert all(
-        t2.replace(tzinfo=None) - t1.replace(tzinfo=None) == del1h or
-        t2.replace(tzinfo=None) - t1.replace(tzinfo=None) == del2h
-        for t1, t2, in zip(tss, tss_berlin)
+        t1.utcoffset() == del1h or t1.utcoffset() == del2h
+        for t1 in tss_berlin
     )
 
     # Second, the pandas (labelled=True) case
     tss = run.train_timestamps(labelled=True)
     tss_berlin = run.train_timestamps(labelled=True, euxfel_local_time=True)
-  
-    dtss = tss_berlin.dt.tz_localize(None) - tss.dt.tz_localize(None) 
+
+    dtss = tss_berlin.dt.tz_localize(None) - tss.dt.tz_localize(None)
     assert all(dtss == del1h) or all(dtss == del2h)
-    
+
     # Finally, check that ValueError is raised if euxfel_local_time is used
     # on its own
     with pytest.raises(ValueError):

--- a/extra_data/tests/test_reader_mockdata.py
+++ b/extra_data/tests/test_reader_mockdata.py
@@ -752,6 +752,7 @@ def test_train_timestamps(mock_scs_run):
     assert isinstance(tss_ser, pd.Series)
     np.testing.assert_array_equal(tss_ser.values, tss)
     np.testing.assert_array_equal(tss_ser.index, run.train_ids)
+    assert tss_ser.dt.tz is timezone.utc
 
 
 def test_train_timestamps_nat(mock_fxe_control_data):

--- a/extra_data/tests/test_reader_mockdata.py
+++ b/extra_data/tests/test_reader_mockdata.py
@@ -4,7 +4,6 @@ from multiprocessing import Process
 from pathlib import Path
 from textwrap import dedent
 from warnings import catch_warnings
-from zoneinfo import ZoneInfo  # Needed for checking euxfel_local_time
 
 import h5py
 import numpy as np

--- a/extra_data/tests/test_reader_mockdata.py
+++ b/extra_data/tests/test_reader_mockdata.py
@@ -763,7 +763,6 @@ def test_train_timestamps_local_time(mock_scs_run):
     del2h = timedelta(hours=2)
 
     # First, the pydatetime case
-    tss = run.train_timestamps(pydatetime=True)
     tss_berlin = run.train_timestamps(pydatetime=True, euxfel_local_time=True)
 
     # The time difference between UTC and Europe/Berlin can only be


### PR DESCRIPTION
This is an alternative to #538. The idea is that where possible, we return timezone-aware UTC timestamps, making it easier to convert them to local time after calling this method, if desired. E.g. with pandas you would do:

```python
run.train_timestamps(labelled=True).dt.tz_convert('Europe/Berlin')
```

Timezone-aware timestamps are AFAIK always better where possible. Unfortunately, Numpy datetime64 has no notion of timezones. I've also added an option to get timezone-aware Python `datetime` objects, which may be more familiar.