### PR TITLE
Handle cases where there is no output from the check command

### DIFF
--- a/extra_data/cli/check_readable.py
+++ b/extra_data/cli/check_readable.py
@@ -113,7 +113,10 @@ sys.exit(check_access(Path({!r})))
                 timeout=args.timeout, capture_output=True,
                 env={'OMP_NUM_THREADS': '1'})
         except subprocess.TimeoutExpired as e:
-            path_states[path] = e.stdout.decode().splitlines()[-1]
+            if e.stdout is None:
+                path_states[path] = "Status unknown, no output from check command"
+            else:
+                path_states[path] = e.stdout.decode().splitlines()[-1]
             return 'T'
         else:
             path_states[path] = p.stdout.decode().splitlines()[-1]


### PR DESCRIPTION
According to the docs `TimeoutExpired.output` may be `None` if there was no output from the command: https://docs.python.org/3/library/subprocess.html#subprocess.TimeoutExpired.output

Observed when running `extra-data-readable` on a directory that seems to be having dcache issues:
```python
wrigleyj@max-exfl462 /gpfs/exfel/exp/MID/202501/p008616/raw/r0248 % extra-data-readable .                          
Traceback (most recent call last):
  File "/gpfs/exfel/sw/software/euxfel-environment-management/environments/202502/.pixi/envs/default/lib/python3.11/site-packages/extra_data/cli/check_readable.py", line 111, in monitor_access_check
    p = subprocess.run(
        ^^^^^^^^^^^^^^^
  File "/gpfs/exfel/sw/software/euxfel-environment-management/environments/202502/.pixi/envs/default/lib/python3.11/subprocess.py", line 550, in run
    stdout, stderr = process.communicate(input, timeout=timeout)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/gpfs/exfel/sw/software/euxfel-environment-management/environments/202502/.pixi/envs/default/lib/python3.11/subprocess.py", line 1209, in communicate
    stdout, stderr = self._communicate(input, endtime, timeout)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/gpfs/exfel/sw/software/euxfel-environment-management/environments/202502/.pixi/envs/default/lib/python3.11/subprocess.py", line 2116, in _communicate
    self._check_timeout(endtime, orig_timeout, stdout, stderr)
  File "/gpfs/exfel/sw/software/euxfel-environment-management/environments/202502/.pixi/envs/default/lib/python3.11/subprocess.py", line 1253, in _check_timeout
    raise TimeoutExpired(
subprocess.TimeoutExpired: Command '['/gpfs/exfel/sw/software/euxfel-environment-management/environments/202502/.pixi/envs/default/bin/python3.11', '-c', "\nimport sys\nfrom pathlib import Path\nfrom extra_data.cli.check_readable import check_access\nsys.exit(check_access(Path('RAW-R0248-AGIPD11-S00001.h5')))\n    "]' timed out after 5.0 seconds

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/gpfs/exfel/sw/software/euxfel-environment-management/environments/202502/.pixi/envs/default/bin/extra-data-readable", line 10, in <module>
    sys.exit(main())
             ^^^^^^
  File "/gpfs/exfel/sw/software/euxfel-environment-management/environments/202502/.pixi/envs/default/lib/python3.11/site-packages/extra_data/cli/check_readable.py", line 129, in main
    for res in pool.imap_unordered(monitor_access_check, paths):
  File "/gpfs/exfel/sw/software/euxfel-environment-management/environments/202502/.pixi/envs/default/lib/python3.11/multiprocessing/pool.py", line 873, in next
    raise value
  File "/gpfs/exfel/sw/software/euxfel-environment-management/environments/202502/.pixi/envs/default/lib/python3.11/multiprocessing/pool.py", line 125, in worker
    result = (True, func(*args, **kwds))
                    ^^^^^^^^^^^^^^^^^^^
  File "/gpfs/exfel/sw/software/euxfel-environment-management/environments/202502/.pixi/envs/default/lib/python3.11/site-packages/extra_data/cli/check_readable.py", line 116, in monitor_access_check
    path_states[path] = e.stdout.decode().splitlines()[-1]
                        ^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'decode'
```