### PR TITLE
No longer throw NoDataError when there is no source_file_path

### DIFF
--- a/extra_data/sourcedata.py
+++ b/extra_data/sourcedata.py
@@ -106,7 +106,7 @@ class SourceData:
             # This property is an empty list if no trains are selected.
             sample_path = first_kd.source_file_paths[0]
         except IndexError:
-            raise NoDataError(self.source) from None
+            sample_path = first_kd.files[0].filename
 
         return FileAccess(sample_path)
 

--- a/extra_data/tests/test_sourcedata.py
+++ b/extra_data/tests/test_sourcedata.py
@@ -201,11 +201,14 @@ def test_euxfel_path_infos(mock_spb_raw_run):
     assert xgm.data_category == 'RAW'
     assert xgm.aggregator == 'DA01'
 
+    # Changed to preserve the behaviour of above, as using a voview
+    # file with 0-len datasets anyway causes a return of None. It
+    # therefore attempts to use the regular .files property instead,
+    # either suceeding or failing as badly as it would with a voview.
     run = RunDirectory(mock_spb_raw_run).select_trains(np.s_[:0])
     xgm = run['SPB_XTD9_XGM/DOOCS/MAIN']
-
-    with pytest.raises(NoDataError):
-        xgm.storage_class
+    assert xgm.storage_class is None
+    assert xgm.aggregator == 'DA01'
 
 
 @pytest.mark.parametrize('source', [


### PR DESCRIPTION
https://github.com/European-XFEL/EXtra-data/pull/399 introduced properties for filename traits like `aggregator`. To transparently work with voview files, it uses the `.source_file_paths` property rather than `.files`.

Back then I introduced the behaviour of throwing `NoDataError` when `.source_file_paths` is empty, which at the time I assumed to only happen when no trains are selected. Unfortunately what happens in reality is that the voview file generally contains true datasets for emtpy sources, and `.source_file_paths` actually contains the voview file, causing a return of `None` for the `.aggregator` property.

Therefore I see no benefit of throwing this exception, as the worst case is to return `None` (which happens anyway already) or more likely we're able to actually return a proper result (if no voview file is used, `.files` still contains at least one usable path).

Additionally, this fixes an issue I had with corrupted files in p2654 containing only zero train IDs.