### PR TITLE
Fix getting pulse/cell_id_coordinates for XTDF data with pulse selection

### DIFF
--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -1117,11 +1117,17 @@ class XtdfImageMultimodKeyData(MultimodKeyData):
 
     def pulse_id_coordinates(self):
         """Get an array of pulse IDs per-frame for this data"""
-        return self.det._collect_inner_ids('pulseId')
+        a = self.det._collect_inner_ids('pulseId')
+        if not self._all_pulses():
+            a = a[self._sel_frames]
+        return a
 
     def cell_id_coordinates(self):
         """Get an array of memory cell IDs per-frame for this data"""
-        return self.det._collect_inner_ids('cellId')
+        a = self.det._collect_inner_ids('cellId')
+        if not self._all_pulses():
+            a = a[self._sel_frames]
+        return a
 
     @property
     def dimensions(self):

--- a/extra_data/tests/test_components.py
+++ b/extra_data/tests/test_components.py
@@ -403,6 +403,13 @@ def test_pulse_id_cell_id(mock_lpd_mini_gap_run):
         kd.cell_id_coordinates(), np.tile(np.arange(10), 5)
     )
 
+    np.testing.assert_array_equal(
+        kd.select_pulses(np.s_[2:5]).pulse_id_coordinates(), np.tile(np.arange(2, 5), 5)
+    )
+    np.testing.assert_array_equal(
+        kd.select_pulses(np.s_[2:5]).cell_id_coordinates(), np.tile(np.arange(2, 5), 5)
+    )
+
 def test_pulse_id_cell_id_reduced(mock_reduced_spb_proc_run):
     run = RunDirectory(mock_reduced_spb_proc_run)
     det = AGIPD1M(run)


### PR DESCRIPTION
I discovered that e.g. `lpd['image.data'].select_pulses(np.s_[:5]).pulse_id_coordinates()` ignores the pulse selection and gives you all the pulse IDs in the underlying data. This is a bug; these methods are meant to work as labels for what `.ndarray()` would return.