### PR TITLE
Combine raw & proc in open_run() by default

### DIFF
--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -2011,7 +2011,7 @@ def open_run(
                 origin_dc = open_run(
                     proposal, run, data=origin, include=include,
                     file_filter=file_filter, inc_suspect_trains=inc_suspect_trains,
-                    parallelize=parallelize, aliases=aliases,
+                    parallelize=parallelize, aliases=aliases, _use_voview=_use_voview,
                 )
             except FileNotFoundError:
                 if origin not in absence_ok:

--- a/extra_data/tests/conftest.py
+++ b/extra_data/tests/conftest.py
@@ -169,6 +169,22 @@ def mock_modern_spb_proc_run():
         make_examples.make_modern_spb_proc_run(td)
         yield td
 
+@pytest.fixture()
+def mock_spb_raw_and_modern_proc_run():
+    with TemporaryDirectory() as td:
+        prop_dir = osp.join(str(td), 'SPB', '201830', 'p002012')
+
+        # Set up raw
+        raw_run_dir = osp.join(prop_dir, 'raw', 'r0238')
+        os.makedirs(raw_run_dir)
+        make_examples.make_spb_run(raw_run_dir)
+
+        # Set up proc
+        proc_run_dir = osp.join(prop_dir, 'proc', 'r0238')
+        os.makedirs(proc_run_dir)
+        make_examples.make_modern_spb_proc_run(proc_run_dir)
+
+        yield td, raw_run_dir, proc_run_dir
 
 @pytest.fixture(scope='session')
 def mock_jungfrau_run():

--- a/extra_data/tests/test_open_run.py
+++ b/extra_data/tests/test_open_run.py
@@ -1,0 +1,151 @@
+import os
+import shutil
+from multiprocessing import Process
+from pathlib import Path
+from textwrap import dedent
+from unittest import mock
+from warnings import catch_warnings
+
+import numpy as np
+import pytest
+
+from extra_data import open_run
+from extra_data.reader import DEFAULT_ALIASES_FILE
+
+
+def test_open_run(mock_spb_raw_and_proc_run):
+    mock_data_root, raw_run_dir, proc_run_dir = mock_spb_raw_and_proc_run
+
+    with mock.patch('extra_data.read_machinery.DATA_ROOT_DIR', mock_data_root):
+        # With integers
+        run = open_run(proposal=2012, run=238)
+        paths = {f.filename for f in run.files}
+
+        assert paths
+        for path in paths:
+            assert '/raw/' in path
+
+        # With strings
+        run = open_run(proposal='2012', run='238')
+        assert {f.filename for f in run.files} == paths
+
+        # With numpy integers
+        run = open_run(proposal=np.int64(2012), run=np.uint16(238))
+        assert {f.filename for f in run.files} == paths
+
+        # Proc folder
+        proc_run = open_run(proposal=2012, run=238, data='proc')
+
+        proc_paths = {f.filename for f in proc_run.files}
+        assert proc_paths
+        for path in proc_paths:
+            assert '/raw/' not in path
+
+        # Helper function to write an alias file at a specific path
+        def write_aliases(path):
+            aliases_path.parent.mkdir(parents=True, exist_ok=True)
+            aliases_path.write_text(dedent("""
+            xgm: SA1_XTD2_XGM/DOOCS/MAIN
+            """))
+
+        # To set the aliases, we should be able to use a string relative to the
+        # proposal directory.
+        aliases_path = Path(mock_data_root) / "SPB/201830/p002012/foo.yml"
+        write_aliases(aliases_path)
+        run = open_run(2012, 238, data="all", aliases="{}/foo.yml")
+        assert "xgm" in run.alias
+
+        # And a proper path
+        aliases_path = Path(mock_data_root) / "foo.yml"
+        write_aliases(aliases_path)
+        run = open_run(2012, 238, aliases=aliases_path)
+        assert "xgm" in run.alias
+
+        # And a plain string
+        run = open_run(2012, 238, aliases=str(aliases_path))
+        assert "xgm" in run.alias
+
+        # If the default file exists, it should be used automatically
+        aliases_path = Path(DEFAULT_ALIASES_FILE.format(mock_data_root + "/SPB/201830/p002012"))
+        write_aliases(aliases_path)
+        run = open_run(2012, 238)
+        assert "xgm" in run.alias
+
+        # Check that aliases are loaded for old proposals where proc contains
+        # all sources from raw too. Necessary because the aliases are only
+        # loaded once for the raw data but the proc DataCollection will be used
+        # if all sources exist in proc.
+        shutil.rmtree(proc_run_dir)
+        shutil.copytree(raw_run_dir, proc_run_dir)
+        run = open_run(2012, 238, data="all")
+        assert "xgm" in run.alias
+
+
+
+@pytest.mark.parametrize('location', ['all', ['raw', 'proc']],
+                         ids=['all', 'list'])
+def test_open_run_multiple(mock_spb_raw_and_proc_run, location):
+    mock_data_root, raw_run_dir, proc_run_dir = mock_spb_raw_and_proc_run
+
+    with mock.patch('extra_data.read_machinery.DATA_ROOT_DIR', mock_data_root):
+        # Separate folders
+        run = open_run(proposal=2012, run=238)
+        proc_run = open_run(proposal=2012, run=238, data='proc')
+
+        # All folders
+        all_run = open_run(proposal=2012, run=238, data=location)
+
+        # Raw contains all sources.
+        assert run.all_sources == all_run.all_sources
+
+        # Proc is a true subset.
+        assert proc_run.all_sources < all_run.all_sources
+
+        for source, srcdata in all_run._sources_data.items():
+            for file in srcdata.files:
+                if '/DET/' in source:
+                    # AGIPD data is in proc.
+                    assert '/raw/' not in file.filename
+                else:
+                    # Non-AGIPD data is in raw.
+                    # (CAM, XGM)
+                    assert '/proc/' not in file.filename
+
+        # Delete the proc data
+        shutil.rmtree(proc_run_dir)
+        assert not os.path.isdir(proc_run_dir)
+
+        with catch_warnings(record=True) as w:
+            # Opening a run with 'all', with no proc data
+            all_run = open_run(proposal=2012, run=238, data=location)
+
+            # Attempting to open the proc data should raise a warning
+            assert len(w) == 1
+
+        # It should have opened at least the raw data
+        assert run.all_sources == all_run.all_sources
+
+        # Run that doesn't exist
+        with pytest.raises(Exception):
+            open_run(proposal=2012, run=999)
+
+        # run directory exists but contains no data
+        os.makedirs(proc_run_dir)
+        with catch_warnings(record=True) as w:
+            open_run(proposal=2012, run=238, data=location)
+            assert len(w) == 1
+
+
+def open_run_daemonized_helper(mock_data_root):
+    with mock.patch('extra_data.read_machinery.DATA_ROOT_DIR', mock_data_root):
+        open_run(2012, 238, data="all", parallelize=False)
+
+def test_open_run_daemonized(mock_spb_raw_and_proc_run):
+    mock_data_root, raw_run_dir, proc_run_dir = mock_spb_raw_and_proc_run
+
+    # Daemon processes can't start their own children, check that opening a run is still possible.
+    p = Process(target=open_run_daemonized_helper, args=(mock_data_root,), daemon=True)
+    p.start()
+    p.join()
+
+    assert p.exitcode == 0

--- a/extra_data/tests/test_reader_mockdata.py
+++ b/extra_data/tests/test_reader_mockdata.py
@@ -1,8 +1,5 @@
 from datetime import datetime, timedelta, timezone
 from itertools import islice
-from multiprocessing import Process
-from pathlib import Path
-from textwrap import dedent
 from warnings import catch_warnings
 
 import h5py
@@ -11,18 +8,14 @@ import os
 import pandas as pd
 import pytest
 import stat
-import shutil
 from tempfile import mkdtemp
 from testpath import assert_isfile
-from unittest import mock
 from xarray import DataArray
 
 from extra_data import (
     H5File, RunDirectory, by_index, by_id,
-    SourceNameError, PropertyNameError, DataCollection, open_run,
-    MultiRunError
+    SourceNameError, PropertyNameError, DataCollection,  MultiRunError
 )
-from extra_data.reader import DEFAULT_ALIASES_FILE
 
 
 def test_iterate_trains(mock_agipd_data, mock_control_data_with_empty_source):
@@ -898,129 +891,6 @@ def test_run_immutable_sources(mock_fxe_raw_run):
     assert len(test_run.all_sources) == before
 
 
-def test_open_run(mock_spb_raw_and_proc_run):
-    mock_data_root, raw_run_dir, proc_run_dir = mock_spb_raw_and_proc_run
-
-    with mock.patch('extra_data.read_machinery.DATA_ROOT_DIR', mock_data_root):
-        # With integers
-        run = open_run(proposal=2012, run=238)
-        paths = {f.filename for f in run.files}
-
-        assert paths
-        for path in paths:
-            assert '/raw/' in path
-
-        # With strings
-        run = open_run(proposal='2012', run='238')
-        assert {f.filename for f in run.files} == paths
-
-        # With numpy integers
-        run = open_run(proposal=np.int64(2012), run=np.uint16(238))
-        assert {f.filename for f in run.files} == paths
-
-        # Proc folder
-        proc_run = open_run(proposal=2012, run=238, data='proc')
-
-        proc_paths = {f.filename for f in proc_run.files}
-        assert proc_paths
-        for path in proc_paths:
-            assert '/raw/' not in path
-
-        # Helper function to write an alias file at a specific path
-        def write_aliases(path):
-            aliases_path.parent.mkdir(parents=True, exist_ok=True)
-            aliases_path.write_text(dedent("""
-            xgm: SA1_XTD2_XGM/DOOCS/MAIN
-            """))
-
-        # To set the aliases, we should be able to use a string relative to the
-        # proposal directory.
-        aliases_path = Path(mock_data_root) / "SPB/201830/p002012/foo.yml"
-        write_aliases(aliases_path)
-        run = open_run(2012, 238, data="all", aliases="{}/foo.yml")
-        assert "xgm" in run.alias
-
-        # And a proper path
-        aliases_path = Path(mock_data_root) / "foo.yml"
-        write_aliases(aliases_path)
-        run = open_run(2012, 238, aliases=aliases_path)
-        assert "xgm" in run.alias
-
-        # And a plain string
-        run = open_run(2012, 238, aliases=str(aliases_path))
-        assert "xgm" in run.alias
-
-        # If the default file exists, it should be used automatically
-        aliases_path = Path(DEFAULT_ALIASES_FILE.format(mock_data_root + "/SPB/201830/p002012"))
-        write_aliases(aliases_path)
-        run = open_run(2012, 238)
-        assert "xgm" in run.alias
-
-        # Check that aliases are loaded for old proposals where proc contains
-        # all sources from raw too. Necessary because the aliases are only
-        # loaded once for the raw data but the proc DataCollection will be used
-        # if all sources exist in proc.
-        shutil.rmtree(proc_run_dir)
-        shutil.copytree(raw_run_dir, proc_run_dir)
-        run = open_run(2012, 238, data="all")
-        assert "xgm" in run.alias
-
-
-
-@pytest.mark.parametrize('location', ['all', ['raw', 'proc']],
-                         ids=['all', 'list'])
-def test_open_run_multiple(mock_spb_raw_and_proc_run, location):
-    mock_data_root, raw_run_dir, proc_run_dir = mock_spb_raw_and_proc_run
-
-    with mock.patch('extra_data.read_machinery.DATA_ROOT_DIR', mock_data_root):
-        # Separate folders
-        run = open_run(proposal=2012, run=238)
-        proc_run = open_run(proposal=2012, run=238, data='proc')
-
-        # All folders
-        all_run = open_run(proposal=2012, run=238, data=location)
-
-        # Raw contains all sources.
-        assert run.all_sources == all_run.all_sources
-
-        # Proc is a true subset.
-        assert proc_run.all_sources < all_run.all_sources
-
-        for source, srcdata in all_run._sources_data.items():
-            for file in srcdata.files:
-                if '/DET/' in source:
-                    # AGIPD data is in proc.
-                    assert '/raw/' not in file.filename
-                else:
-                    # Non-AGIPD data is in raw.
-                    # (CAM, XGM)
-                    assert '/proc/' not in file.filename
-
-        # Delete the proc data
-        shutil.rmtree(proc_run_dir)
-        assert not os.path.isdir(proc_run_dir)
-
-        with catch_warnings(record=True) as w:
-            # Opening a run with 'all', with no proc data
-            all_run = open_run(proposal=2012, run=238, data=location)
-
-            # Attempting to open the proc data should raise a warning
-            assert len(w) == 1
-
-        # It should have opened at least the raw data
-        assert run.all_sources == all_run.all_sources
-
-        # Run that doesn't exist
-        with pytest.raises(Exception):
-            open_run(proposal=2012, run=999)
-
-        # run directory exists but contains no data
-        os.makedirs(proc_run_dir)
-        with catch_warnings(record=True) as w:
-            open_run(proposal=2012, run=238, data=location)
-            assert len(w) == 1
-
-
 def test_open_file(mock_sa3_control_data):
     f = H5File(mock_sa3_control_data)
     file_access = f.files[0]
@@ -1031,20 +901,6 @@ def test_open_file(mock_sa3_control_data):
     else:
         assert 'METADATA/dataSources/dataSourceId' in file_access.file
 
-
-def open_run_daemonized_helper(mock_data_root):
-    with mock.patch('extra_data.read_machinery.DATA_ROOT_DIR', mock_data_root):
-        open_run(2012, 238, data="all", parallelize=False)
-
-def test_open_run_daemonized(mock_spb_raw_and_proc_run):
-    mock_data_root, raw_run_dir, proc_run_dir = mock_spb_raw_and_proc_run
-
-    # Daemon processes can't start their own children, check that opening a run is still possible.
-    p = Process(target=open_run_daemonized_helper, args=(mock_data_root,), daemon=True)
-    p.start()
-    p.join()
-
-    assert p.exitcode == 0
 
 @pytest.mark.skipif(hasattr(os, 'geteuid') and os.geteuid() == 0,
                     reason="cannot run permission tests as root")


### PR DESCRIPTION
This adds a new `data='default'` option (which becomes the default) to combine raw & proc data, preferring raw where names clash. For new data, this means you can access corrected detector data with the new source names (e.g. `*/CORR/*`), alongside raw data with names like `*/DET/*`. For older data, there will be no difference from `data='raw'`.

- This & #468 together aren't 100% backwards compatible. Code that calls `open_run()` without passing `data=` and then uses a detector component like `AGIPD1M()` previously got raw data, but would now get corrected data when reading runs with the new source names. But hopefully this isn't common, and it's easily fixed.
- I'm not completely sure about when to error or warn on missing folders. At present, this errors if neither raw or proc run folders exist, and warns if only proc exists (somehow). It won't complain about a missing proc folder if run exists.

A large part of the diff is just moving some existing tests to a new file, so it may be easier to review by commit.