### PR TITLE
Feat: trainid selection by bool

### DIFF
--- a/docs/reading_files.rst
+++ b/docs/reading_files.rst
@@ -277,6 +277,14 @@ of the data matching the train selection. For example, You can do::
     # key data
     key = key[np.s_[10:20]]  # data for the 10th to the 20th trains
 
+Train selection can additionally be done with boolean arrays or xarray
+DataArrays with a `trainId` coordinate. This is useful for selecting a subset
+of the data that matches a condition::
+
+    # XGM energy
+    xgm = run['SA1_XTD2_XGM/XGM/DOOCS', 'pulseEnergy.photonFlux'].xarray()
+    sel = run[xgm > 1000]
+
 Some kinds of data, e.g. from AGIPD, are too big to load a whole run into
 memory at once. In these cases, it's convenient to load one train at a time.
 

--- a/docs/reading_files.rst
+++ b/docs/reading_files.rst
@@ -277,6 +277,18 @@ of the data matching the train selection. For example, You can do::
     # key data
     key = key[np.s_[10:20]]  # data for the 10th to the 20th trains
 
+Train selection can additionally be done with boolean arrays or xarray
+DataArrays with a `trainId` coordinate. This is useful for selecting a subset
+of the data that matches a condition::
+
+    # XGM energy
+    xgm = run['SA1_XTD2_XGM/XGM/DOOCS', 'pulseEnergy.photonFlux'].xarray()
+    sel = run[xgm > 1000]
+
+    # ADC traces
+    traces = run.alias['adc-channel-1'].xarray()
+    sel = run[traces]
+
 Some kinds of data, e.g. from AGIPD, are too big to load a whole run into
 memory at once. In these cases, it's convenient to load one train at a time.
 

--- a/docs/reading_files.rst
+++ b/docs/reading_files.rst
@@ -277,18 +277,6 @@ of the data matching the train selection. For example, You can do::
     # key data
     key = key[np.s_[10:20]]  # data for the 10th to the 20th trains
 
-Train selection can additionally be done with boolean arrays or xarray
-DataArrays with a `trainId` coordinate. This is useful for selecting a subset
-of the data that matches a condition::
-
-    # XGM energy
-    xgm = run['SA1_XTD2_XGM/XGM/DOOCS', 'pulseEnergy.photonFlux'].xarray()
-    sel = run[xgm > 1000]
-
-    # ADC traces
-    traces = run.alias['adc-channel-1'].xarray()
-    sel = run[traces]
-
 Some kinds of data, e.g. from AGIPD, are too big to load a whole run into
 memory at once. In these cases, it's convenient to load one train at a time.
 

--- a/extra_data/read_machinery.py
+++ b/extra_data/read_machinery.py
@@ -152,6 +152,8 @@ def select_train_ids(train_ids, sel):
         # Select a list of trains by index in this collection
         return sorted(np.asarray(train_ids)[sel])
     elif isinstance_no_import(sel, 'xarray', 'DataArray'):
+        if sel.dtype != bool:
+            raise TypeError(f"xarray selector must be boolean, got {sel.dtype}")
         if 'trainId' not in sel.coords:
             raise ValueError("xarray selector must have a 'trainId' coordinate")
 

--- a/extra_data/read_machinery.py
+++ b/extra_data/read_machinery.py
@@ -152,8 +152,6 @@ def select_train_ids(train_ids, sel):
         # Select a list of trains by index in this collection
         return sorted(np.asarray(train_ids)[sel])
     elif isinstance_no_import(sel, 'xarray', 'DataArray'):
-        if sel.dtype != bool:
-            raise TypeError(f"xarray selector must be boolean, got {sel.dtype}")
         if 'trainId' not in sel.coords:
             raise ValueError("xarray selector must have a 'trainId' coordinate")
 

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -43,7 +43,7 @@ from .read_machinery import (DETECTOR_SOURCE_RE, by_id, by_index,
                              same_run, select_train_ids)
 from .run_files_map import RunFilesMap
 from .sourcedata import SourceData
