### PR TITLE
Require Python >= 3.9

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - name: Checkout

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ setup(name="EXtra-data",
               'testpath',
           ]
       },
-      python_requires='>=3.8',
+      python_requires='>=3.9',
       classifiers=[
           'Development Status :: 5 - Production/Stable',
           'Environment :: Console',


### PR DESCRIPTION
From discussion on #550.

Offline calibration has moved to Python 3.11 now, so I think there's no longer any need for us to use EXtra-data on Python 3.8.