### PR TITLE
Allow passing a path object for a proposal folder in open_run()

### DIFF
--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -2067,14 +2067,17 @@ def open_run(
 
         return base_dc
 
-    if isinstance(proposal, str):
-        if ('/' not in proposal) and not proposal.startswith('p'):
-            proposal = 'p' + proposal.rjust(6, '0')
+    if isinstance(proposal, os.PathLike):
+        prop_dir = os.fsdecode(proposal)
     else:
-        # Allow integers, including numpy integers
-        proposal = 'p{:06d}'.format(index(proposal))
+        if isinstance(proposal, str):
+            if ('/' not in proposal) and not proposal.startswith('p'):
+                proposal = 'p' + proposal.rjust(6, '0')
+        else:
+            # Allow integers, including numpy integers
+            proposal = 'p{:06d}'.format(index(proposal))
 
-    prop_dir = find_proposal(proposal)
+        prop_dir = find_proposal(proposal)
 
     if isinstance(run, str):
         if run.startswith('r'):

--- a/extra_data/tests/test_open_run.py
+++ b/extra_data/tests/test_open_run.py
@@ -33,6 +33,11 @@ def test_open_run(mock_spb_raw_and_proc_run):
         run = open_run(proposal=np.int64(2012), run=np.uint16(238))
         assert {f.filename for f in run.files} == paths
 
+        # With a proposal path
+        prop_path = Path(mock_data_root, 'SPB', '201830', 'p002012')
+        run = open_run(proposal=prop_path, run=238)
+        assert {f.filename for f in run.files} == paths
+
         # Proc folder
         proc_run = open_run(proposal=2012, run=238, data='proc')
 


### PR DESCRIPTION
From discussion on https://github.com/European-XFEL/extra-proposal/pull/4