### PR TITLE
Expose source files from virtual overview even when data is missing or deselected

### DIFF
--- a/extra_data/keydata.py
+++ b/extra_data/keydata.py
@@ -147,7 +147,8 @@ class KeyData:
         paths = []
         for chunk in self._data_chunks:
             if chunk.dataset.is_virtual:
-                for vspace, filename, _, _ in chunk.dataset.virtual_sources():
+                mappings = chunk.dataset.virtual_sources()
+                for vspace, filename, _, _ in mappings:
                     if filename in paths:
                         continue  # Already got it
 
@@ -159,8 +160,19 @@ class KeyData:
                     ck = chunk.slice
                     if (map_stop > ck.start) and (map_start < ck.stop):
                         paths.append(filename)
+
+                # Include 1 source file even if no trains are selected
+                if (not paths) and mappings:
+                    paths.append(mappings[0][1])
             else:
                 paths.append(chunk.file.filename)
+
+        # Fallback for virtual overview files where no data was recorded for
+        # this source, so there's no mapping to point to.
+        if not paths:
+            source_grp = self.files[0].file[f"{self.section}/{self.source}"]
+            if 'source_files' in source_grp.attrs:
+                paths.append(source_grp.attrs['source_files'][0])
 
         from pathlib import Path
         return [Path(p) for p in paths]

--- a/extra_data/keydata.py
+++ b/extra_data/keydata.py
@@ -163,7 +163,7 @@ class KeyData:
 
                 # Include 1 source file even if no trains are selected
                 if (not paths) and mappings:
-                    paths.append(mappings[0][1])
+                    paths.append(mappings[0].file_name)
             else:
                 paths.append(chunk.file.filename)
 

--- a/extra_data/tests/test_voview.py
+++ b/extra_data/tests/test_voview.py
@@ -1,8 +1,9 @@
+from pathlib import Path
 from shutil import copytree
 
 from testpath import assert_isfile
 
-from extra_data import RunDirectory, voview
+from extra_data import H5File, RunDirectory, voview
 
 def test_main(mock_spb_raw_run, tmp_path):
     voview_file = tmp_path / 'run_overview.h5'
@@ -63,6 +64,9 @@ def test_use_voview(mock_spb_raw_run, tmp_path):
     assert {p.name for p in xgm_intens[:30].source_file_paths} == {
         'RAW-R0238-DA01-S00000.h5'
     }
+    assert {p.name for p in xgm_intens[:0].source_file_paths} == {
+        'RAW-R0238-DA01-S00000.h5'
+    }
     assert xgm_intens.units == 'μJ'
     assert xgm_intens.units_name == 'microjoule'
 
@@ -70,6 +74,23 @@ def test_use_voview(mock_spb_raw_run, tmp_path):
     src_grp = xgm_src.files[0].file[f'INSTRUMENT/{xgm_src.source}']
     assert src_grp.attrs['source_files'][:].tolist() == [
         str(new_run_dir / f'RAW-R0238-DA01-S{i:05}.h5') for i in range(2)
+    ]
+
+
+def test_make_voview_missing_data(mock_fxe_raw_run, tmp_path):
+    run_orig = RunDirectory(mock_fxe_raw_run)
+    voview_file = tmp_path / 'overview.h5'
+
+    vofw = voview.VirtualOverviewFileWriter(voview_file, run_orig)
+    vofw.write()
+
+    vf = H5File(voview_file)
+    cam_src = vf['FXE_XAD_GEC/CAM/CAMERA_NODATA:daqOutput']
+    assert cam_src.aggregator == 'DA01'
+    cam_data = cam_src['data.image.pixels']
+    assert cam_data.shape[0] == 0
+    assert cam_data.source_file_paths == [
+        Path(mock_fxe_raw_run, 'RAW-R0450-DA01-S00000.h5')
     ]
 
 

--- a/extra_data/tests/test_voview.py
+++ b/extra_data/tests/test_voview.py
@@ -66,6 +66,11 @@ def test_use_voview(mock_spb_raw_run, tmp_path):
     assert xgm_intens.units == 'μJ'
     assert xgm_intens.units_name == 'microjoule'
 
+    xgm_src = run['SA1_XTD2_XGM/DOOCS/MAIN:output']
+    src_grp = xgm_src.files[0].file[f'INSTRUMENT/{xgm_src.source}']
+    assert src_grp.attrs['source_files'][:].tolist() == [
+        str(new_run_dir / f'RAW-R0238-DA01-S{i:05}.h5') for i in range(2)
+    ]
 
 
 def open_run_with_voview(run_src, new_run_dir):

--- a/extra_data/writer.py
+++ b/extra_data/writer.py
@@ -228,15 +228,19 @@ class VirtualFileWriter(FileWriter):
     copy_keys = {'image.pulseId', 'image.cellId'}
 
     def prepare_source(self, source):
-        for key in self.data.keys_for_source(source):
+        srcdata = self.data[source]
+        grp_out = self.file.require_group(f'{srcdata.section}/{source}')
+        grp_out.attrs['source_files'] = sorted([f.filename for f in srcdata.files])
+
+        for key in srcdata.keys():
             if key in self.copy_keys:
                 self.copy_dataset(source, key)
             else:
                 self.add_dataset(source, key)
 
         # Add a link in RUN for control sources
-        if source in self.data.control_sources:
-            src_file = self.data[source].files[0]
+        if srcdata.is_control:
+            src_file = srcdata.files[0]
             run_path = f'RUN/{source}'
             self.file[run_path] = h5py.ExternalLink(src_file.filename, run_path)
 


### PR DESCRIPTION
This aims to ensure that `KeyData.source_file_paths` always returns at least one path, like the way that `.files` works, because it's useful to be able to inspect details of the underlying files that it is (/would be) pointing to. Hopefully this will fix some problems @philsmt was running into. The list of files for a source is now stored as an attribute on the source group.

This also includes a fix to make virtual datasets even when there are no mappings, so at least we can conveniently recognise them. I'll try to move this code into h5py.

Obviously virtual overview files will need to be regenerated to benefit from most of this, but it should have no detrimental effect on using existing virtual overview files.