### PR TITLE
Fix one_key() not finding a key for CONTROL sources with a selection

### DIFF
--- a/extra_data/sourcedata.py
+++ b/extra_data/sourcedata.py
@@ -195,7 +195,7 @@ class SourceData:
         any index group.
         """
         if self.sel_keys is not None:
-            if index_group is None:
+            if index_group is None or self.is_control:
                 return next(iter(self.sel_keys))
 
             prefix = f'{index_group}.'

--- a/extra_data/tests/test_sourcedata.py
+++ b/extra_data/tests/test_sourcedata.py
@@ -53,6 +53,11 @@ def test_keys(mock_spb_raw_run):
     xgm_output = run['SPB_XTD9_XGM/DOOCS/MAIN:output']
     assert xgm_output.one_key() in xgm_output.keys()
 
+    # one_key() may be called with an empty index group for CONTROL
+    # sources, which had a bug in combination with a key selection.
+    assert xgm.one_key('') in xgm.keys()
+    assert xgm.select_keys('beamPosition.*').one_key('') in xgm.keys()
+
     # Test one_key() with index group.
     am0 = run['SPB_DET_AGIPD1M-1/DET/0CH0:xtdf']
     assert am0.one_key('image').startswith('image.')


### PR DESCRIPTION
`SourceData.one_key(index_group=None)` may be called with `''` for `index_group` in the case of `CONTROL` sources internally, which is meant to be supported throughout the stack. This fails however in the case of a key selection, as this enters a different branch not handling it properly. I suspect this fell through given the lack of test for it specifically.

Oddly enough I found this bug through `exdf-tools` reductions, where one would have assumed it should've come up sooner 🤷 