### PR TITLE
Parallel decompression for detector data

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,6 @@
 [run]
 omit = */tests/*
-concurrency = multiprocessing
+concurrency = multiprocessing,thread
 
 [paths]
 source =

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,8 +40,9 @@ jobs:
         MPLBACKEND: agg
 
     - name: Upload coverage to Codecov
-      # This specific version uses Node 20 - see codecov-action#1293
-      uses: codecov/codecov-action@v3.1.5
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
 
   publish:
     runs-on: ubuntu-latest

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,7 @@
 version: 2  # Required
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
     python: "3.12"
 

--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -1264,7 +1264,8 @@ class XtdfImageMultimodKeyData(MultimodKeyData):
 
         return True
 
-    def ndarray(self, *, fill_value=None, out=None, roi=(), astype=None, module_gaps=False, decompress_threads=1):
+    def ndarray(self, *, fill_value=None, out=None, roi=(), astype=None,
+                module_gaps=False, decompress_threads=16):
         """Get an array of per-pulse data (image.*) for xtdf detector"""
         out_shape = self.buffer_shape(module_gaps=module_gaps, roi=roi)
 
@@ -1274,7 +1275,7 @@ class XtdfImageMultimodKeyData(MultimodKeyData):
         elif out.shape != out_shape:
             raise ValueError(f'requires output array of shape {out_shape}')
 
-        if decompress_threads > 1 and roi == () and astype is None:  # TODO
+        if decompress_threads > 1 and roi == () and astype is None:
             if self._read_parallel_decompress(out, module_gaps, decompress_threads):
                 return out
 

--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -1304,8 +1304,13 @@ class XtdfImageMultimodKeyData(MultimodKeyData):
         })
 
     def xarray(self, *, pulses=None, fill_value=None, roi=(), astype=None,
-               subtrain_index='pulseId', unstack_pulses=False):
-        arr = self.ndarray(fill_value=fill_value, roi=roi, astype=astype)
+               subtrain_index='pulseId', unstack_pulses=False, decompress_threads=1):
+        arr = self.ndarray(
+            fill_value=fill_value,
+            roi=roi,
+            astype=astype,
+            decompress_threads=decompress_threads,
+        )
         out = self._wrap_xarray(arr, subtrain_index)
 
         if unstack_pulses:

--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -1,8 +1,6 @@
 """Interfaces to data from specific instruments
 """
 import logging
-import os
-
 import math
 import re
 from collections.abc import Iterable

--- a/extra_data/compression.py
+++ b/extra_data/compression.py
@@ -1,0 +1,65 @@
+import h5py
+import numpy as np
+from zlib_into import decompress_into
+
+def filter_ids(dset: h5py.Dataset):
+    dcpl = dset.id.get_create_plist()
+    return [dcpl.get_filter(i)[0] for i in range(dcpl.get_nfilters())]
+
+class DeflateDecompressor:
+    def __init__(self, deflate_filter_idx=0):
+        self.deflate_filter_bit = (1 << deflate_filter_idx)
+
+    @classmethod
+    def for_dataset(cls, dset: h5py.Dataset):
+        filters = filter_ids(dset)
+        if filters == [h5py.h5z.FILTER_DEFLATE]:
+            return cls()
+        if dset.dtype.itemsize == 1 and filters == [
+            h5py.h5z.FILTER_SHUFFLE, h5py.h5z.FILTER_DEFLATE
+        ]:
+            # The shuffle filter doesn't change single byte values, so we can
+            # skip it.
+            return cls(deflate_filter_idx=1)
+
+    def apply_filters(self, data, filter_mask, out):
+        if filter_mask & self.deflate_filter_bit:
+            # The deflate filter is skipped, so just copy the data
+            memoryview(out)[:] = data
+        else:
+            decompress_into(data, out)
+
+
+class ShuffleDeflateDecompressor:
+    def __init__(self, chunk_shape, dtype):
+        chunk_nbytes = dtype.itemsize
+        for l in chunk_shape:
+            chunk_nbytes *= l
+        # This will hold the decompressed data before shuffling
+        self.chunk_buf = np.zeros(chunk_nbytes, dtype=np.uint8)
+        self.shuffled_view = (     # E.g. for int32 data with chunks (10, 5):
+                self.chunk_buf                  # (200,) uint8
+                .reshape((dtype.itemsize, -1))  # (4, 50)
+                .transpose()                    # (50, 4)
+        )
+        # Check this is still a view on the buffered data
+        assert self.shuffled_view.base is self.chunk_buf
+
+    @classmethod
+    def for_dataset(cls, dset: h5py.Dataset):
+        if filter_ids(dset) == [h5py.h5z.FILTER_SHUFFLE, h5py.h5z.FILTER_DEFLATE]:
+            return cls(dset.chunks, dset.dtype)
+
+    def apply_filters(self, data, filter_mask, out):
+        if filter_mask & 2:
+            # The deflate filter is skipped
+            memoryview(self.chunk_buf)[:] = data
+        else:
+            decompress_into(data, self.chunk_buf)
+
+        if filter_mask & 1:
+            # The shuffle filter is skipped
+            memoryview(out)[:] = self.chunk_buf
+        else:
+            # Numpy does the shuffling by copying data between views
+            out.reshape((-1, 1)).view(np.uint8)[:] = self.shuffled_view

--- a/extra_data/compression.py
+++ b/extra_data/compression.py
@@ -29,6 +29,8 @@ class DeflateDecompressor:
             # skip it.
             return cls(deflate_filter_idx=1)
 
+        return None
+
     def clone(self):
         return copy(self)
 
@@ -62,6 +64,8 @@ class ShuffleDeflateDecompressor:
         if filter_ids(dset) == [h5py.h5z.FILTER_SHUFFLE, h5py.h5z.FILTER_DEFLATE]:
             return cls(dset.chunks, dset.dtype)
 
+        return None
+
     def clone(self):
         return type(self)(self.chunk_shape, self.dtype)
 
@@ -84,6 +88,8 @@ def dataset_decompressor(dset):
     for cls in [DeflateDecompressor, ShuffleDeflateDecompressor]:
         if (inst := cls.for_dataset(dset)) is not None:
             return inst
+
+    return None
 
 
 def multi_dataset_decompressor(dsets):

--- a/extra_data/compression.py
+++ b/extra_data/compression.py
@@ -115,6 +115,9 @@ def parallel_decompress_chunks(tasks, decompressor_proto, threads=16):
         except AttributeError:
             tlocal.decompressor = decomp = decompressor_proto.clone()
 
+        if dset_id.get_chunk_info_by_coord(coord).byte_offset is None:
+            return   # Chunk not allocated in file
+
         filter_mask, compdata = dset_id.read_direct_chunk(coord)
         decomp.apply_filters(compdata, filter_mask, dest)
 

--- a/extra_data/keydata.py
+++ b/extra_data/keydata.py
@@ -165,6 +165,21 @@ class KeyData:
         from pathlib import Path
         return [Path(p) for p in paths]
 
+    def _without_virtual_overview(self):
+        if not self.files[0].file[self.hdf5_data_path].is_virtual:
+            # We're already looking at regular source files
+            return self
+
+        return KeyData(
+            self.source, self.key,
+            train_ids=self.train_ids,
+            files=[FileAccess(p) for p in self.source_file_paths],
+            section=self.section,
+            dtype=self.dtype,
+            eshape=self.entry_shape,
+            inc_suspect_trains=self.inc_suspect_trains,
+        )
+
     def _find_attributes(self, dset):
         """Find Karabo attributes belonging to a dataset."""
         attrs = dict(dset.attrs)

--- a/extra_data/tests/make_examples.py
+++ b/extra_data/tests/make_examples.py
@@ -355,6 +355,11 @@ def make_modern_spb_proc_run(dir_path, format_version='1.2'):
                         legacy_name=f'SPB_DET_AGIPD1M-1/DET/{modno}CH0')
             ], ntrains=64, chunksize=32, format_version=format_version)
 
+    # Ensure one chunk of mask data is actually written
+    with h5py.File(path, 'r+') as f:
+        ds = f['INSTRUMENT/SPB_DET_AGIPD1M-1/CORR/15CH0:output/image/mask']
+        ds[0, 0, 5] = 1
+
 
 def make_agipd1m_run(
     dir_path,

--- a/extra_data/tests/test_components.py
+++ b/extra_data/tests/test_components.py
@@ -592,6 +592,23 @@ def test_modern_corr_sources(mock_modern_spb_proc_run, mock_spb_raw_run_fmt1):
     assert 'image.mask' in agipd_dflt
 
 
+def test_decompress_threads(mock_modern_spb_proc_run):
+    run = RunDirectory(mock_modern_spb_proc_run)
+
+    agipd = AGIPD1M(run[:1])
+    # Load
+    ref = agipd['image.mask'].ndarray(decompress_threads=1)
+    print(ref.shape)
+    print(ref[15, 0, :10, :10])
+    assert ref[15, 0, 0, 0] == 0
+    assert ref[15, 0, 0, 5] == 1
+
+    import h5py
+    h5py._errors.unsilence_errors()
+    arr = agipd['image.mask'].ndarray(decompress_threads=16)
+    np.testing.assert_array_equal(arr, ref)
+
+
 def test_write_virtual_cxi(mock_spb_proc_run, tmpdir):
     run = RunDirectory(mock_spb_proc_run)
     det = AGIPD1M(run)

--- a/extra_data/tests/test_compression.py
+++ b/extra_data/tests/test_compression.py
@@ -1,0 +1,58 @@
+"""Test the decompression machinery"""
+
+import h5py
+import numpy as np
+
+from extra_data.compression import (
+    DeflateDecompressor, ShuffleDeflateDecompressor,
+    dataset_decompressor, multi_dataset_decompressor, filter_ids,
+)
+
+def test_deflate(tmp_path):
+    f = h5py.File(tmp_path / 'test.h5', 'w')
+    # Shuffling single-byte data is a no-op
+    arr = np.arange(200, dtype=np.uint8).reshape(4, 50)
+    ds = f.create_dataset('d', data=arr, chunks=(4, 10), shuffle=True, compression='gzip')
+    assert filter_ids(ds) == [h5py.h5z.FILTER_SHUFFLE, h5py.h5z.FILTER_DEFLATE]
+
+    decomp = dataset_decompressor(ds)
+    assert isinstance(decomp, DeflateDecompressor)
+
+    filter_mask, data = ds.id.read_direct_chunk((0, 0))
+    out = np.zeros((4, 10), dtype=np.uint8)
+    decomp.apply_filters(data, filter_mask, out)
+    np.testing.assert_array_equal(out, arr[:, :10])
+
+
+def test_shuffle_deflate(tmp_path):
+    f = h5py.File(tmp_path / 'test.h5', 'w')
+    # Shuffling single-byte data is a no-op
+    arr = np.arange(200, dtype=np.uint32).reshape(4, 50)
+    ds = f.create_dataset('d', data=arr, chunks=(4, 10), shuffle=True, compression='gzip')
+    assert filter_ids(ds) == [h5py.h5z.FILTER_SHUFFLE, h5py.h5z.FILTER_DEFLATE]
+
+    decomp = dataset_decompressor(ds)
+    assert isinstance(decomp, ShuffleDeflateDecompressor)
+
+    filter_mask, data = ds.id.read_direct_chunk((0, 0))
+    out = np.zeros((4, 10), dtype=np.uint32)
+    decomp.apply_filters(data, filter_mask, out)
+    np.testing.assert_array_equal(out, arr[:, :10])
+
+
+def test_multi_dataset_decompressor(tmp_path):
+    f = h5py.File(tmp_path / 'test.h5', 'w')
+    ds1 = f.create_dataset('a', shape=(10, 50), chunks=(1, 50),
+                           compression='gzip', dtype=np.uint32)
+    ds2 = f.create_dataset('b', shape=(20, 50), chunks=(1, 50),
+                           compression='gzip', dtype=np.uint32)
+    ds3 = f.create_dataset('c', shape=(10, 50), chunks=(1, 50),
+                           compression='gzip', dtype=np.uint8)
+
+    # Differing shape is OK
+    assert isinstance(multi_dataset_decompressor([ds1, ds2]), DeflateDecompressor)
+
+    # But dtype needs to match
+    assert multi_dataset_decompressor([ds1, ds3]) is None
+
+    assert multi_dataset_decompressor([]) is None

--- a/extra_data/utils.py
+++ b/extra_data/utils.py
@@ -28,7 +28,7 @@ def default_num_threads(fixed_limit=16):
     threads_limits = ([fixed_limit, available_cpu_cores()])
     try:
         threads_limits.append(int(os.environ['OMP_NUM_THREADS']))
-    except (KeyError, ValueError):
+    except (KeyError, ValueError):  # Not set, or not an integer
         pass
     return min(threads_limits)
 

--- a/extra_data/utils.py
+++ b/extra_data/utils.py
@@ -24,10 +24,10 @@ def available_cpu_cores():
 
 
 def default_num_threads(fixed_limit=16):
-    # Default to 16, OMP_NUM_THREADS, or available CPU cores (picking lowest)
+    # Default to 16, EXTRA_NUM_THREADS, or available CPU cores (picking lowest)
     threads_limits = ([fixed_limit, available_cpu_cores()])
     try:
-        threads_limits.append(int(os.environ['OMP_NUM_THREADS']))
+        threads_limits.append(int(os.environ['EXTRA_NUM_THREADS']))
     except (KeyError, ValueError):  # Not set, or not an integer
         pass
     return min(threads_limits)

--- a/extra_data/utils.py
+++ b/extra_data/utils.py
@@ -23,6 +23,16 @@ def available_cpu_cores():
         return min(ncpu, 8)
 
 
+def default_num_threads(fixed_limit=16):
+    # Default to 16, OMP_NUM_THREADS, or available CPU cores (picking lowest)
+    threads_limits = ([fixed_limit, available_cpu_cores()])
+    try:
+        threads_limits.append(int(os.environ['OMP_NUM_THREADS']))
+    except (KeyError, ValueError):
+        pass
+    return min(threads_limits)
+
+
 def progress_bar(done, total, suffix=" "):
     line = f"Progress: {done}/{total}{suffix}[{{}}]"
     length = min(get_terminal_size().columns - len(line), 50)

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(name="EXtra-data",
           'pandas',
           'xarray',
           'pyyaml',
+          'zlib_into',
       ],
       extras_require={
           'bridge': [


### PR DESCRIPTION
Where detector data is stored compressed, HDF5 normally decompresses it in serial. This uses HDF5 to get the compressed chunk data, and then decompresses it in several worker threads. As I mentioned in Zulip, I experimented with a few ways of doing this, but the differences between them were minor.

I found some compressed (photonised) AGIPD data in MID proposal 6578. This shows loading 1000 frames across 16 modules. The value for 1 thread is the existing code path, with HDF5 doing the decompression. The others are all the new code path.

![image](https://github.com/user-attachments/assets/1141801b-0a27-4ee1-a214-4459ab515b62)

Questions:

1. I haven't yet implemented non-zero fill values for gaps. Is that worth doing, or shall we fall back to HDF5's code when we do that?
2. Make zlib_into (tiny package I made for this) a regular dependency or an optional one?
3. For now the parallel decompression is opt-in, by passing e.g. `.ndarray(decompress_threads=16)`. Do we want to turn it on by default for compressed data? Or use some heuristics to determine when it's most likely to be useful?
4. Filling the output array one frame at a time opens up the possibility of making an array shaped like (frames, modules, slow_scan, fast_scan), instead of (modules, frames, ...), i.e. putting the different modules for one frame together in memory, which the current reading code does not allow. You could do this by making a (frames, modules, ...) array and then rearranging the axes to pass it as (modules, frames, ...) in the `out=` parameter. Do we want to do something to make that easier?

I have some ideas about speeding this up further, and I'd also like to get back to parallel reading of uncompressed data (as explored in #340). But I wanted to make some concrete progress on this.