### PR TITLE
Fix labelled data counts not covering all selected train IDs

### DIFF
--- a/extra_data/keydata.py
+++ b/extra_data/keydata.py
@@ -398,7 +398,9 @@ class KeyData:
 
         if labelled:
             import pandas as pd
-            return pd.Series(counts, index=train_ids)
+            res = pd.Series(0, index=self.train_ids)
+            res.loc[train_ids] = counts
+            return res
         else:
             all_tids_arr = np.array(self.train_ids)
             res = np.zeros(len(all_tids_arr), dtype=np.uint64)

--- a/extra_data/tests/test_keydata.py
+++ b/extra_data/tests/test_keydata.py
@@ -170,7 +170,7 @@ def test_get_train_keep_dims(mock_jungfrau_run):
     assert val.shape == (1, 16, 512, 1024)
 
 
-def test_data_counts(mock_reduced_spb_proc_run):
+def test_data_counts(mock_reduced_spb_proc_run, mock_jungfrau_run):
     run = RunDirectory(mock_reduced_spb_proc_run)
 
     # control data
@@ -188,6 +188,14 @@ def test_data_counts(mock_reduced_spb_proc_run):
     count = mod.data_counts()
     assert count.index.tolist() == mod.train_ids
     assert count.values.sum() == mod.shape[0]
+
+    # Combine data with more train IDs than our original sources, and
+    # ensure that the data counts now cover these additional train IDs
+    # as well with 0.
+    multi_run = run.union(RunDirectory(mock_jungfrau_run))
+    mod = multi_run['SPB_DET_AGIPD1M-1/DET/0CH0:xtdf', 'image.data']
+    count = mod.data_counts()
+    assert count.index.tolist() == mod.train_ids
 
 
 def test_data_counts_empty(mock_fxe_raw_run):
@@ -230,8 +238,8 @@ def test_data_counts_missing_train(fxe_run_module_offset):
     lpd_m8 = run['FXE_DET_LPD1M-1/DET/8CH0:xtdf', 'image.cellId']
 
     ser = lpd_m8.data_counts(labelled=True)
-    assert len(ser) == 480
-    np.testing.assert_array_equal(ser.index, run.train_ids[1:])
+    assert len(ser) == 481
+    np.testing.assert_array_equal(ser.index, run.train_ids)
 
     arr = lpd_m8.data_counts(labelled=False)
     assert len(arr) == 481


### PR DESCRIPTION
When building tests for `exdf-tools`, I noticed a difference in behaviour between labelled and unlabelled `KeyData.data_counts()`. Whereas the latter always covers the selected train IDs, the former only contains only those described by data chunks for this key.

This situation can arise if a source is missing entirely in one or more sequences as opposed to being present with no data counts. In practice, this can happen e.g. when:
* A device goes down during a run, causing the aggregator to close the current sequence and start a new one
* Combining two runs with a source only present in one of them
* A source being dropped from sequence due to train selection in `exdf-reduce` (what triggered this observation)

While this is somewhat recoverable given the returned series is labelled, I would argue our APIs *generally* cover all selected train IDs and hence I would fix this for consistency.