-from .utils import available_cpu_cores
+from .utils import available_cpu_cores, isinstance_no_import
 
 __all__ = [
     'H5File',
@@ -284,6 +284,7 @@ class DataCollection:
             return self._get_source_data(item)
         elif (
             isinstance(item, (by_id, by_index, list, np.ndarray, slice)) or
+            isinstance_no_import(item, 'xarray', 'DataArray') or
             is_int_like(item)
         ):
             return self.select_trains(item)

--- a/extra_data/sourcedata.py
+++ b/extra_data/sourcedata.py
@@ -11,6 +11,7 @@ from .keydata import KeyData
 from .read_machinery import (by_id, by_index, glob_wildcards_re, is_int_like,
                              same_run, select_train_ids, split_trains,
                              trains_files_index)
+from .utils import isinstance_no_import
 
 
 class SourceData:
@@ -71,6 +72,7 @@ class SourceData:
     def __getitem__(self, key):
         if (
             isinstance(key, (by_id, by_index, list, np.ndarray, slice)) or
+            isinstance_no_import(key, 'xarray', 'DataArray') or
             is_int_like(key)
         ):
             return self.select_trains(key)

--- a/extra_data/tests/test_read_machinery.py
+++ b/extra_data/tests/test_read_machinery.py
@@ -143,19 +143,20 @@ def test_select_train_ids():
 
 def test_select_train_ids_xarray():
     train_ids = list(range(1000000, 1000010))
-
+    
     # Create a boolean xarray with trainId coordinate
     trainid_coord = np.array([1000001, 1000003, 1000005, 1000007, 1000009])
     data = np.ones(len(trainid_coord), dtype=bool)
     data[-1] = False
     xr_sel = xr.DataArray(data, coords={'trainId': trainid_coord}, dims=['trainId'])
+
+    # Test filtering with xarray
     assert select_train_ids(train_ids, xr_sel) == [1000001, 1000003, 1000005, 1000007]
 
-    # Test with xarray that isn't boolean dtype
-    float_trainid_coord = np.array([1000002, 1000004, 1000006])
-    float_data = np.array([1.5, 0.0, 3.2])  # Only non-zero values should be selected
-    float_xr_sel = xr.DataArray(float_data, coords={'trainId': float_trainid_coord}, dims=['trainId'])
-    assert select_train_ids(train_ids, float_xr_sel) == [1000002, 1000006]
+    # Test with non-boolean xarray
+    non_bool_xr = xr.DataArray(np.ones(5, dtype=float), coords={'trainId': trainid_coord}, dims=['trainId'])
+    with pytest.raises(TypeError, match="xarray selector must be boolean"):
+        select_train_ids(train_ids, non_bool_xr)
 
     # Test with xarray missing trainId coordinate
     wrong_coord_xr = xr.DataArray(np.ones(5, dtype=bool), coords={'time': np.arange(5)}, dims=['time'])

--- a/extra_data/tests/test_read_machinery.py
+++ b/extra_data/tests/test_read_machinery.py
@@ -143,20 +143,19 @@ def test_select_train_ids():
 
 def test_select_train_ids_xarray():
     train_ids = list(range(1000000, 1000010))
-    
+
     # Create a boolean xarray with trainId coordinate
     trainid_coord = np.array([1000001, 1000003, 1000005, 1000007, 1000009])
     data = np.ones(len(trainid_coord), dtype=bool)
     data[-1] = False
     xr_sel = xr.DataArray(data, coords={'trainId': trainid_coord}, dims=['trainId'])
-
-    # Test filtering with xarray
     assert select_train_ids(train_ids, xr_sel) == [1000001, 1000003, 1000005, 1000007]
 
-    # Test with non-boolean xarray
-    non_bool_xr = xr.DataArray(np.ones(5, dtype=float), coords={'trainId': trainid_coord}, dims=['trainId'])
-    with pytest.raises(TypeError, match="xarray selector must be boolean"):
-        select_train_ids(train_ids, non_bool_xr)
+    # Test with xarray that isn't boolean dtype
+    float_trainid_coord = np.array([1000002, 1000004, 1000006])
+    float_data = np.array([1.5, 0.0, 3.2])  # Only non-zero values should be selected
+    float_xr_sel = xr.DataArray(float_data, coords={'trainId': float_trainid_coord}, dims=['trainId'])
+    assert select_train_ids(train_ids, float_xr_sel) == [1000002, 1000006]
 
     # Test with xarray missing trainId coordinate
     wrong_coord_xr = xr.DataArray(np.ones(5, dtype=bool), coords={'time': np.arange(5)}, dims=['time'])

--- a/extra_data/utils.py
+++ b/extra_data/utils.py
@@ -9,6 +9,7 @@ program. If not, see <https://opensource.org/licenses/BSD-3-Clause>
 """
 
 import os
+import sys
 from shutil import get_terminal_size
 
 
@@ -39,3 +40,12 @@ def progress_bar(done, total, suffix=" "):
     filled = int(length * done // total)
     bar = "#" * filled + " " * (length - filled)
     return line.format(bar)
+
+
+def isinstance_no_import(obj, mod: str, cls: str):
+    """Check if isinstance(obj, mod.cls) without loading mod"""
+    m = sys.modules.get(mod)
+    if m is None:
+        return False
+
+    return isinstance(obj, getattr(m, cls))


### PR DESCRIPTION
Allows selecting train IDs of a DataCollection, Source/KeyData with a boolean (x)array.
This lets you do things like:

```
xgm = run.alias['xgm-photonFlux'].xarray()
sel = run[xgm > 1000]
```