### PR TITLE
Make zlib_into an optional dependency

### DIFF
--- a/extra_data/components.py
+++ b/extra_data/components.py
@@ -1224,7 +1224,10 @@ class XtdfImageMultimodKeyData(MultimodKeyData):
             )
 
     def _read_parallel_decompress(self, out, module_gaps, threads=16):
-        from .compression import multi_dataset_decompressor, parallel_decompress_chunks
+        try:
+            from .compression import multi_dataset_decompressor, parallel_decompress_chunks
+        except ImportError:
+            return False
 
         modno_to_keydata_no_virtual = {}
         all_datasets = []

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,6 @@ setup(name="EXtra-data",
           'pandas',
           'xarray',
           'pyyaml',
-          'zlib_into',
       ],
       extras_require={
           'bridge': [
@@ -69,6 +68,7 @@ setup(name="EXtra-data",
               'dask[array]',
               'extra_data[bridge]',
               'tomli; python_version < "3.11"',
+              'zlib_into',
           ],
           'docs': [
               'extra_data[bridge]',  # For autodoc of ZMQStreamer


### PR DESCRIPTION
So that EXtra-data can still easily be installed on other platforms, but we don't have to build `zlib_into` for those platforms.