### PR TITLE
Fix default value of `skip` when calling validate from cli

### DIFF
--- a/extra_data/validation.py
+++ b/extra_data/validation.py
@@ -382,14 +382,14 @@ def main(argv=None):
     ap.add_argument('path', help="HDF5 file or run directory of HDF5 files.")
     ap.add_argument('-l', '--list', action=ListAction, nargs=0,
                     help="List available checks (options for --skip)")
-    ap.add_argument('--skip', action='append',
+    ap.add_argument('--skip', action='append', default=[],
                     help="Skip a named check (may be used several times)")
     args = ap.parse_args(argv)
 
     available_checks = {
         f.__name__ for f in FileValidator.check_funcs + RunValidator.check_funcs
     }
-    bad_skips = set(args.skip or []) - available_checks
+    bad_skips = set(args.skip) - available_checks
     if bad_skips:
         print("Unknown names passed to --skip:", ", ".join(sorted(bad_skips)))
         return 1


### PR DESCRIPTION
I noticed the following when calling `extra-data-validate .`

```python
Checking run directory: .

Traceback (most recent call last):
  File "/gpfs/exfel/sw/software/mambaforge/22.11/envs/202501/bin/extra-data-validate", line 10, in <module>
    sys.exit(main())
             ^^^^^^
  File "/gpfs/exfel/sw/software/mambaforge/22.11/envs/202501/lib/python3.11/site-packages/extra_data/validation.py", line 401, in main
    validator = RunValidator(path, term_progress=True, skip_checks=args.skip)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/gpfs/exfel/sw/software/mambaforge/22.11/envs/202501/lib/python3.11/site-packages/extra_data/validation.py", line 266, in __init__
    self.skip_checks = set(skip_checks)
                       ^^^^^^^^^^^^^^^^
TypeError: 'NoneType' object is not iterable
```

Seems to happen due to `args.skip` being `None` if not used.

PR sets the default value to an empty list.