### PR TITLE
Added a `__len__` magic method for KeyData objects

### DIFF
--- a/extra_data/keydata.py
+++ b/extra_data/keydata.py
@@ -103,6 +103,9 @@ class KeyData:
         """
         return (sum(c.total_count for c in self._data_chunks),) + self.entry_shape
 
+    def __len__(self):
+        return self.shape[0]
+
     @property
     def nbytes(self):
         """The number of bytes this data would take up in memory."""


### PR DESCRIPTION
The simple (and perhaps naive) motivation for implementing a `__len__` magic method for `KeyData` objects is this:
> Even though a `KeyData` object is *not* itself an array, eventually the data it points to will be loaded as an array for analysis. This object already has a `.shape` attribute.
Naively, I was surprised that while it does have a `.shape` attribute, calling `len()` on it returns a `TypeError: object of type 'KeyData' has no len()`. 

Based on my discussions with @philsmt and @tmichela, I now understand that there are strong opinions and very good reasons against implementing this magic method. For example, which length to report if one is working with a selection among other reasons.

Nevertheless, I/we thought it might still be worthwhile to have a broader discussion especially with @takluyver to discuss the simple/naive usability expectation that if the thing has a `.shape` attribute, then `len(thing) == thing.shape[0]` should evaluate to `True` as it would for a Numpy array or an xarray or a Pandas series (which can all be obtained from a `KeyData` object).

For reference, magic methods for `KeyData` and `SourceData` objects were also discussed in [PR#582](https://github.com/European-XFEL/EXtra-data/pull/582).