### PR TITLE
Close newly written virtual overview file before renaming it

### DIFF
--- a/extra_data/voview.py
+++ b/extra_data/voview.py
@@ -132,8 +132,8 @@ def write_atomic(path, data):
     with TemporaryDirectory(prefix=".create-voview-", dir=dirname) as td:
         tmp_filename = osp.join(td, basename)
         try:
-            vofw = VirtualOverviewFileWriter(tmp_filename, data)
-            vofw.write()
+            with VirtualOverviewFileWriter(tmp_filename, data) as vofw:
+                vofw.write()
             os.replace(tmp_filename, path)
         except:
             os.unlink(tmp_filename)

--- a/extra_data/writer.py
+++ b/extra_data/writer.py
@@ -18,6 +18,12 @@ class FileWriter:
         self.indexes = {}  # {path: (first, count)}
         self.data_sources = set()
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.file.close()
+
     def prepare_source(self, source):
         """Prepare all the datasets for one source.
 


### PR DESCRIPTION
This will hopefully prevent a rare race condition where something tries to read a virtual overview file before it's fully written.