### PR TITLE
Set thresholds for coverage CI statuses

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        threshold: 1  # Allow coverage to drop t% without giving a failed status
+    patch:
+      default:
+        threshold: 20  # Changed code can have t% lower coverage than overall


### PR DESCRIPTION
This should reduce PRs being marked as 'failing' based on code coverage.

(Of course we can always choose to ignore the status from codecov and merge anyway, but it's nice to have the status be more informative.)