### PR TITLE
Optionally include aggregators in lsxfel and run.info()

### DIFF
--- a/extra_data/lsxfel.py
+++ b/extra_data/lsxfel.py
@@ -11,13 +11,13 @@ from .read_machinery import FilenameInfo
 from .reader import H5File, RunDirectory
 
 
-def describe_file(path, details_for_sources=()):
+def describe_file(path, details_for_sources=(), with_aggregators=False):
     """Describe a single HDF5 data file"""
     basename = os.path.basename(path)
     print(basename, ": Data file")
 
     h5file = H5File(path)
-    h5file.info(details_for_sources)
+    h5file.info(details_for_sources, with_aggregators)
 
 
 def summarise_file(path):
@@ -28,13 +28,13 @@ def summarise_file(path):
     print(f"  {len(f.train_ids)} trains, {len(f.all_sources)} sources")
 
 
-def describe_run(path, details_for_sources=()):
+def describe_run(path, details_for_sources=(), with_aggregators=False):
     basename = os.path.basename(path)
     print(basename, ": Run directory")
     print()
 
     run = RunDirectory(path)
-    run.info(details_for_sources)
+    run.info(details_for_sources, with_aggregators)
 
 
 def summarise_run(path, indent=''):
@@ -80,6 +80,9 @@ def main(argv=None):
              "Can be used more than once to include several patterns. "
              "Only used when inspecting a single run or file."
     )
+    ap.add_argument('--aggregators', '-g', action='store_true',
+        help="Include the aggregator each source is saved in. "
+             "This can slow down lsxfel considerably. ")
     args = ap.parse_args(argv)
     paths = args.paths or [os.path.abspath(os.getcwd())]
 
@@ -91,7 +94,7 @@ def main(argv=None):
             contents = sorted(os.listdir(path))
             if any(f.endswith('.h5') for f in contents):
                 # Run directory
-                describe_run(path, args.detail)
+                describe_run(path, args.detail, args.aggregators)
             elif any(re.match(r'r\d+', f) for f in contents):
                 # Proposal directory, containing runs
                 print(basename, ": Proposal data directory")
@@ -112,7 +115,7 @@ def main(argv=None):
                 print(basename, ": Unrecognised directory")
         elif os.path.isfile(path):
             if path.endswith('.h5'):
-                describe_file(path, args.detail)
+                describe_file(path, args.detail, args.aggregators)
             else:
                 print(basename, ": Unrecognised file")
                 return 2

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -1264,7 +1264,7 @@ class DataCollection:
         return f"<extra_data.DataCollection for {len(self.all_sources)} " \
                f"sources and {len(self.train_ids)} trains>"
 
-    def info(self, details_for_sources=()):
+    def info(self, details_for_sources=(), with_aggregators=False):
         """Show information about the selected data.
         """
         details_sources_re = [re.compile(fnmatch.translate(p))
@@ -1377,7 +1377,8 @@ class DataCollection:
             print(len(displayed_inst_srcs), 'instrument sources (excluding XTDF detectors):')
 
         for s in sorted(displayed_inst_srcs):
-            print('  -', s, src_alias_list(s))
+            agg_str = f' [{self[s].aggregator}]' if with_aggregators else ''
+            print('  -' + agg_str, s, src_alias_list(s))
             if not any(p.match(s) for p in details_sources_re):
                 continue
 
@@ -1392,7 +1393,8 @@ class DataCollection:
         print()
         print(len(self.control_sources), 'control sources:')
         for s in sorted(self.control_sources):
-            print('  -', s, src_alias_list(s))
+            agg_str = f' [{self[s].aggregator}]' if with_aggregators else ''
+            print('  -' + agg_str, s, src_alias_list(s))
             if any(p.match(s) for p in details_sources_re):
                 # Detail for control sources: list keys
                 ctrl_keys = self[s].keys(inc_timestamps=False)

--- a/extra_data/tests/test_reader_mockdata.py
+++ b/extra_data/tests/test_reader_mockdata.py
@@ -98,7 +98,8 @@ def test_train_info(mock_lpd_data, capsys):
 
 def test_info(mock_spb_raw_run):
     run = RunDirectory(mock_spb_raw_run)
-    run.info(details_for_sources='*/DOOCS/*')  # Smoketest
+    run.info(details_for_sources='*/DOOCS/*',
+             with_aggregators=True)  # Smoketest
 
 
 def test_iterate_trains_fxe(mock_fxe_control_data):


### PR DESCRIPTION
It's sometimes useful to quickly find in which aggregator a given source has been saved, e.g. for debugging purposes. This has recently become more pressing due to the introduction of load balancing.

This PR adds a new flag to `DataCollection.info()` to include the aggregator of a given source, and a correspondig flag to `lsxfel`.

Calling `SourceData.aggregator` is somewhat expensive, as a key has to be accessed to differentiate between real and virtual datasets. If one were to use `SourceData.files` directly, this is actually free.