### PR TITLE
Fix det.masked_data().select_pulses() in XTDF detector components

### DIFF
--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -1027,9 +1027,13 @@ class DetectorMaskedKeyData(MultimodKeyData):
         )
         return kw
 
+    # Overridden for XTDF data to accommodate pulse selection
+    def _mask_keydata(self):
+        return self.det[self._mask_key]
+
     def _load_mask(self, module_gaps):
         """Load the mask & convert to boolean (True for bad pixels)"""
-        mask_data = self.det[self._mask_key].ndarray(module_gaps=module_gaps)
+        mask_data = self._mask_keydata().ndarray(module_gaps=module_gaps)
         if self._mask_bits is None:
             return mask_data != 0  # Skip extra temporary array from &
         else:
@@ -1272,7 +1276,8 @@ class XtdfImageMultimodKeyData(MultimodKeyData):
 
 class XtdfMaskedKeyData(DetectorMaskedKeyData, XtdfImageMultimodKeyData):
     # Created from xtdf_det.masked_data()
-    pass
+    def _mask_keydata(self):
+        return self.det[self._mask_key].select_pulses(self._pulse_sel)
 
 
 class FramesFileWriter(FileWriter):

--- a/extra_data/tests/test_components.py
+++ b/extra_data/tests/test_components.py
@@ -301,6 +301,11 @@ def test_xtdf_masked_data(mock_reduced_spb_proc_run):
     line0_2mod[1, 1:32] = np.nan
     np.testing.assert_array_equal(arr[:, 0, 0, :], line0_2mod)
 
+    # Test with pulse selection (frames per train is consistent but arbitrary)
+    kd_pulse_sel = kd.select_pulses(np.s_[:3])
+    assert kd_pulse_sel.shape[1] <= 3
+    assert kd_pulse_sel.ndarray().shape == kd_pulse_sel.shape
+
     kd = agipd.masked_data(mask_bits=[1, 4], masked_value=-1).select_trains(np.s_[:1])
     arr = kd.ndarray()
     line0_2mod = np.zeros((2, 128), dtype=np.float32)


### PR DESCRIPTION
We were loading the data with the pulse selection, but loading all pulses for the mask, and then failing to combine them.

@JunCEEE @philsmt 