### PR TITLE
Change DataCollection.alias to a static property

### DIFF
--- a/docs/reading_files.rst
+++ b/docs/reading_files.rst
@@ -72,7 +72,9 @@ to refer to all data associated with that 0.1 second window.
 
    .. automethod:: info
 
-   .. autoattribute:: alias
+   .. attribute:: alias
+
+      Enables item access via source and key aliases.
 
    .. automethod:: with_aliases
 

--- a/extra_data/aliases.py
+++ b/extra_data/aliases.py
@@ -4,6 +4,8 @@ from collections.abc import Iterable
 from .exceptions import AliasError
 
 class AliasIndexer:
+    """Enables item access via source and key aliases."""
+
     __slots__ = ('data',)
 
     def __init__(self, data):

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -118,6 +118,7 @@ class DataCollection:
         self._sources_data = sources_data
 
         self._aliases = aliases or {}
+        self.alias = AliasIndexer(self)
 
         # Throw an error if we have conflicting data for the same source
         self._check_source_conflicts()
@@ -876,11 +877,6 @@ class DataCollection:
             inc_suspect_trains=self.inc_suspect_trains,
             is_single_run=self.is_single_run
         )
-
-    @property
-    def alias(self):
-        """Enables item access via source and key aliases."""
-        return AliasIndexer(self)
 
     def _expand_selection(self, selection):
         if isinstance(selection, dict):


### PR DESCRIPTION
I got a complaint that aliases do not support tab completion in Jupyter, even though it actually contains an `_ipython_key_completions_` method. Some testing revealed this is due to it being a `@property`, which IPython apparently checks for explicitly.

Given `AliasIndexer` is actually stateless we could just make it a attribute, but it turned out `@cached_property` works just as well and doesn't require any logic changes. 