### PR TITLE
Only update Github actions on major versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,8 @@ updates:
       actions:
         patterns:
           - "*"
+    # We currently only specify a major version of actions (e.g. actions/checkout@v6)
+    # So we only want to change it when the major version changes.
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch", "version-update:semver-minor"]


### PR DESCRIPTION
The major version tags, e.g. `v6`, are generally moved to each new minor/patch version when it's ready, so we get those updates without needing a PR. We only need dependabot for e.g. v6 -> v7.