### PR TITLE
Support string keys in KeyData.as_single_value

### DIFF
--- a/extra_data/keydata.py
+++ b/extra_data/keydata.py
@@ -340,7 +340,13 @@ class KeyData:
         the first value encountered. By default, 'median' is used.
 
         If within tolerances, the reduced value is returned.
+
+        For non-numerical keys like strings, the method behaves
+        identically to .as_unique_value() and ignores all arguments.
         """
+
+        if not np.issubdtype(self.dtype, np.number):
+            return self.as_unique_value()
 
         data = self.ndarray()
 
@@ -365,6 +371,26 @@ class KeyData:
                              f'(absolute: {adev:.3g}, relative: {rdev:.3g})')
 
         return value
+
+    def as_unique_value(self):
+        """Retrieve a single value if unique.
+
+        Returns the single unique of this key for all trains provided
+        there is a single one.
+        """
+
+        data = self.ndarray()
+
+        if len(data) == 0:
+            raise NoDataError(self.source, self.key)
+
+        axis = 0 if np.issubdtype(self.dtype, np.number) else None
+        unique_values = np.unique(data, axis=axis)
+
+        if len(unique_values) > 1:
+            raise ValueError(f'data values are not unique: {unique_values}')
+
+        return unique_values[0]
 
     # Getting data as different kinds of array: -------------------------------
 


### PR DESCRIPTION
For a short while now, `CONTROL` data also contains string properties. The current `KeyData.ndarray()` reads this as an array of `bytes` objects right now. This breaks the current implementation of `KeyData.as_single_value()` as it was written with the assumption of numerical types.

This PR is a minimal attempt of fixing this by introducing a new method `KeyData.as_unique_value()` and having `KeyData.as_single_value()` to behave identically for string valued keys, essentially forcing `np.unique` reduction behaviour for such types.

Some tidbits or questions related to this:
* The HDF dataset does not easily convert to an actual *string* type like `U<N>` beforehand with `h5py` throwing `no conversation path` exceptions even if I know the right one, I got only `data.astype(str)` to work after the fact.
* `np.unique()` only works on `object` arrays if the `axis` keyword argument is omitted
* Assuming all object arrays are strings, which seems to hold at the moment, should we transparently convert such keys in all read methods to, well, `str`?

 