### PR TITLE
Support more magic methods

### DIFF
--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -290,6 +290,18 @@ class DataCollection:
 
         raise TypeError("Expected data[source], data[source, key] or data[train_selection]")
 
+    def __contains__(self, item):
+        if (
+            isinstance(item, tuple) and
+            len(item) == 2 and
+            all(isinstance(e, str) for e in item)
+        ):
+            return item[1] in self._get_source_data(item[0])
+        elif isinstance(item, str):
+            return item in self.all_sources
+
+        return False
+
     def _ipython_key_completions_(self):
         return list(self.all_sources)
 

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -662,6 +662,12 @@ class DataCollection:
             is_single_run=same_run(self, *others),
         )
 
+    def __or__(self, other):
+        return self.union(other)
+
+    def __ior__(self, other):
+        return self.union(other)
+
     def _parse_aliases(self, alias_defs):
         """Parse alias definitions into alias dictionaries."""
 

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -302,6 +302,8 @@ class DataCollection:
 
         return False
 
+    __iter__ = None  # Disable iteration
+
     def _ipython_key_completions_(self):
         return list(self.all_sources)
 

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -296,7 +296,8 @@ class DataCollection:
             len(item) == 2 and
             all(isinstance(e, str) for e in item)
         ):
-            return item[1] in self._get_source_data(item[0])
+            return item[0] in self.all_sources and \
+                item[1] in self._get_source_data(item[0])
         elif isinstance(item, str):
             return item in self.all_sources
 

--- a/extra_data/sourcedata.py
+++ b/extra_data/sourcedata.py
@@ -66,6 +66,8 @@ class SourceData:
             res = self._has_exact_key(key + '.value')
         return res
 
+    __iter__ = None  # Disable iteration
+
     def __getitem__(self, key):
         if (
             isinstance(key, (by_id, by_index, list, np.ndarray, slice)) or

--- a/extra_data/sourcedata.py
+++ b/extra_data/sourcedata.py
@@ -499,3 +499,9 @@ class SourceData:
             is_single_run=same_run(self, *others),
             inc_suspect_trains=self.inc_suspect_trains
         )
+
+    def __or__(self, other):
+        return self.union(other)
+
+    def __ior__(self, other):
+        return self.union(other)

--- a/extra_data/tests/test_reader_mockdata.py
+++ b/extra_data/tests/test_reader_mockdata.py
@@ -843,6 +843,26 @@ def test_union(mock_fxe_raw_run):
     assert joined[xgm].train_ids == expected_tids
     assert joined[camera].train_ids == expected_tids
 
+    # Try via operators.
+    sel1 = run.select(xgm, 'beamPosition.ixPos')
+    sel2 = run.select(xgm, 'beamPosition.iyPos')
+
+    joined = sel1 | sel2
+    assert joined.selection == {
+        xgm: {
+            'beamPosition.ixPos.value',
+            'beamPosition.iyPos.value',
+        }
+    }
+
+    sel1 |= sel2
+    assert sel1.selection == {
+        xgm: {
+            'beamPosition.ixPos.value',
+            'beamPosition.iyPos.value',
+        }
+    }
+
 
 def test_union_raw_proc(mock_spb_raw_run, mock_spb_proc_run):
     raw_run = RunDirectory(mock_spb_raw_run)

--- a/extra_data/tests/test_reader_mockdata.py
+++ b/extra_data/tests/test_reader_mockdata.py
@@ -1050,3 +1050,13 @@ def test_proc_legacy_sources(mock_modern_spb_proc_run):
         assert run.get_dtype(det_mod0, 'image.data') == np.float32
 
     assert run.select(det_mod0).all_sources == {det_mod0}
+
+
+def test_datacollection_contains(mock_fxe_control_data):
+    run = H5File(mock_fxe_control_data)
+
+    assert 'FXE_XAD_GEC/CAM/CAMERA:daqOutput' in run
+    assert 'MY/LITTLE/PONY' not in run
+    assert 'SPB_XTD9_XGM/DOOCS/MAIN', 'beamPosition.ixPos' in run
+    assert 'SPB_XTD9/XGM/DOOCS/MAIN', '42' not in run
+    assert 42 not in run

--- a/extra_data/tests/test_reader_mockdata.py
+++ b/extra_data/tests/test_reader_mockdata.py
@@ -1077,7 +1077,7 @@ def test_datacollection_contains(mock_fxe_control_data):
 
     assert 'FXE_XAD_GEC/CAM/CAMERA:daqOutput' in run
     assert 'MY/LITTLE/PONY' not in run
-    assert 'MY/LITTLE/PONY', 'actualPosition' not in run
-    assert 'SPB_XTD9_XGM/DOOCS/MAIN', 'beamPosition.ixPos' in run
-    assert 'SPB_XTD9/XGM/DOOCS/MAIN', '42' not in run
+    assert ('MY/LITTLE/PONY', 'actualPosition') not in run
+    assert ('SPB_XTD9_XGM/DOOCS/MAIN', 'beamPosition.ixPos') in run
+    assert ('SPB_XTD9/XGM/DOOCS/MAIN', '42') not in run
     assert 42 not in run

--- a/extra_data/tests/test_reader_mockdata.py
+++ b/extra_data/tests/test_reader_mockdata.py
@@ -1077,6 +1077,7 @@ def test_datacollection_contains(mock_fxe_control_data):
 
     assert 'FXE_XAD_GEC/CAM/CAMERA:daqOutput' in run
     assert 'MY/LITTLE/PONY' not in run
+    assert 'MY/LITTLE/PONY', 'actualPosition' not in run
     assert 'SPB_XTD9_XGM/DOOCS/MAIN', 'beamPosition.ixPos' in run
     assert 'SPB_XTD9/XGM/DOOCS/MAIN', '42' not in run
     assert 42 not in run

--- a/extra_data/tests/test_sourcedata.py
+++ b/extra_data/tests/test_sourcedata.py
@@ -155,6 +155,13 @@ def test_union(mock_spb_raw_run):
     with pytest.raises(ValueError):
         xgm.union(am0)
 
+    sel = xgm.select_trains(np.s_[:10]) | xgm.select_trains(np.s_[-10:])
+    assert sel.train_ids == list(range(10000, 10010)) + list(range(10054, 10064))
+
+    sel = xgm.select_trains(np.s_[:10])
+    sel |= xgm.select_trains(np.s_[-10:])
+    assert sel.train_ids == list(range(10000, 10010)) + list(range(10054, 10064))
+
 
 def test_run_value(mock_spb_raw_run):
     run = RunDirectory(mock_spb_raw_run)


### PR DESCRIPTION
By chance I stumbled upon weird exceptions when you try to use the `in` operator on a `DataCollection`. Due to interactions in the [Python data model](https://docs.python.org/3/reference/datamodel.html#object.__contains__), the absence of a custom `__contains__` causes it to try treating `DataCollection` as a sequence...

This PR adds proper support for `__contains__` in `DataCollection` via a custom magic method. While at it, I also added support for the OR operator for merging (both binary and infix) and excplicitly disabled direct iteration to avoid the issue above.

Open questions:
- Should `__contains__` allow train ID checks? It is somewhat weird to use, but without it we would not support everything one can pass to `__getitem__`  
- Any other magic methods we could add? What I deliberated and rejected:
  - `__eq__`: somewhat straightforward to add semantically, but probably not useful outside of tests
  - `__len__`: which axis to use, trains or sources/keys?
  - `__iter__`: Rather iterate explicitly via the provided methods, and avoid weird data model interactions