### PR TITLE
Allow substring matches for lsxfel --detail option

### DIFF
--- a/extra_data/cli/lsxfel.py
+++ b/extra_data/cli/lsxfel.py
@@ -7,8 +7,8 @@ import os.path as osp
 import re
 import sys
 
-from .read_machinery import FilenameInfo
-from .reader import H5File, RunDirectory
+from ..read_machinery import FilenameInfo
+from ..reader import H5File, RunDirectory
 
 
 def describe_file(path, details_for_sources=(), with_aggregators=False):

--- a/extra_data/cli/lsxfel.py
+++ b/extra_data/cli/lsxfel.py
@@ -72,7 +72,7 @@ def main(argv=None):
         prog='lsxfel', description="Summarise XFEL data in files or folders"
     )
     ap.add_argument('paths', nargs='*', help="Files/folders to look at")
-    ap.add_argument('--detail', action='append', default=[],
+    ap.add_argument('--detail', '-d', action='append', default=[],
         help="Show details on keys & data for specified sources. "
              "This can slow down lsxfel considerably. "
              "Wildcard patterns like '*XGM/*:output' are allowed, or partial "

--- a/extra_data/tests/test_lsxfel.py
+++ b/extra_data/tests/test_lsxfel.py
@@ -1,4 +1,4 @@
-from extra_data import lsxfel
+from extra_data.cli import lsxfel
 
 
 def test_lsxfel_file(mock_lpd_data, capsys):

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(name="EXtra-data",
       },
       entry_points={
           "console_scripts": [
-              "lsxfel = extra_data.lsxfel:main",
+              "lsxfel = extra_data.cli.lsxfel:main",
               "karabo-bridge-serve-files = extra_data.cli.serve_files:main",
               "karabo-bridge-serve-run = extra_data.cli.serve_run:main",
               "extra-data-validate = extra_data.validation:main",


### PR DESCRIPTION
This allows e.g. `--detail XGM`, saving a few keystrokes in many common situations.

The previous behaviour is kept if the value looks like a glob pattern (has `*`, `?` or `[`), so if you want to wildcard part of the pattern, you may also need an explicit wildcard at the start and/or end.