### PR TITLE
Add support for custom error messages in SourceNameError

### DIFF
--- a/extra_data/exceptions.py
+++ b/extra_data/exceptions.py
@@ -6,11 +6,12 @@ class FileStructureError(Exception):
 
 
 class SourceNameError(KeyError):
-    def __init__(self, source):
+    def __init__(self, source=None, custom_message=None):
         self.source = source
+        self.custom_message = custom_message
 
     def __str__(self):
-        return (
+        return self.custom_message if self.custom_message is not None else (
             "This data has no source named {!r}.\n"
             "See data.all_sources for available sources.".format(self.source)
         )


### PR DESCRIPTION
Now that DAMNIT can recognize `SourceNameError` I'd like to try using it a bit more extensively in EXtra to be more consistent. Currently the components tend to return either `RuntimeError` or `ValueError` when they can't find a source, which leads to this situation:
![image](https://github.com/user-attachments/assets/c65c8b75-0f54-4256-b5fe-008aa2b8aa0d)

Focusing on the bottom half of the runs, the attenuator boxes are gray because their variables just do `run.alias[...]` and that raises a `SourceNameError`, but the Pulses/Scan type/XGM boxes are orange because they raise different exceptions even though it's the same underlying problem.

Components often have specific, more informative error messages so this adds an option to override the default message, and then I think we can start using it in EXtra.