### PR TITLE
Add support for generating Jupyterhub links to alias files

### DIFF
--- a/docs/reading_files.rst
+++ b/docs/reading_files.rst
@@ -132,8 +132,10 @@ will print something like this (note the ✗ for an invalid alias)::
       agipd3-data: image.data
       agipd3-mask: image.mask
 
-Aliases can be used for selections as well, see
-:meth:`DataCollection.AliasIndexer.select` for more details.
+If aliases were loaded from a file, then clickable links to them will be
+displayed in the ``run.alias`` output (or you can call
+``run.alias.jhub_links()`` explicitly). Aliases can be used for selections as
+well, see :meth:`DataCollection.AliasIndexer.select` for more details.
 
 
 

--- a/extra_data/aliases.py
+++ b/extra_data/aliases.py
@@ -93,8 +93,21 @@ class AliasIndexer:
         if len(source_key_aliases) == 0:
             return "No aliases have been loaded."
 
+        # Print links to the alias files
+        output_lines = []
+        n_files = len(self.file_paths())
+        links = self.jhub_links()
+        if n_files == 1:
+            path = self.file_paths()[0]
+            output_lines.append(f"Alias file: {links.get(path, path)}\n")
+        elif n_files > 1:
+            output_lines.append(f"Alias files:")
+            for i, path in enumerate(self.file_paths()):
+                line_end = "\n" if i == n_files - 1 else ""
+                output_lines.append(f"- {links.get(path, path)}{line_end}")
+
         # Print the aliases
-        output_lines = ["Loaded aliases:"]
+        output_lines.append("Loaded aliases:")
         for source, alias_keys in source_key_aliases.items():
             if len(alias_keys) == 0:
                 # If there are no keys then this is a plain source alias
@@ -166,6 +179,23 @@ class AliasIndexer:
                 res.append(item)
 
         return res
+
+    def file_paths(self):
+        """Return any file paths that were used to add aliases."""
+        return self.data._alias_files
+
+    def jhub_links(self):
+        """Return a dict of alias file paths to clickable Jupyterhub links.
+
+        Note that a link will only be generated if the file path is under ``/gpfs``.
+        """
+        links = { }
+        for p in self.file_paths():
+            path_from_home = str(p).replace("/gpfs", "GPFS")
+            if path_from_home.startswith("GPFS"):
+                links[p] = f"https://max-jhub.desy.de/hub/user-redirect/lab/tree/{path_from_home}"
+
+        return links
 
     def select(self, seln_or_alias, key_glob='*', require_all=False,
                require_any=False):

--- a/extra_data/tests/test_aliases.py
+++ b/extra_data/tests/test_aliases.py
@@ -1,4 +1,3 @@
-
 from itertools import islice
 
 import pytest
@@ -9,10 +8,12 @@ from extra_data import (
     AliasError, SourceNameError, PropertyNameError
 )
 
-
-def test_with_aliases(mock_sa3_control_data, mock_sa3_control_aliases):
+def test_with_aliases(mock_sa3_control_data, mock_sa3_control_aliases, mock_sa3_control_aliases_yaml):
     run_without_aliases = H5File(mock_sa3_control_data)
     run = run_without_aliases.with_aliases(mock_sa3_control_aliases)
+
+    # There should be no files since we're adding aliases explicitly as a dict
+    assert len(run._alias_files) == 0
 
     def assert_equal_keydata(kd1, kd2):
         assert isinstance(kd1, KeyData)
@@ -77,10 +78,21 @@ def test_with_aliases(mock_sa3_control_data, mock_sa3_control_aliases):
     run4 = run.drop_aliases()
     assert not run4._aliases
 
+    # Test that file paths are recorded and dropped appropriately
+    run = run_without_aliases.with_aliases(mock_sa3_control_aliases_yaml)
+    assert run._alias_files == [mock_sa3_control_aliases_yaml]
+    assert run.drop_aliases()._alias_files == []
+
     # Smoke tests for __str__() and __repr__()
     assert "Loaded aliases" in repr(run.alias)
     assert "No aliases" in repr(run_without_aliases.alias)
     str(run.alias)
+
+    # Add a dummy alias file and check that the link is shown by repr()
+    run._alias_files[0] = "/gpfs/foo.yaml"
+    assert "Alias file: https://max-jhub.desy" in repr(run.alias)
+    run._alias_files.append("/gpfs/bar.yaml")
+    assert "Alias files:" in repr(run.alias)
 
 
 def test_alias_clash(mock_sa3_control_data, mock_sa3_control_aliases):
