### PR TITLE
Miscellaneous minor cleanups

### DIFF
--- a/extra_data/file_access.py
+++ b/extra_data/file_access.py
@@ -134,12 +134,12 @@ class FileAccess(metaclass=MetaFileAccess):
     # Paths starting with /gpfs/exfel/exp are either the canonical link
     # on Maxwell or an ONC path.
     euxfel_exp_path_pattern = re.compile(
-        r'\/gpfs\/exfel\/exp\/(\w+)\/(\d{6})\/p(\d{6})\/([a-z]+)\/(?:r(\d{4})|.extra_data)')
+        r'/gpfs/exfel/exp/(\w+)/(\d{6})/p(\d{6})/([a-z]+)/(?:r(\d{4})|.extra_data)')
 
     # Otherwise it is a direct GPFS or dCache path on Maxwell.
     euxfel_direct_path_pattern = re.compile(
-        r'\/(gpfs\/exfel\/d|gpfs\/exfel\/u|pnfs\/xfel.eu\/exfel\/archive\/XFEL)'
-        r'\/([a-z]+)\/(\w+)\/(\d{6})\/p(\d{6})\/(?:r(\d{4})|.extra_data)'
+        r'/(gpfs/exfel/d|gpfs/exfel/u|pnfs/xfel.eu/exfel/archive/XFEL)'
+        r'/([a-z]+)/(\w+)/(\d{6})/p(\d{6})/(?:r(\d{4})|.extra_data)'
     )
 
     euxfel_filename_pattern = re.compile(r'([A-Z]+)-R(\d{4})-(\w+)(?:-S(\d{5}))?.h5')

--- a/extra_data/keydata.py
+++ b/extra_data/keydata.py
@@ -1,4 +1,3 @@
-from typing import List, Optional, Tuple
 from warnings import warn
 
 import h5py
@@ -110,7 +109,7 @@ class KeyData:
         self.source = source
         self.key = key
         self.train_ids = train_ids
-        self.files: List[FileAccess] = files
+        self.files: list[FileAccess] = files
         self.section = section
         self.dtype = dtype
         self.entry_shape = eshape
@@ -144,7 +143,7 @@ class KeyData:
     _cached_chunks = None
 
     @property
-    def _data_chunks(self) -> List[DataChunk]:
+    def _data_chunks(self) -> list[DataChunk]:
         """An ordered list of chunks containing data"""
         if self._cached_chunks is None:
             self._cached_chunks = sorted(
@@ -153,7 +152,7 @@ class KeyData:
         return self._cached_chunks
 
     @property
-    def _data_chunks_nonempty(self) -> List[DataChunk]:
+    def _data_chunks_nonempty(self) -> list[DataChunk]:
         return [c for c in self._data_chunks if c.total_count]
 
     def __repr__(self):
@@ -740,7 +739,7 @@ class KeyData:
 
     # Getting data by train: --------------------------------------------------
 
-    def _find_tid(self, tid) -> Tuple[Optional[FileAccess], int]:
+    def _find_tid(self, tid) -> tuple[FileAccess | None, int]:
         for fa in self.files:
             matches = (fa.train_ids == tid).nonzero()[0]
             if self.inc_suspect_trains and matches.size > 0:

--- a/extra_data/read_machinery.py
+++ b/extra_data/read_machinery.py
@@ -9,7 +9,6 @@ import os
 import os.path as osp
 import re
 import time
-from glob import iglob
 from numbers import Integral
 from pathlib import Path
 from warnings import warn
@@ -21,7 +20,7 @@ from .utils import isinstance_no_import
 log = logging.getLogger(__name__)
 
 DETECTOR_NAMES = {'AGIPD', 'DSSC', 'LPD'}
-DETECTOR_SOURCE_RE = re.compile(r'(.+\/(?:DET|CORR))\/(\d+)CH')
+DETECTOR_SOURCE_RE = re.compile(r'(.+/(?:DET|CORR))/(\d+)CH')
 
 
 def data_root_dir():
@@ -173,7 +172,7 @@ def select_train_ids(train_ids, sel):
         raise TypeError(type(sel))
 
 
-def split_trains(n_trains, parts=None, trains_per_part=None) -> [slice]:
+def split_trains(n_trains, parts=None, trains_per_part=None) -> list[slice]:
     if trains_per_part is not None:
         assert trains_per_part >= 1
         n_parts = math.ceil(n_trains / trains_per_part)

--- a/extra_data/reader.py
+++ b/extra_data/reader.py
@@ -26,7 +26,6 @@ from itertools import chain
 from multiprocessing import current_process
 from operator import index
 from pathlib import Path
-from typing import Tuple
 from warnings import warn
 
 import h5py
@@ -38,7 +37,7 @@ from .exceptions import (MultiRunError, PropertyNameError, SourceNameError,
 from .file_access import FileAccess
 from .keydata import KeyData
 from .read_machinery import (DETECTOR_SOURCE_RE, by_id, by_index,
-                             data_root_dir, find_proposal, glob_wildcards_re,
+                             find_proposal, glob_wildcards_re,
                              is_int_like, same_run, select_train_ids,
                              sw_root_dir)
 from .run_files_map import RunFilesMap
@@ -1288,7 +1287,7 @@ class DataCollection:
         """
         return self._get_key_data(source, key)._data_chunks
 
-    def _find_data(self, source, train_id) -> Tuple[FileAccess, int]:
+    def _find_data(self, source, train_id) -> tuple[FileAccess | None, int | None]:
         for f in self._sources_data[source].files:
             ixs = (f.train_ids == train_id).nonzero()[0]
             if self.inc_suspect_trains and ixs.size > 0:
@@ -1564,7 +1563,7 @@ class DataCollection:
             series = pd.Series(arr, index=self.train_ids).dt.tz_localize('UTC')
             return series.dt.tz_convert('Europe/Berlin') if euxfel_local_time else series
         elif pydatetime:
-            from datetime import datetime, timezone
+            from datetime import timezone
             res = []
             for npdt in arr:
                 pydt = npdt.astype('datetime64[ms]').item()


### PR DESCRIPTION
Modernising type hints, removing unused imports and unnecessary character escapes. This cuts down on the warnings I see in Pycharm.

I'll merge this so long as the tests pass, I don't think it's worth review.