### PR TITLE
Index groups according to metadata

### DIFF
--- a/extra_data/file_access.py
+++ b/extra_data/file_access.py
@@ -515,8 +515,15 @@ class FileAccess(metaclass=MetaFileAccess):
             root = 'CONTROL'
         elif source in self.instrument_sources:
             root = 'INSTRUMENT'
-            if index_group not in self._index_groups[source]:
-                raise ValueError(f'{index_group} not an index group of `{source}`')
+            index_groups = self._index_groups[source]
+            if index_group:
+                if index_group not in index_groups:
+                    raise ValueError(f'{index_group} not an index group of `{source}`')
+            else:
+                if not index_groups:
+                    raise ValueError(f'`{source}` has no keys')
+                index_group = next(iter(index_groups))
+                prefix = index_group + '.'
         else:
             raise SourceNameError(source)
 

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -161,7 +161,7 @@ class DataCollection:
 
         for path in paths:
             cache_info = _files_map and _files_map.get(path)
-            if cache_info and ('flag' in cache_info):
+            if cache_info and ('flag' in cache_info) and ('index_groups' in cache_info):
                 filename, fa = cls._open_file(path, cache_info=cache_info)
                 handle_open_file_attempt(filename, fa)
             else:

--- a/extra_data/run_files_map.py
+++ b/extra_data/run_files_map.py
@@ -161,6 +161,10 @@ class RunFilesMap:
                 'instrument_sources': frozenset(d['instrument_sources']),
                 'legacy_sources': dict(d['legacy_sources']),
             }
+            if 'index_groups' in d:
+                res['index_groups'] = {
+                    source: set(groups) for source, groups in d['index_groups'].items()}
+
             res['flag'] = flag = np.ones_like(d['train_ids'], dtype=np.bool_)
             flag[d['suspect_train_indices']] = 0
             return res
@@ -202,6 +206,8 @@ class RunFilesMap:
                     'instrument_sources': sorted(file_access.instrument_sources),
                     'legacy_sources': {k: file_access.legacy_sources[k]
                                        for k in sorted(file_access.legacy_sources)},
+                    'index_groups': {k: sorted(file_access._index_groups[k])
+                                     for k in sorted(file_access._index_groups)},
                     'suspect_train_indices': [
                         int(i) for i in (~file_access.validity_flag).nonzero()[0]
                     ],

--- a/extra_data/sourcedata.py
+++ b/extra_data/sourcedata.py
@@ -397,7 +397,7 @@ class SourceData:
                     raise ValueError('source has index groups with differing '
                                      'data counts')
 
-            index_group = self.index_groups.pop()
+            index_group = next(iter(self.index_groups))
 
         return self[self.one_key(index_group)].train_id_coordinates()
 

--- a/extra_data/tests/test_file_access.py
+++ b/extra_data/tests/test_file_access.py
@@ -71,6 +71,7 @@ _empty_cache_info = dict(
     instrument_sources=frozenset(),
     flag=np.zeros(0, dtype=np.int32),
     legacy_sources={},
+    index_groups={},
 )
 
 


### PR DESCRIPTION
`EXtra-data` reconstructs the index groups of instrument sources by stored index structure. But index groups are also listed in `METADATA/dataSources` and this list is ignored.

In contrast, `EXtra-data` respects the list of sources in METADATA and does not give an access to sources are not listed there even if they really stored in files.

Usually there is no difference between the stored index groups and exposed in METADATA. But recently it changed. In the legacy sources may be less indexed groups then in new sources. But legacy source is a link to the new source and structurally they are identical.

We have an example when we reduce the original data and the `exdf-tools` change the metadata by adding index groups of new source to the legacy source, although they were not there in initial files.

see discussion in https://git.xfel.eu/dataAnalysis/exdf-tools/-/merge_requests/25

This reads the index groups from metadata.

@takluyver @philsmt 