@@ -120,33 +132,12 @@ def test_json_alias_file(mock_sa3_control_data, mock_sa3_control_aliases, tmp_pa
     run = H5File(mock_sa3_control_data).with_aliases(aliases_path)
     assert run._aliases == mock_sa3_control_aliases
 
+    # Since we're loading from a file the file path should be recorded
+    assert run._alias_files == [aliases_path]
 
-def test_yaml_alias_file(mock_sa3_control_data, mock_sa3_control_aliases, tmp_path):
-    aliases_path = tmp_path / 'aliases.yaml'
-    aliases_path.write_text('''
-sa3-xgm: SA3_XTD10_XGM/XGM/DOOCS
 
-SA3_XTD10_XGM/XGM/DOOCS:
-  hv: pulseEnergy.wavelengthUsed
-  beam-x: beamPosition.ixPos
-  beam-y: beamPosition.iyPos
-
-imgfel-frames: [SA3_XTD10_IMGFEL/CAM/BEAMVIEW:daqOutput, data.image.pixels]
-imgfel-frames2: [SA3_XTD10_IMGFEL/CAM/BEAMVIEW2:daqOutput, data.image.pixels]
-imgfel-screen-pos: [SA3_XTD10_IMGFEL/MOTOR/SCREEN, actualPosition]
-imgfel-filter-pos: [SA3_XTD10_IMGFEL/MOTOR/FILTER, actualPosition]
-
-# Will be normalised to mcp-adc
-MCP_ADC: SA3_XTD10_MCP/ADC/1
-mcp-mpod: SA3_XTD10_MCP/MCPS/MPOD
-mcp-voltage: [SA3_XTD10_MCP/MCPS/MPOD, channels.U3.voltage]
-mcp-trace: [SA3_XTD10_MCP/ADC/1:channel_5.output, data.rawData]
-
-bogus-source: SA4_XTD20_XGM/XGM/DOOCS
-bogus-key: [SA3_XTD10_XGM/XGM/DOOCS, foo]
-    ''')
-
-    run = H5File(mock_sa3_control_data).with_aliases(aliases_path)
+def test_yaml_alias_file(mock_sa3_control_data, mock_sa3_control_aliases, mock_sa3_control_aliases_yaml):
+    run = H5File(mock_sa3_control_data).with_aliases(mock_sa3_control_aliases_yaml)
     assert run._aliases == mock_sa3_control_aliases
 
 
@@ -178,7 +169,7 @@ beam-y = "beamPosition.iyPos"
     assert run._aliases == mock_sa3_control_aliases
 
 
-def test_only_aliases(mock_sa3_control_data, mock_sa3_control_aliases):
+def test_only_aliases(mock_sa3_control_data, mock_sa3_control_aliases, mock_sa3_control_aliases_yaml):
     run = H5File(mock_sa3_control_data).with_aliases(mock_sa3_control_aliases)
     subrun = H5File(mock_sa3_control_data).only_aliases(mock_sa3_control_aliases)
 
@@ -236,26 +227,38 @@ def test_only_aliases(mock_sa3_control_data, mock_sa3_control_aliases):
     subrun = run.only_aliases(strict_aliases, require_all=True, strict=True)
     np.testing.assert_array_equal(subrun.train_ids, run.train_ids[1::2])
 
+    # Test that alias file paths are preserved
+    subrun = H5File(mock_sa3_control_data).only_aliases(mock_sa3_control_aliases_yaml)
+    assert subrun._alias_files == [mock_sa3_control_aliases_yaml]
 
-def test_preserve_aliases(mock_sa3_control_data, mock_sa3_control_aliases):
-    run = H5File(mock_sa3_control_data).with_aliases(mock_sa3_control_aliases)
+
+def test_preserve_aliases(mock_sa3_control_data, mock_sa3_control_aliases_yaml):
+    run = H5File(mock_sa3_control_data).with_aliases(mock_sa3_control_aliases_yaml)
 
     # Test whether selection operations preserve aliases.
-    assert run.select_trains(by_index[:5])._aliases == run._aliases
-    assert run.select_trains(by_id[run.train_ids[:5]])._aliases == run._aliases
+    for x in (by_index[:5], by_id[run.train_ids[:5]]):
+        assert run.select_trains(x)._aliases == run._aliases
+        assert run.select_trains(x)._alias_files == run._alias_files
+
     assert run.select('*')._aliases == run._aliases
+    assert run.select('*')._alias_files == run._alias_files
     assert run.deselect('*XGM*')._aliases == run._aliases
+    assert run.deselect('*XGM*')._alias_files == run._alias_files
     assert all([subrun._aliases == run._aliases
+                for subrun in run.split_trains(parts=5)])
+    assert all([subrun._alias_files == run._alias_files
                 for subrun in run.split_trains(parts=5)])
 
 
-def test_aliases_union(mock_sa3_control_data, mock_sa3_control_aliases):
-    run = H5File(mock_sa3_control_data).with_aliases(mock_sa3_control_aliases)
+def test_aliases_union(mock_sa3_control_data, mock_sa3_control_aliases, mock_sa3_control_aliases_yaml):
+    run = H5File(mock_sa3_control_data).with_aliases(mock_sa3_control_aliases_yaml)
 
     # Split the aliases into two halves and test the union.
     run1 = run.with_aliases(dict(islice(mock_sa3_control_aliases.items(), 0, None, 2)))
     run2 = run.with_aliases(dict(islice(mock_sa3_control_aliases.items(), 1, None, 2)))
-    assert run1.union(run2)._aliases == mock_sa3_control_aliases
+    union = run1.union(run2)
+    assert union._aliases == mock_sa3_control_aliases
+    assert union._alias_files == [mock_sa3_control_aliases_yaml]
 
     # Split the run into two.
     even_run = run.select_trains(by_id[run.train_ids[0::2]])
@@ -271,8 +274,8 @@ def test_aliases_union(mock_sa3_control_data, mock_sa3_control_aliases):
         even_run.union(odd_run.with_aliases(conflicting_aliases))
 
 
-def test_alias_select(mock_sa3_control_data, mock_sa3_control_aliases):
-    run = H5File(mock_sa3_control_data).with_aliases(mock_sa3_control_aliases)
+def test_alias_select(mock_sa3_control_data, mock_sa3_control_aliases_yaml):
+    run = H5File(mock_sa3_control_data).with_aliases(mock_sa3_control_aliases_yaml)
 
     # Only source alias.
     subrun = run.alias.select('sa3-xgm')
@@ -300,9 +303,12 @@ def test_alias_select(mock_sa3_control_data, mock_sa3_control_aliases):
     assert subrun.alias['sa3-xgm'].keys() == run.alias['sa3-xgm'].keys()
     assert subrun.alias['mcp-mpod'].keys() == {'channels.U1.voltage.value'}
 
+    # Test that file paths are preserved
+    assert run.alias.select("sa3-xgm")._alias_files == [mock_sa3_control_aliases_yaml]
 
-def test_alias_deselect(mock_sa3_control_data, mock_sa3_control_aliases):
-    run = H5File(mock_sa3_control_data).with_aliases(mock_sa3_control_aliases)
+
+def test_alias_deselect(mock_sa3_control_data, mock_sa3_control_aliases_yaml):
+    run = H5File(mock_sa3_control_data).with_aliases(mock_sa3_control_aliases_yaml)
 
     # De-select via alias.
     subrun = run.alias.deselect([
@@ -316,3 +322,14 @@ def test_alias_deselect(mock_sa3_control_data, mock_sa3_control_aliases):
         'beamPosition.ixPos.value', 'beamPosition.ixPos.timestamp',
         'beamPosition.iyPos.value', 'beamPosition.iyPos.timestamp',
         'pollingInterval.value', 'pollingInterval.timestamp'}
+    assert subrun._alias_files == [mock_sa3_control_aliases_yaml]
+
+def test_alias_jhub_links(mock_sa3_control_data, mock_sa3_control_aliases_yaml):
+    run = H5File(mock_sa3_control_data).with_aliases(mock_sa3_control_aliases_yaml)
+
+    # A link for the current alias file should not be generated since it isn't under /gpfs
+    assert run.alias.jhub_links() == { }
+
+    # Test that the /gpfs root is replaced with the ~/GPFS symlink
+    run._alias_files[0] = "/gpfs/foo.yaml"
+    assert run.alias.jhub_links() == {"/gpfs/foo.yaml": "https://max-jhub.desy.de/hub/user-redirect/lab/tree/GPFS/foo.yaml"}


### PR DESCRIPTION
This required tracking any alias files used through the `DataCollection` object.

The result is:
![image](https://github.com/user-attachments/assets/75c2ce99-4724-4768-9fd5-ec8561f7ada5)
