### PR TITLE
Option to get run values without timestamps

### DIFF
--- a/extra_data/sourcedata.py
+++ b/extra_data/sourcedata.py
@@ -439,7 +439,7 @@ class SourceData:
             return val.decode('utf-8', 'surrogateescape')
         return val
 
-    def run_values(self):
+    def run_values(self, inc_timestamps=True):
         """Get a dict of all RUN values for this source
 
         This includes keys which are also in CONTROL.
@@ -461,6 +461,8 @@ class SourceData:
 
         # Arbitrary file - should be the same across a run
         self.files[0].file['RUN'][self.source].visititems(visitor)
+        if not inc_timestamps:
+            return {k[:-6]: v for (k, v) in res.items() if k.endswith('.value')}
         return res
 
     @property

--- a/extra_data/tests/test_sourcedata.py
+++ b/extra_data/tests/test_sourcedata.py
@@ -164,6 +164,14 @@ def test_run_value(mock_spb_raw_run):
     value = xgm.run_value('pulseEnergy.conversion.value')
     assert isinstance(value, np.float64)
 
+    run_dict = xgm.run_values()
+    assert 'pulseEnergy.conversion.value' in run_dict
+    assert 'pulseEnergy.conversion.timestamp' in run_dict
+
+    values_dict = xgm.run_values(inc_timestamps=False)
+    assert 'pulseEnergy.conversion' in values_dict
+    assert 'pulseEnergy.conversion.timestamp' not in values_dict
+
     with pytest.raises(ValueError):
         # no run values for instrument sources
         am0.run_values()


### PR DESCRIPTION
To parallel `src.keys(inc_timestamps=False)`, this allows `src.run_values(inc_timestamps=False)`.

cc @philsmt 